### PR TITLE
Fix libraries compatibility in some linux distros with older ffmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,11 @@ endif()
 # Verificar se FetchContent está disponível (CMake 3.11+)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.11")
     include(FetchContent)
+    
+    # Configurar FetchContent para não tentar fazer update (evita erro de "dubious ownership")
+    # Se o diretório já existe, usamos ele; caso contrário, baixamos do zero
+    set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+    
     FetchContent_Declare(
         imgui
         GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -279,7 +284,7 @@ target_link_libraries(imgui PUBLIC
 )
 
 if(PLATFORM_LINUX)
-    target_link_libraries(imgui PUBLIC X11)
+    target_link_libraries(imgui PUBLIC X11 dl)
 endif()
 
 # Fontes

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,5 +1,5 @@
 # Dockerfile para build do RetroCapture no Linux
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,6 +11,10 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     && rm -rf /var/lib/apt/lists/*
+
+# Configurar Git para evitar erro de "dubious ownership" no Docker
+# Isso permite que o Git trabalhe com repositórios clonados pelo FetchContent
+RUN git config --global --add safe.directory '*'
 
 # Instalar dependências do RetroCapture
 RUN apt-get update && apt-get install -y \

--- a/build-linux-docker.sh
+++ b/build-linux-docker.sh
@@ -3,24 +3,29 @@ set -e
 
 # Build type: Release (default) or Debug
 BUILD_TYPE="${1:-Release}"
+FORCE_REBUILD="${2:-}"
 
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
     echo ""
-    echo "Uso: $0 [Release|Debug]"
+    echo "Uso: $0 [Release|Debug] [--rebuild]"
     echo "  Release - Build otimizado para produção (padrão)"
     echo "  Debug   - Build com símbolos de debug"
+    echo "  --rebuild - Força rebuild completo da imagem Docker (mais lento)"
     exit 1
 fi
 
 echo "🐳 RetroCapture - Build para Linux usando Docker"
 echo "================================================="
 echo "📦 Build type: $BUILD_TYPE"
+echo "🔧 Base: Ubuntu 24.04 LTS (Noble Numbat) - FFmpeg 6.x (versão 60)"
+echo "✅ Compatível com: Elementary OS 8.1 (Circe), Ubuntu 24.04+, etc."
 echo ""
 
 if ! command -v docker &> /dev/null; then
     echo "❌ Docker não está instalado!"
+    echo "   Instale com: sudo apt-get install -y docker.io docker-compose"
     exit 1
 fi
 
@@ -29,17 +34,47 @@ if ! command -v docker-compose &> /dev/null && docker compose version &> /dev/nu
     DOCKER_COMPOSE="docker compose"
 fi
 
+# Detectar se precisa usar sudo (usuário não está no grupo docker)
+DOCKER_CMD="docker"
+DOCKER_COMPOSE_CMD="$DOCKER_COMPOSE"
+if ! docker info &>/dev/null; then
+    if sudo docker info &>/dev/null; then
+        DOCKER_CMD="sudo docker"
+        DOCKER_COMPOSE_CMD="sudo $DOCKER_COMPOSE"
+        echo "⚠️  Usando sudo para Docker (usuário não está no grupo docker)"
+        echo "   Para evitar sudo, execute: sudo usermod -aG docker $USER"
+        echo "   Depois faça logout e login novamente."
+        echo ""
+    else
+        echo "❌ Não foi possível acessar o Docker!"
+        echo "   Verifique se o Docker está instalado e rodando:"
+        echo "   sudo systemctl status docker"
+        exit 1
+    fi
+fi
+
 echo "📦 Construindo imagem Docker..."
-echo "   Isso pode demorar alguns minutos na primeira vez..."
+if [ "$FORCE_REBUILD" = "--rebuild" ]; then
+    echo "   🔄 Forçando rebuild completo (sem cache)..."
+    echo "   Isso pode demorar vários minutos..."
+    BUILD_FLAGS="--no-cache"
+else
+    echo "   Isso pode demorar alguns minutos na primeira vez..."
+fi
+echo "   (Usando Ubuntu 24.04 LTS - mesma base do Elementary OS 8.1)"
 echo ""
 
-$DOCKER_COMPOSE build build-linux
+if [ "$FORCE_REBUILD" = "--rebuild" ]; then
+    $DOCKER_COMPOSE_CMD build $BUILD_FLAGS build-linux
+else
+    $DOCKER_COMPOSE_CMD build build-linux
+fi
 
 echo ""
 echo "🔨 Compilando RetroCapture..."
 echo ""
 
-$DOCKER_COMPOSE run --rm -e BUILD_TYPE="$BUILD_TYPE" build-linux > build-linux.log 2>&1
+$DOCKER_COMPOSE_CMD run --rm -e BUILD_TYPE="$BUILD_TYPE" build-linux > build-linux.log 2>&1
 
 echo ""
 echo "✅ Concluído!"

--- a/docker-build-linux.sh
+++ b/docker-build-linux.sh
@@ -21,6 +21,11 @@ if [ ! -f "CMakeLists.txt" ]; then
     exit 1
 fi
 
+# Configurar Git ANTES de qualquer operação (resolve "dubious ownership" no Docker)
+# Isso deve ser feito antes de entrar no diretório de build
+echo "⚙️  Configurando Git..."
+git config --global --add safe.directory '*' || true
+
 # Criar diretório de build (limpar cache CMake se existir)
 BUILD_DIR="build-linux"
 mkdir -p "$BUILD_DIR"
@@ -31,6 +36,13 @@ if [ -f "CMakeCache.txt" ]; then
     echo "🧹 Limpando cache do CMake..."
     rm -f CMakeCache.txt
     rm -rf CMakeFiles
+fi
+
+# Limpar diretório _deps se existir (pode ter sido criado com permissões incorretas)
+# Isso garante que o FetchContent baixe tudo do zero com as permissões corretas
+if [ -d "_deps" ]; then
+    echo "🧹 Limpando dependências anteriores..."
+    rm -rf _deps
 fi
 
 echo "⚙️  Configurando CMake..."

--- a/src/audio/AudioCapture.cpp
+++ b/src/audio/AudioCapture.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <algorithm>
 #include <atomic>
+#include <unistd.h>
 
 AudioCapture::AudioCapture()
     : m_mainloop(nullptr)

--- a/src/audio/AudioCapturePulse.cpp
+++ b/src/audio/AudioCapturePulse.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <algorithm>
 #include <atomic>
+#include <unistd.h>
 
 AudioCapturePulse::AudioCapturePulse()
     : m_mainloop(nullptr)


### PR DESCRIPTION
…atibility

- Update Dockerfile.linux to use Ubuntu 24.04 LTS (Noble Numbat)
  - Matches Elementary OS 8.1 (Circe) base for FFmpeg 6.x compatibility
- Add automatic sudo detection in build-linux-docker.sh
  - Detects if user needs sudo for Docker access
  - Provides helpful messages for Docker group setup
- Fix compilation errors:
  - Add #include <unistd.h> in AudioCapture.cpp and AudioCapturePulse.cpp (for usleep)
  - Add dl library link in CMakeLists.txt (for ImGui dynamic loading)
- Improve build script messages with compatibility information

This ensures the executable is compiled with FFmpeg 6.x (version 60), matching the libraries available on Elementary OS 8.1 and other Ubuntu 24.04-based systems.