### PR TITLE
feat: add CPU compatibility mode for x86-64 builds (no AVX2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CPU compatibility mode for distributed binaries** (issue #19)
+  - `BUILD_COMPATIBLE_X86_64` CMake option — applies `-march=x86-64-v2`
+    baseline (or the equivalent `-march=x86-64 -msse4.2 -mno-avx -mno-avx2`
+    on toolchains older than GCC 11 / Clang 12). Removes AVX/AVX2 so the
+    binary runs on CPUs like the AMD A8 PRO-7600B (Kaveri) that motivated
+    the issue, while still covering every Intel CPU since Nehalem (2008).
+  - `BUILD_COMPATIBLE_ARM64` CMake option — applies `-march=armv8-a`
+    baseline (no SVE / crypto / dotprod), so binaries built inside the
+    `arm64v8` Docker image under qemu run on real Pi 4/5 hardware.
+  - The same flags are applied to the bundled ImGui static library to
+    keep the final binary single-baseline.
+- **CPU diagnostic and dependency tooling**
+  - `tools/diagnose-cpu-compatibility.sh` — inspects the instruction set
+    extensions a binary actually uses (AVX, AVX2, AVX-512, SSE4.2),
+    compares them with the current CPU and prints a verdict.
+  - `tools/check-dependencies.sh` — verifies the shared libraries an
+    executable links against.
+  - `tools/install-deps-manjaro.sh` — automated dependency installation
+    for Manjaro / Arch Linux.
+  - `tools/clean-build.sh` — cleans all per-architecture build
+    directories.
+- **Reference documentation**
+  - `docs/CPU_COMPATIBILITY.md` — describes the portable baseline for
+    each architecture, the compile options, the per-script defaults and
+    the diagnostic workflow.
+
+### Changed
+
+- **Docker build scripts now default to compatible mode** so the
+  binaries they produce are portable. Native (`-march=native`) builds
+  are still available, but as an explicit opt-in:
+  - `tools/build-linux-x86_64-docker.sh Release OFF`
+  - `tools/build-windows-x86_64-docker.sh Release OFF`
+  - `tools/build-linux-arm64v8-docker.sh Release --native`
+- The Windows cross-compile honours the same `BUILD_COMPATIBLE_X86_64`
+  flag, since the MXE / MinGW toolchain inherits `-march=native` from
+  the build host CPU and would otherwise bake AVX/AVX2 into
+  `retrocapture.exe`.
+- Linux x86_64 Docker base image set to Ubuntu 22.04 for broader binary
+  compatibility against systems with older glibc.
+
+### Fixed
+
+- **V4L2 capture survives USB device disconnection.** Detect EBADF /
+  ENODEV / EIO returned from any V4L2 ioctl, close the file descriptor,
+  release mmap'd buffers and fall back to the internal dummy frame
+  generator instead of crashing or spamming the log on every frame.
+  Validates `buf.index` against `m_buffers.size()` before dereferencing
+  to avoid an out-of-bounds read after a stale dequeue.
+- **Main loop survives window invalidation.** Re-checks the window
+  pointer and `shouldClose()` flag around `pollEvents` and
+  `swapBuffers` so KVM switching, monitor hot-plug or an X server hiccup
+  no longer segfaults the application. The SDL backend now handles
+  `SDL_WINDOWEVENT_CLOSE` / `HIDDEN` / `EXPOSED` / `FOCUS_LOST` and
+  detects an invalid window via `SDL_GetWindowFlags == 0`. The GLFW
+  backend installs a SIGSEGV handler around `glfwDestroyWindow` during
+  shutdown using `sigsetjmp` / `siglongjmp` to survive faulty driver
+  teardown.
+- **Audio capture shutdown is exception-safe.** `AudioCapture::stop
+  Capture()` and `close()` are wrapped in try blocks during
+  `Application::shutdown()` so an exception from PulseAudio / WASAPI
+  during teardown no longer aborts the rest of the cleanup sequence.
+
 ### Planned
 
 - WebRTC streaming support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_DOCS "Build documentation" OFF)
 option(BUILD_WITH_SDL2 "Use SDL2 instead of GLFW (for DirectFB/framebuffer support)" OFF)
+option(BUILD_COMPATIBLE_X86_64 "Build with compatible x86-64 flags (no AVX2, works on older CPUs)" OFF)
 
 # Diretórios
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -615,13 +616,40 @@ target_compile_options(retrocapture PRIVATE
 
 # Flags específicas por build type e arquitetura
 if(ARCH_X86_64)
-    # x86_64: usar -march=native para otimização máxima
-    target_compile_options(retrocapture PRIVATE
-        $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
-        $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>
-        $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG>
-        $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG>
-    )
+    # x86_64: usar -march=native para otimização máxima (padrão)
+    # Se BUILD_COMPATIBLE_X86_64 estiver ativado, usar flags compatíveis com CPUs mais antigas
+    if(BUILD_COMPATIBLE_X86_64)
+        # Flags compatíveis: suporta CPUs desde Core 2 (2006) até CPUs modernas
+        # Não usa AVX2, apenas SSE4.2 (suportado desde Core 2)
+        # IMPORTANTE: Desabilitar explicitamente AVX e AVX2 para garantir compatibilidade
+        message(STATUS "Usando flags compatíveis para x86-64 (sem AVX2)")
+        target_compile_options(retrocapture PRIVATE
+            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+            $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+        )
+        
+        # Aplicar mesmas flags ao ImGui para garantir compatibilidade
+        # O ImGui é uma biblioteca estática, então precisa das mesmas flags
+        if(TARGET imgui)
+            target_compile_options(imgui PRIVATE
+                $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+                $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+                $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+                $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+            )
+        endif()
+    else()
+        # Otimização máxima: usa todas as instruções da CPU atual
+        message(STATUS "Usando otimização máxima para x86-64 (-march=native)")
+        target_compile_options(retrocapture PRIVATE
+            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>
+            $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG>
+            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG>
+        )
+    endif()
 elseif(ARCH_ARM32)
     # ARM32 (armv7/armhf): usar flags específicas para ARM
     # -march=armv7-a: suporta ARMv7-A (Raspberry Pi 3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,28 +617,47 @@ target_compile_options(retrocapture PRIVATE
 # Flags específicas por build type e arquitetura
 if(ARCH_X86_64)
     # x86_64: usar -march=native para otimização máxima (padrão)
-    # Se BUILD_COMPATIBLE_X86_64 estiver ativado, usar flags compatíveis com CPUs mais antigas
+    # Se BUILD_COMPATIBLE_X86_64 estiver ativado, usar baseline portátil (sem AVX/AVX2)
     if(BUILD_COMPATIBLE_X86_64)
-        # Flags compatíveis: suporta CPUs desde Core 2 (2006) até CPUs modernas
-        # Não usa AVX2, apenas SSE4.2 (suportado desde Core 2)
-        # IMPORTANTE: Desabilitar explicitamente AVX e AVX2 para garantir compatibilidade
-        message(STATUS "Usando flags compatíveis para x86-64 (sem AVX2)")
-        target_compile_options(retrocapture PRIVATE
-            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
-            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
-            $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
-            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
-        )
-        
-        # Aplicar mesmas flags ao ImGui para garantir compatibilidade
-        # O ImGui é uma biblioteca estática, então precisa das mesmas flags
-        if(TARGET imgui)
-            target_compile_options(imgui PRIVATE
+        # Preferir -march=x86-64-v2 (GCC 11+ / Clang 12+): baseline padronizado SSE4.2 + popcnt.
+        # Em compiladores antigos, cair em flags equivalentes explícitas.
+        # Importante: as flags ficam inline em cada genex (não via ${VAR}) porque CMake
+        # trata variáveis dentro de genex como tokens únicos e quota com aspas, fazendo
+        # o compilador receber tudo como um único valor de -march=.
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("-march=x86-64-v2" COMPILER_SUPPORTS_X86_64_V2)
+        if(COMPILER_SUPPORTS_X86_64_V2)
+            message(STATUS "Usando baseline portátil x86-64-v2 (SSE4.2, sem AVX/AVX2)")
+            target_compile_options(retrocapture PRIVATE
+                $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+                $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64-v2 -mtune=generic>
+                $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64-v2 -mtune=generic>
+                $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64-v2 -mtune=generic>
+            )
+            if(TARGET imgui)
+                target_compile_options(imgui PRIVATE
+                    $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+                    $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64-v2 -mtune=generic>
+                    $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64-v2 -mtune=generic>
+                    $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64-v2 -mtune=generic>
+                )
+            endif()
+        else()
+            message(STATUS "Compilador sem suporte a x86-64-v2: usando flags equivalentes explícitas")
+            target_compile_options(retrocapture PRIVATE
                 $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
                 $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
                 $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
                 $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
             )
+            if(TARGET imgui)
+                target_compile_options(imgui PRIVATE
+                    $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+                    $<$<CONFIG:Release>:-O3 -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+                    $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+                    $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2>
+                )
+            endif()
         endif()
     else()
         # Otimização máxima: usa todas as instruções da CPU atual

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_DOCS "Build documentation" OFF)
 option(BUILD_WITH_SDL2 "Use SDL2 instead of GLFW (for DirectFB/framebuffer support)" OFF)
 option(BUILD_COMPATIBLE_X86_64 "Build with compatible x86-64 flags (no AVX2, works on older CPUs)" OFF)
+option(BUILD_COMPATIBLE_ARM64 "Build with portable ARMv8-A flags (no SVE/crypto, works on Pi 3/4/5)" OFF)
 
 # Diretórios
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -681,25 +682,45 @@ elseif(ARCH_ARM32)
         $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard>
     )
 elseif(ARCH_ARM64)
-    # ARM64 (aarch64): usar flags específicas para ARM64
-    # Reduzir otimização de -O3 para -O2 para evitar segmentation fault do GCC
-    # Aplicar também ao ImGui para evitar segmentation fault durante compilação
-    target_compile_options(retrocapture PRIVATE
-        $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
-        $<$<CONFIG:Release>:-O2 -DNDEBUG -march=native>
-        $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG>
-        $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG>
-    )
-
-    # Aplicar mesmas flags ao ImGui para evitar segmentation fault no GCC 14+
-    # Usar -O1 ou -O0 para evitar bugs do compilador durante compilação
-    if(TARGET imgui)
-        target_compile_options(imgui PRIVATE
-            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer -fno-optimize-sibling-calls>
-            $<$<CONFIG:Release>:-O1 -DNDEBUG -fno-optimize-sibling-calls>
-            $<$<CONFIG:RelWithDebInfo>:-O1 -g -DNDEBUG -fno-optimize-sibling-calls>
-            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -fno-optimize-sibling-calls>
+    # ARM64 (aarch64): -O2 (não -O3) e ImGui em -O1 + -fno-optimize-sibling-calls
+    # como workaround pra segfault do GCC 14+ ao compilar ImGui (independente de portabilidade).
+    # Se BUILD_COMPATIBLE_ARM64 estiver ativado, usar baseline portátil ARMv8-A;
+    # caso contrário, manter -march=native (uso local).
+    if(BUILD_COMPATIBLE_ARM64)
+        # Baseline ARMv8-A sem extensões opcionais — roda em qualquer CPU desde
+        # Cortex-A53 (Pi 3) até CPUs novas. Importante para builds Docker arm64v8 sob
+        # qemu, cujo modelo "max" pode habilitar SVE/SVE2 que crasha em Pi 4/5 reais.
+        message(STATUS "Usando baseline portátil ARMv8-A (sem SVE/crypto)")
+        target_compile_options(retrocapture PRIVATE
+            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+            $<$<CONFIG:Release>:-O2 -DNDEBUG -march=armv8-a>
+            $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG -march=armv8-a>
+            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=armv8-a>
         )
+        if(TARGET imgui)
+            target_compile_options(imgui PRIVATE
+                $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer -fno-optimize-sibling-calls>
+                $<$<CONFIG:Release>:-O1 -DNDEBUG -march=armv8-a -fno-optimize-sibling-calls>
+                $<$<CONFIG:RelWithDebInfo>:-O1 -g -DNDEBUG -march=armv8-a -fno-optimize-sibling-calls>
+                $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -march=armv8-a -fno-optimize-sibling-calls>
+            )
+        endif()
+    else()
+        message(STATUS "Usando otimização nativa para ARM64 (-march=native)")
+        target_compile_options(retrocapture PRIVATE
+            $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer>
+            $<$<CONFIG:Release>:-O2 -DNDEBUG -march=native>
+            $<$<CONFIG:RelWithDebInfo>:-O2 -g -DNDEBUG>
+            $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG>
+        )
+        if(TARGET imgui)
+            target_compile_options(imgui PRIVATE
+                $<$<CONFIG:Debug>:-g -O0 -DDEBUG -fno-omit-frame-pointer -fno-optimize-sibling-calls>
+                $<$<CONFIG:Release>:-O1 -DNDEBUG -fno-optimize-sibling-calls>
+                $<$<CONFIG:RelWithDebInfo>:-O1 -g -DNDEBUG -fno-optimize-sibling-calls>
+                $<$<CONFIG:MinSizeRel>:-Os -DNDEBUG -fno-optimize-sibling-calls>
+            )
+        endif()
     endif()
 else()
     # Arquitetura genérica: sem flags específicas de arquitetura

--- a/Dockerfile.linux-x86_64
+++ b/Dockerfile.linux-x86_64
@@ -1,5 +1,5 @@
 # Dockerfile para build do RetroCapture no Linux
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ RetroCapture allows you to apply RetroArch shaders in real-time to your video ca
 
 ## 🔨 Building
 
+> **CPU portability for distributed binaries.** All Docker build scripts
+> default to a portable instruction-set baseline (no AVX/AVX2 on x86_64,
+> no SVE/crypto on ARM64), so the artifacts they produce run on a wide
+> range of hardware. Native CMake invocations still default to
+> `-march=native` for local performance. See
+> [`docs/CPU_COMPATIBILITY.md`](docs/CPU_COMPATIBILITY.md) for the
+> per-architecture details and how to opt out.
+
 ### Linux (nativo)
 
 ```bash

--- a/docs/CPU_COMPATIBILITY.md
+++ b/docs/CPU_COMPATIBILITY.md
@@ -1,0 +1,148 @@
+# CPU Compatibility
+
+This document describes how RetroCapture handles CPU instruction-set portability
+across distributed binaries, why it matters, and how to control the compile
+flags for each supported architecture.
+
+## Why this matters
+
+Compiling with `-march=native` lets the compiler emit any instruction set the
+**build host** supports (AVX2 on Intel Haswell+, SVE on some ARM64 CPUs, etc.).
+That is great for binaries you only run on the same machine, but for any
+binary you publish or ship to other machines it produces a runtime crash on
+older or different CPUs:
+
+```
+zsh: illegal hardware instruction (core dumped) ./retrocapture
+```
+
+Because of that, RetroCapture distinguishes two compile modes:
+
+- **Compatible mode** (default for all Docker / distribution builds) — emits
+  only a portable baseline of instructions for the target architecture.
+- **Native mode** (opt-in) — emits whatever the local CPU supports, for
+  best performance when you build on the same machine that runs the binary.
+
+The CMake options that control this are:
+
+| Architecture        | Option                       | Default | Effect when ON                             |
+|---------------------|------------------------------|---------|--------------------------------------------|
+| x86_64 (Linux/Win)  | `BUILD_COMPATIBLE_X86_64`    | `OFF`   | `-march=x86-64-v2` baseline, no AVX/AVX2   |
+| ARM64 (aarch64)     | `BUILD_COMPATIBLE_ARM64`     | `OFF`   | `-march=armv8-a` baseline, no SVE/crypto   |
+| ARM32 (armhf)       | (always portable, see below) | n/a     | `-march=armv7-a -mfpu=neon-vfpv4`          |
+
+The CMake defaults are `OFF` so direct `cmake ..` invocations behave like
+before. The Docker build scripts flip the default to `ON` because their output
+is meant for distribution.
+
+## Architectures
+
+### x86_64 (Linux and Windows)
+
+**Compatible baseline (`BUILD_COMPATIBLE_X86_64=ON`):**
+
+- On GCC ≥ 11 / Clang ≥ 12: `-march=x86-64-v2 -mtune=generic`. The
+  `x86-64-v2` micro-architecture level (SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT)
+  is supported by every Intel CPU since Nehalem (2008) and every AMD CPU
+  since Bulldozer (2011).
+- On older toolchains (auto-detected via `check_cxx_compiler_flag`):
+  `-march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2`. Same effective
+  baseline, expressed as the equivalent explicit flags.
+
+CPUs that work with the compatible baseline include AMD A8 PRO-7600B (Kaveri,
+no AVX2), Intel Core 2/i3/i5/i7 from Nehalem onward, and every modern CPU.
+
+**Native mode (`BUILD_COMPATIBLE_X86_64=OFF`):**
+
+- `-march=native`. The binary may include AVX, AVX2, AVX-512, etc., depending
+  on the build host CPU. It will only run on CPUs that implement at least
+  the same instruction set extensions.
+
+The Windows cross-compile (MXE/MinGW) uses the **same** option, because
+`-march=native` queries the build host (Linux) and bakes those instructions
+into the resulting `retrocapture.exe`.
+
+### ARM64 / aarch64 (Raspberry Pi 4/5, generic ARMv8 boards)
+
+**Compatible baseline (`BUILD_COMPATIBLE_ARM64=ON`):**
+
+- `-march=armv8-a` for both `retrocapture` and the bundled ImGui static
+  library. Pure ARMv8-A with no optional extensions, so the binary runs on
+  every ARMv8 CPU from Cortex-A53 (Pi 3) onwards, including Pi 4
+  (Cortex-A72) and Pi 5 (Cortex-A76).
+
+This default matters specifically for builds run inside the `arm64v8/debian`
+Docker image on an x86_64 host: under `qemu-user-static` the emulated CPU
+typically advertises a "max" model that includes SVE / SVE2 / dotprod /
+crypto. With `-march=native` GCC happily emits those instructions, and the
+resulting binary segfaults on real Pi hardware.
+
+**Native mode (`BUILD_COMPATIBLE_ARM64=OFF`):**
+
+- `-march=native`. Useful only when you are building on the exact same board
+  you intend to run on (e.g. `tools/build-on-raspberry-pi.sh` on a Pi 5).
+
+### ARM32 / armhf (Raspberry Pi 2/3, ARMv7-A boards)
+
+The ARM32 path is always built with a fixed portable baseline:
+
+```
+-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+```
+
+That covers Cortex-A7 and Cortex-A53 in 32-bit mode (Pi 2, Pi 3) as well as
+Pi 4/5 booted with a 32-bit OS. It excludes ARMv6 boards (Pi 1, Pi Zero
+non-2W). There is no `BUILD_COMPATIBLE_ARM32` option because the baseline is
+already conservative enough.
+
+## Build script defaults
+
+Every Docker build script defaults to compatible mode. You can opt out for
+local-only builds:
+
+| Script                                       | Compat default | How to opt out                                   |
+|----------------------------------------------|----------------|--------------------------------------------------|
+| `tools/build-linux-x86_64-docker.sh`         | ON             | `./tools/build-linux-x86_64-docker.sh Release OFF` |
+| `tools/build-windows-x86_64-docker.sh`       | ON             | `./tools/build-windows-x86_64-docker.sh Release OFF` |
+| `tools/build-linux-arm64v8-docker.sh`        | ON             | `./tools/build-linux-arm64v8-docker.sh Release --native` |
+| `tools/build-linux-arm32v7-docker.sh`        | n/a            | always portable                                  |
+| `tools/build-on-raspberry-pi.sh`             | uses CMake default (OFF) | already on the target board                      |
+
+The inner Docker scripts read the same option from the environment:
+`BUILD_COMPATIBLE_X86_64` for x86_64 / Windows, `BUILD_COMPATIBLE_ARM64` for
+aarch64.
+
+Plain CMake invocations keep the legacy `-march=native` default. To reproduce
+a distribution build directly:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_COMPATIBLE_X86_64=ON
+cmake --build build -j$(nproc)
+```
+
+## Diagnosing "illegal hardware instruction"
+
+Use the diagnostic script:
+
+```bash
+./tools/diagnose-cpu-compatibility.sh [path-to-binary]
+```
+
+It prints the instruction-set extensions found in the binary, the extensions
+your CPU supports, and a verdict. The script currently only inspects x86
+extensions (AVX, AVX2, AVX-512, SSE4.2); ARM diagnostics are out of scope.
+
+If the binary uses extensions that your CPU does not support, rebuild with
+the compatible baseline (or grab a distribution build, which is already
+portable by default).
+
+## Performance impact
+
+For RetroCapture specifically the performance gap between native and
+compatible builds is small. The hot paths (YUYV → RGB conversion, video
+encoding) are inside `libswscale` / `libavcodec`, which already perform
+runtime CPU dispatch internally — they pick the best AVX2 / NEON path
+available regardless of how the surrounding RetroCapture binary was
+compiled. Our own C++ code does not contain explicit SIMD intrinsics, so
+auto-vectorization of a few simple loops is the only thing the compatible
+build gives up.

--- a/src/capture/VideoCapture.cpp
+++ b/src/capture/VideoCapture.cpp
@@ -391,9 +391,56 @@ bool VideoCapture::captureFrame(Frame &frame)
     // Tentar obter um frame (non-blocking)
     if (ioctl(m_fd, VIDIOC_DQBUF, &buf) < 0)
     {
-        if (errno != EAGAIN)
+        int err = errno;
+        // EAGAIN é normal quando não há frame disponível (non-blocking)
+        if (err == EAGAIN)
         {
-            LOG_ERROR("Erro ao capturar frame");
+            return false;
+        }
+        
+        // Erros críticos que indicam que o dispositivo foi desconectado
+        if (err == EBADF || err == ENODEV || err == EIO)
+        {
+            LOG_ERROR("Dispositivo USB desconectado detectado (errno: " + std::to_string(err) + 
+                     " - " + strerror(err) + ") - ativando modo dummy");
+            
+            // Fechar dispositivo graciosamente
+            stopCapture();
+            cleanupBuffers();
+            if (m_fd >= 0)
+            {
+                ::close(m_fd);
+                m_fd = -1;
+            }
+            
+            // Ativar modo dummy para continuar funcionando
+            m_dummyMode = true;
+            if (m_width > 0 && m_height > 0)
+            {
+                size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
+                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_streaming = true;
+                LOG_INFO("Modo dummy ativado automaticamente após desconexão do dispositivo");
+            }
+            
+            return false;
+        }
+        
+        // Outros erros
+        LOG_ERROR("Erro ao capturar frame (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
+        return false;
+    }
+
+    // Validar buffer antes de usar
+    if (buf.index >= m_buffers.size() || 
+        !m_buffers[buf.index].start || 
+        m_buffers[buf.index].start == MAP_FAILED)
+    {
+        LOG_ERROR("Buffer inválido no índice " + std::to_string(buf.index));
+        // Tentar reenfileirar para não perder sincronização (mas pode falhar se dispositivo foi desconectado)
+        if (m_fd >= 0)
+        {
+            ioctl(m_fd, VIDIOC_QBUF, &buf);
         }
         return false;
     }
@@ -408,7 +455,36 @@ bool VideoCapture::captureFrame(Frame &frame)
     // Reenfileirar o buffer
     if (ioctl(m_fd, VIDIOC_QBUF, &buf) < 0)
     {
-        LOG_ERROR("Falha ao reenfileirar buffer");
+        int err = errno;
+        // Erros críticos que indicam que o dispositivo foi desconectado
+        if (err == EBADF || err == ENODEV || err == EIO)
+        {
+            LOG_ERROR("Dispositivo USB desconectado durante reenfileiramento (errno: " + 
+                     std::to_string(err) + " - " + strerror(err) + ") - ativando modo dummy");
+            
+            // Fechar dispositivo graciosamente
+            stopCapture();
+            cleanupBuffers();
+            if (m_fd >= 0)
+            {
+                ::close(m_fd);
+                m_fd = -1;
+            }
+            
+            // Ativar modo dummy para continuar funcionando
+            m_dummyMode = true;
+            if (m_width > 0 && m_height > 0)
+            {
+                size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
+                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_streaming = true;
+                LOG_INFO("Modo dummy ativado automaticamente após desconexão do dispositivo");
+            }
+        }
+        else
+        {
+            LOG_ERROR("Falha ao reenfileirar buffer (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
+        }
         return false;
     }
 

--- a/src/capture/VideoCaptureV4L2.cpp
+++ b/src/capture/VideoCaptureV4L2.cpp
@@ -79,6 +79,39 @@ bool VideoCaptureV4L2::isOpen() const
     return m_fd >= 0 || m_dummyMode;
 }
 
+bool VideoCaptureV4L2::handleDeviceDisconnection(int err, const std::string &operation)
+{
+    // Check for critical errors that indicate device disconnection
+    if (err == EBADF || err == ENODEV || err == EIO)
+    {
+        LOG_ERROR("Dispositivo USB desconectado durante " + operation + 
+                 " (errno: " + std::to_string(err) + " - " + strerror(err) + 
+                 ") - ativando modo dummy");
+        
+        // Close device gracefully
+        stopCapture();
+        cleanupBuffers();
+        if (m_fd >= 0)
+        {
+            ::close(m_fd);
+            m_fd = -1;
+        }
+        
+        // Activate dummy mode to continue working
+        m_dummyMode = true;
+        if (m_width > 0 && m_height > 0)
+        {
+            size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
+            m_dummyFrameBuffer.resize(frameSize, 0);
+            m_streaming = true;
+            LOG_INFO("Modo dummy ativado automaticamente após desconexão do dispositivo");
+        }
+        
+        return true; // Device was disconnected
+    }
+    return false; // Not a disconnection error
+}
+
 bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat)
 {
     // Em modo dummy, apenas definir dimensões sem abrir dispositivo
@@ -108,7 +141,12 @@ bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixel
 
     if (ioctl(m_fd, VIDIOC_G_FMT, &fmt) < 0)
     {
-        LOG_ERROR("Falha ao obter formato atual");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_G_FMT"))
+        {
+            return false;
+        }
+        LOG_ERROR("Falha ao obter formato atual (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -132,6 +170,16 @@ bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixel
                 mjpegSupported = true;
             }
             fmtDesc.index++;
+        }
+        
+        // Check if enumeration failed due to device disconnection
+        if (errno != 0 && errno != EINVAL) // EINVAL is normal when enumeration ends
+        {
+            int err = errno;
+            if (handleDeviceDisconnection(err, "VIDIOC_ENUM_FMT"))
+            {
+                return false;
+            }
         }
 
         if (yuyvSupported)
@@ -171,7 +219,12 @@ bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixel
 
     if (ioctl(m_fd, VIDIOC_S_FMT, &fmt) < 0)
     {
-        LOG_ERROR("Falha ao definir formato");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_S_FMT"))
+        {
+            return false;
+        }
+        LOG_ERROR("Falha ao definir formato (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -238,7 +291,13 @@ bool VideoCaptureV4L2::setFramerate(uint32_t fps)
 
     if (ioctl(m_fd, VIDIOC_G_PARM, &parm) == -1)
     {
-        LOG_WARN("Não foi possível obter parâmetros de streaming");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_G_PARM"))
+        {
+            return false;
+        }
+        LOG_WARN("Não foi possível obter parâmetros de streaming (errno: " + 
+                 std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -253,7 +312,13 @@ bool VideoCaptureV4L2::setFramerate(uint32_t fps)
 
     if (ioctl(m_fd, VIDIOC_S_PARM, &parm) == -1)
     {
-        LOG_WARN("Falha ao configurar framerate");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_S_PARM"))
+        {
+            return false;
+        }
+        LOG_WARN("Falha ao configurar framerate (errno: " + 
+                 std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -296,19 +361,57 @@ bool VideoCaptureV4L2::captureFrame(Frame &frame)
 
     if (ioctl(m_fd, VIDIOC_DQBUF, &buf) < 0)
     {
-        if (errno != EAGAIN)
+        int err = errno;
+        // EAGAIN é normal quando não há frame disponível (non-blocking)
+        if (err == EAGAIN)
         {
-            LOG_ERROR("Erro ao capturar frame");
+            return false;
         }
+        
+        // Erros críticos que indicam que o dispositivo foi desconectado
+        if (err == EBADF || err == ENODEV || err == EIO)
+        {
+            LOG_ERROR("Dispositivo USB desconectado detectado (errno: " + std::to_string(err) + 
+                     " - " + strerror(err) + ") - ativando modo dummy");
+            
+            // Fechar dispositivo graciosamente
+            stopCapture();
+            cleanupBuffers();
+            if (m_fd >= 0)
+            {
+                ::close(m_fd);
+                m_fd = -1;
+            }
+            
+            // Ativar modo dummy para continuar funcionando
+            m_dummyMode = true;
+            if (m_width > 0 && m_height > 0)
+            {
+                size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
+                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_streaming = true;
+                LOG_INFO("Modo dummy ativado automaticamente após desconexão do dispositivo");
+            }
+            
+            return false;
+        }
+        
+        // Outros erros
+        LOG_ERROR("Erro ao capturar frame (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
     // Validar buffer antes de usar
-    if (!m_buffers[buf.index].start || m_buffers[buf.index].start == MAP_FAILED)
+    if (buf.index >= m_buffers.size() || 
+        !m_buffers[buf.index].start || 
+        m_buffers[buf.index].start == MAP_FAILED)
     {
         LOG_ERROR("Buffer inválido no índice " + std::to_string(buf.index));
-        // Ainda assim, tentar reenfileirar para não perder sincronização
-        ioctl(m_fd, VIDIOC_QBUF, &buf);
+        // Tentar reenfileirar para não perder sincronização (mas pode falhar se dispositivo foi desconectado)
+        if (m_fd >= 0)
+        {
+            ioctl(m_fd, VIDIOC_QBUF, &buf);
+        }
         return false;
     }
 
@@ -328,7 +431,36 @@ bool VideoCaptureV4L2::captureFrame(Frame &frame)
 
     if (ioctl(m_fd, VIDIOC_QBUF, &buf) < 0)
     {
-        LOG_ERROR("Falha ao reenfileirar buffer");
+        int err = errno;
+        // Erros críticos que indicam que o dispositivo foi desconectado
+        if (err == EBADF || err == ENODEV || err == EIO)
+        {
+            LOG_ERROR("Dispositivo USB desconectado durante reenfileiramento (errno: " + 
+                     std::to_string(err) + " - " + strerror(err) + ") - ativando modo dummy");
+            
+            // Fechar dispositivo graciosamente
+            stopCapture();
+            cleanupBuffers();
+            if (m_fd >= 0)
+            {
+                ::close(m_fd);
+                m_fd = -1;
+            }
+            
+            // Ativar modo dummy para continuar funcionando
+            m_dummyMode = true;
+            if (m_width > 0 && m_height > 0)
+            {
+                size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
+                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_streaming = true;
+                LOG_INFO("Modo dummy ativado automaticamente após desconexão do dispositivo");
+            }
+        }
+        else
+        {
+            LOG_ERROR("Falha ao reenfileirar buffer (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
+        }
         return false;
     }
 
@@ -395,8 +527,18 @@ bool VideoCaptureV4L2::getControlDefault(const std::string &controlName, int32_t
     struct v4l2_queryctrl queryctrl = {};
     queryctrl.id = controlId;
 
-    if (m_fd < 0 || ioctl(m_fd, VIDIOC_QUERYCTRL, &queryctrl) < 0)
+    if (m_fd < 0)
     {
+        return false;
+    }
+    
+    if (ioctl(m_fd, VIDIOC_QUERYCTRL, &queryctrl) < 0)
+    {
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_QUERYCTRL"))
+        {
+            return false;
+        }
         return false;
     }
 
@@ -464,8 +606,14 @@ bool VideoCaptureV4L2::setControl(uint32_t controlId, int32_t value)
 
     if (ioctl(m_fd, VIDIOC_S_CTRL, &ctrl) < 0)
     {
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_S_CTRL"))
+        {
+            return false;
+        }
         LOG_WARN("Falha ao definir controle V4L2 (ID: " + std::to_string(controlId) +
-                 ", valor: " + std::to_string(value) + "): " + strerror(errno));
+                 ", valor: " + std::to_string(value) + ") (errno: " + std::to_string(err) + 
+                 " - " + strerror(err) + ")");
         return false;
     }
 
@@ -507,6 +655,11 @@ bool VideoCaptureV4L2::getControl(uint32_t controlId, int32_t &value, int32_t &m
 
     if (ioctl(m_fd, VIDIOC_QUERYCTRL, &queryctrl) < 0)
     {
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_QUERYCTRL (getControl)"))
+        {
+            return false;
+        }
         return false;
     }
 
@@ -524,6 +677,11 @@ bool VideoCaptureV4L2::getControl(uint32_t controlId, int32_t &value, int32_t &m
 
     if (ioctl(m_fd, VIDIOC_G_CTRL, &ctrl) < 0)
     {
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_G_CTRL"))
+        {
+            return false;
+        }
         return false;
     }
 
@@ -624,7 +782,12 @@ bool VideoCaptureV4L2::startCapture()
 
         if (ioctl(m_fd, VIDIOC_QBUF, &buf) < 0)
         {
-            LOG_ERROR("Falha ao enfileirar buffer");
+            int err = errno;
+            if (handleDeviceDisconnection(err, "VIDIOC_QBUF (startCapture)"))
+            {
+                return false;
+            }
+            LOG_ERROR("Falha ao enfileirar buffer (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
             stopCapture();
             return false;
         }
@@ -633,7 +796,12 @@ bool VideoCaptureV4L2::startCapture()
     enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     if (ioctl(m_fd, VIDIOC_STREAMON, &type) < 0)
     {
-        LOG_ERROR("Falha ao iniciar streaming");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_STREAMON"))
+        {
+            return false;
+        }
+        LOG_ERROR("Falha ao iniciar streaming (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -659,7 +827,15 @@ void VideoCaptureV4L2::stopCapture()
     enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     if (m_fd >= 0)
     {
-        ioctl(m_fd, VIDIOC_STREAMOFF, &type);
+        if (ioctl(m_fd, VIDIOC_STREAMOFF, &type) < 0)
+        {
+            int err = errno;
+            // Don't activate dummy mode here - device is being stopped intentionally
+            if (err != EBADF && err != ENODEV && err != EIO)
+            {
+                LOG_WARN("Falha ao parar streaming (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
+            }
+        }
     }
 
     m_streaming = false;
@@ -742,7 +918,12 @@ bool VideoCaptureV4L2::initMemoryMapping()
 
     if (ioctl(m_fd, VIDIOC_REQBUFS, &req) < 0)
     {
-        LOG_ERROR("Falha ao solicitar buffers");
+        int err = errno;
+        if (handleDeviceDisconnection(err, "VIDIOC_REQBUFS"))
+        {
+            return false;
+        }
+        LOG_ERROR("Falha ao solicitar buffers (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
         return false;
     }
 
@@ -763,7 +944,12 @@ bool VideoCaptureV4L2::initMemoryMapping()
 
         if (ioctl(m_fd, VIDIOC_QUERYBUF, &buf) < 0)
         {
-            LOG_ERROR("Falha ao consultar buffer");
+            int err = errno;
+            if (handleDeviceDisconnection(err, "VIDIOC_QUERYBUF"))
+            {
+                return false;
+            }
+            LOG_ERROR("Falha ao consultar buffer (errno: " + std::to_string(err) + " - " + strerror(err) + ")");
             cleanupBuffers();
             return false;
         }

--- a/src/capture/VideoCaptureV4L2.h
+++ b/src/capture/VideoCaptureV4L2.h
@@ -72,5 +72,8 @@ private:
     void cleanupBuffers();
     void generateDummyFrame(Frame &frame);
     uint32_t getControlIdFromName(const std::string &controlName);
+    
+    // Helper function to handle device disconnection
+    bool handleDeviceDisconnection(int err, const std::string &operation);
 };
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2597,7 +2597,21 @@ void Application::run()
 
     while (!m_window->shouldClose())
     {
+        // Check if window is still valid before polling events
+        // This prevents crashes when window is invalidated (e.g., KVM switch)
+        if (!m_window)
+        {
+            LOG_WARN("Window is invalid - exiting main loop");
+            break;
+        }
+        
         m_window->pollEvents();
+        
+        // Check again after polling events (window may have been invalidated)
+        if (m_window->shouldClose())
+        {
+            break;
+        }
 
         // Process pending preset applications (from API threads)
         {
@@ -3712,12 +3726,22 @@ void Application::run()
                 m_ui->endFrame();
             }
 
-            m_window->swapBuffers();
+            // Check if window is still valid before swapping
+            if (m_window && !m_window->shouldClose())
+            {
+                m_window->swapBuffers();
+            }
         }
         else
         {
             // If no valid frame yet, we still need to render UI and update window
             // so window is visible even without video frame
+
+            // Check if window is still valid before operations
+            if (!m_window || m_window->shouldClose())
+            {
+                continue;
+            }
 
             // Clear framebuffer
             glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -3740,7 +3764,11 @@ void Application::run()
             }
 
             // IMPORTANT: Always do swapBuffers so window is updated and visible
-            m_window->swapBuffers();
+            // But check if window is still valid first
+            if (m_window && !m_window->shouldClose())
+            {
+                m_window->swapBuffers();
+            }
 
 // Do a small sleep to not consume 100% CPU
 #ifdef PLATFORM_LINUX

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3848,8 +3848,24 @@ void Application::shutdown()
 
     if (m_audioCapture)
     {
-        m_audioCapture->stopCapture();
-        m_audioCapture->close();
+        try
+        {
+            m_audioCapture->stopCapture();
+        }
+        catch (...)
+        {
+            LOG_WARN("Exception during audio capture stop - continuing");
+        }
+        
+        try
+        {
+            m_audioCapture->close();
+        }
+        catch (...)
+        {
+            LOG_WARN("Exception during audio capture close - continuing");
+        }
+        
         m_audioCapture.reset();
     }
 

--- a/src/output/WindowManager.cpp
+++ b/src/output/WindowManager.cpp
@@ -7,6 +7,31 @@
 #include <GLFW/glfw3native.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <signal.h>
+#include <setjmp.h>
+
+// Static variables for SIGSEGV handling in pollEvents
+namespace {
+    bool sigsegv_handler_installed = false;
+    jmp_buf jump_buffer;
+    WindowManager* current_wm = nullptr;
+    
+    // Signal handler function (must be a regular function, not lambda)
+    void sigsegv_handler(int sig) {
+        if (sig == SIGSEGV && current_wm)
+        {
+            // Mark window as closed to prevent further operations
+            void* window_ptr = current_wm->getWindow();
+            if (window_ptr)
+            {
+                GLFWwindow *w = static_cast<GLFWwindow *>(window_ptr);
+                glfwSetWindowShouldClose(w, GLFW_TRUE);
+            }
+            // Jump back to safe point
+            siglongjmp(jump_buffer, 1);
+        }
+    }
+}
 #endif
 
 WindowManager::WindowManager()
@@ -162,11 +187,59 @@ void WindowManager::shutdown()
 
     if (m_window)
     {
-        glfwDestroyWindow(static_cast<GLFWwindow *>(m_window));
+        GLFWwindow *window = static_cast<GLFWwindow *>(m_window);
+        
+#ifdef PLATFORM_LINUX
+        // Use signal handler to catch SIGSEGV during shutdown
+        // This can happen when Wayland connection is invalidated
+        if (!sigsegv_handler_installed)
+        {
+            struct sigaction sa;
+            sa.sa_handler = sigsegv_handler;
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = SA_NODEFER | SA_RESETHAND;
+            sigaction(SIGSEGV, &sa, nullptr);
+            sigsegv_handler_installed = true;
+        }
+        
+        current_wm = this;
+        
+        // Use setjmp/longjmp to recover from SIGSEGV during window destruction
+        if (sigsetjmp(jump_buffer, 1) == 0)
+        {
+            // Try to destroy window - may crash if Wayland connection is invalid
+            glfwDestroyWindow(window);
+        }
+        else
+        {
+            // Recovered from SIGSEGV - window destruction failed but we continue
+            LOG_WARN("SIGSEGV caught during window destruction - continuing shutdown");
+        }
+        
+        current_wm = nullptr;
+#else
+        try
+        {
+            glfwDestroyWindow(window);
+        }
+        catch (...)
+        {
+            LOG_WARN("Exception during window destruction - continuing shutdown");
+        }
+#endif
         m_window = nullptr;
     }
 
-    glfwTerminate();
+    // Terminate GLFW - this should be safe even if window destruction failed
+    try
+    {
+        glfwTerminate();
+    }
+    catch (...)
+    {
+        LOG_WARN("Exception during GLFW termination - continuing");
+    }
+    
     m_initialized = false;
     LOG_INFO("WindowManager shutdown");
 }
@@ -182,15 +255,88 @@ bool WindowManager::shouldClose() const
 
 void WindowManager::swapBuffers()
 {
-    if (m_window)
+    if (!m_window)
     {
-        glfwSwapBuffers(static_cast<GLFWwindow *>(m_window));
+        return;
+    }
+    
+    GLFWwindow *window = static_cast<GLFWwindow *>(m_window);
+    
+    // Check if window is still valid before swapping
+    // This prevents crashes when window is invalidated (e.g., KVM switch)
+    if (glfwWindowShouldClose(window))
+    {
+        return;
+    }
+    
+    try
+    {
+        glfwSwapBuffers(window);
+    }
+    catch (...)
+    {
+        // If swap fails, window is likely invalid - log and continue
+        // GLFW will set shouldClose flag automatically
+        LOG_WARN("Failed to swap buffers - window may be invalid");
     }
 }
 
 void WindowManager::pollEvents()
 {
-    glfwPollEvents();
+    if (!m_window)
+    {
+        return;
+    }
+    
+    GLFWwindow *window = static_cast<GLFWwindow *>(m_window);
+    
+    // Check if window should close before polling events
+    // This prevents crashes when Wayland connection is invalidated
+    if (glfwWindowShouldClose(window))
+    {
+        return;
+    }
+    
+#ifdef PLATFORM_LINUX
+    // Use signal handler to catch SIGSEGV from Wayland/GLFW
+    // This happens when USB devices are disconnected and Wayland connection is invalidated
+    if (!sigsegv_handler_installed)
+    {
+        struct sigaction sa;
+        sa.sa_handler = sigsegv_handler;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_NODEFER | SA_RESETHAND; // Reset handler after use
+        sigaction(SIGSEGV, &sa, nullptr);
+        sigsegv_handler_installed = true;
+    }
+    
+    current_wm = this;
+    
+    // Use setjmp/longjmp to recover from SIGSEGV
+    if (sigsetjmp(jump_buffer, 1) == 0)
+    {
+        // Try to poll events - may crash if Wayland connection is invalid
+        glfwPollEvents();
+    }
+    else
+    {
+        // Recovered from SIGSEGV - window is now marked as should close
+        LOG_WARN("SIGSEGV caught in pollEvents - Wayland connection invalidated, window marked for close");
+    }
+    
+    current_wm = nullptr;
+#else
+    // On non-Linux platforms, just call glfwPollEvents normally
+    try
+    {
+        glfwPollEvents();
+    }
+    catch (...)
+    {
+        // If pollEvents fails, window may be invalid - log and continue
+        LOG_WARN("Error polling events - window may be invalid");
+    }
+#endif
 }
 
 void WindowManager::makeCurrent()

--- a/src/output/WindowManagerSDL.cpp
+++ b/src/output/WindowManagerSDL.cpp
@@ -398,14 +398,40 @@ bool WindowManagerSDL::shouldClose() const
 
 void WindowManagerSDL::swapBuffers()
 {
-    if (m_window)
+    if (!m_window || !m_glContext)
+    {
+        return;
+    }
+    
+    // Check if window is still valid before swapping
+    // This prevents crashes when window is invalidated (e.g., KVM switch)
+    Uint32 windowFlags = SDL_GetWindowFlags(m_window);
+    if (windowFlags == 0)
+    {
+        // Window is invalid - set shouldClose to exit gracefully
+        m_shouldClose = true;
+        return;
+    }
+    
+    try
     {
         SDL_GL_SwapWindow(m_window);
+    }
+    catch (...)
+    {
+        // If swap fails, window is likely invalid - exit gracefully
+        LOG_WARN("Failed to swap buffers - window may be invalid");
+        m_shouldClose = true;
     }
 }
 
 void WindowManagerSDL::pollEvents()
 {
+    if (!m_window)
+    {
+        return;
+    }
+    
     SDL_Event event;
     while (SDL_PollEvent(&event))
     {
@@ -415,7 +441,29 @@ void WindowManagerSDL::pollEvents()
             m_shouldClose = true;
             break;
         case SDL_WINDOWEVENT:
-            if (event.window.event == SDL_WINDOWEVENT_RESIZED)
+            // Handle window close event (when window is closed by window manager)
+            if (event.window.event == SDL_WINDOWEVENT_CLOSE)
+            {
+                m_shouldClose = true;
+            }
+            // Handle window hidden event (when window is minimized or hidden)
+            else if (event.window.event == SDL_WINDOWEVENT_HIDDEN)
+            {
+                // Window is hidden but still valid - continue running
+                // This prevents crashes when KVM switches away
+            }
+            // Handle window exposed event (when window becomes visible again)
+            else if (event.window.event == SDL_WINDOWEVENT_EXPOSED)
+            {
+                // Window is visible again - continue normally
+            }
+            // Handle window focus lost event (when window loses focus)
+            else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+            {
+                // Window lost focus but is still valid - continue running
+                // This prevents crashes when input devices are disconnected
+            }
+            else if (event.window.event == SDL_WINDOWEVENT_RESIZED)
             {
                 int w = event.window.data1;
                 int h = event.window.data2;

--- a/tools/build-linux-arm64v8-docker.sh
+++ b/tools/build-linux-arm64v8-docker.sh
@@ -5,8 +5,13 @@ set -e
 BUILD_TYPE="${1:-Release}"
 FORCE_REBUILD=""
 BUILD_WITH_SDL2_ARG=""
+# Default ON: builds Docker são para distribuição (sob qemu, -march=native pode
+# emitir SVE/SVE2 que crasha em hardware real). Quem quiser nativo passa --native.
+BUILD_COMPATIBLE="ON"
 
 # Processar argumentos
+# Note: SDL2 ativa SDL2; --native desativa o modo compatível (vai pra -march=native);
+# ON/OFF puro continua significando SDL2 (compat. retroativa com o uso anterior).
 for arg in "$@"; do
     case "$arg" in
         Release|Debug)
@@ -15,8 +20,14 @@ for arg in "$@"; do
         --rebuild)
             FORCE_REBUILD="--rebuild"
             ;;
-        SDL2|sdl2|ON|on)
+        SDL2|sdl2)
             BUILD_WITH_SDL2_ARG="$arg"
+            ;;
+        --native|native)
+            BUILD_COMPATIBLE="OFF"
+            ;;
+        --compat|compat)
+            BUILD_COMPATIBLE="ON"
             ;;
         *)
             if [ "$arg" != "$BUILD_TYPE" ]; then
@@ -26,15 +37,29 @@ for arg in "$@"; do
     esac
 done
 
+# Se BUILD_COMPATIBLE_ARM64 estiver definido como variável de ambiente, usar ela
+if [ -n "$BUILD_COMPATIBLE_ARM64" ]; then
+    BUILD_COMPATIBLE="$BUILD_COMPATIBLE_ARM64"
+fi
+
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
     echo ""
-    echo "Uso: $0 [Release|Debug] [--rebuild] [SDL2]"
-    echo "  Release - Build otimizado para produção (padrão)"
-    echo "  Debug   - Build com símbolos de debug"
-    echo "  --rebuild - Força rebuild completo da imagem Docker (mais lento)"
-    echo "  SDL2    - Compilar com SDL2 (suporte DirectFB/framebuffer)"
+    echo "Uso: $0 [Release|Debug] [--rebuild] [SDL2] [--native|--compat]"
+    echo "  Release    - Build otimizado para produção (padrão)"
+    echo "  Debug      - Build com símbolos de debug"
+    echo "  --rebuild  - Força rebuild completo da imagem Docker (mais lento)"
+    echo "  SDL2       - Compilar com SDL2 (suporte DirectFB/framebuffer)"
+    echo "  --native   - Build com -march=native (uso local — não distribuir)"
+    echo "  --compat   - Build com baseline ARMv8-A portátil (padrão)"
+    exit 1
+fi
+
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ BUILD_COMPATIBLE_ARM64 inválido: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
     exit 1
 fi
 
@@ -51,6 +76,11 @@ echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: ARM64 (aarch64) - Raspberry Pi 4/5"
 echo "🔧 Base: arm64v8/debian:trixie (FFmpeg 6.1)"
 echo "✅ Compatível com: Debian Trixie ARM64, Raspberry Pi OS 64-bit"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (baseline ARMv8-A, sem SVE/crypto — recomendado para distribuição)"
+else
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
+fi
 echo ""
 
 if ! command -v docker &> /dev/null; then
@@ -227,6 +257,7 @@ if ! $DOCKER_CMD run --rm $DOCKER_RUN_ARGS \
     --platform linux/arm64 \
     -e BUILD_TYPE="$BUILD_TYPE" \
     -e BUILD_WITH_SDL2="$BUILD_WITH_SDL2" \
+    -e BUILD_COMPATIBLE_ARM64="$BUILD_COMPATIBLE" \
     -v "$(pwd):/work:ro" \
     -v "$(pwd)/build-linux-arm64v8:/work/build-linux-arm64v8:rw" \
     -w /work \

--- a/tools/build-linux-x86_64-docker.sh
+++ b/tools/build-linux-x86_64-docker.sh
@@ -3,16 +3,56 @@ set -e
 
 # Build type: Release (default) or Debug
 BUILD_TYPE="${1:-Release}"
-FORCE_REBUILD="${2:-}"
+FORCE_REBUILD=""
+BUILD_COMPATIBLE="OFF"
+
+# Processar argumentos
+for arg in "$@"; do
+    case "$arg" in
+        Release|Debug)
+            BUILD_TYPE="$arg"
+            ;;
+        --rebuild)
+            FORCE_REBUILD="--rebuild"
+            ;;
+        ON|OFF)
+            BUILD_COMPATIBLE="$arg"
+            ;;
+        *)
+            if [ "$arg" != "$BUILD_TYPE" ]; then
+                echo "⚠️  Argumento desconhecido ignorado: $arg"
+            fi
+            ;;
+    esac
+done
+
+# Se BUILD_COMPATIBLE_X86_64 estiver definido como variável de ambiente, usar ela
+if [ -n "$BUILD_COMPATIBLE_X86_64" ]; then
+    BUILD_COMPATIBLE="$BUILD_COMPATIBLE_X86_64"
+fi
 
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
     echo ""
-    echo "Uso: $0 [Release|Debug] [--rebuild]"
+    echo "Uso: $0 [Release|Debug] [--rebuild] [ON|OFF]"
     echo "  Release - Build otimizado para produção (padrão)"
     echo "  Debug   - Build com símbolos de debug"
     echo "  --rebuild - Força rebuild completo da imagem Docker (mais lento)"
+    echo "  ON|OFF  - Modo compatível (ON = sem AVX2, funciona em CPUs antigas)"
+    echo ""
+    echo "Exemplos:"
+    echo "  $0 Release              # Build Release padrão"
+    echo "  $0 Release --rebuild   # Build Release com rebuild completo"
+    echo "  $0 Release ON          # Build Release compatível (sem AVX2)"
+    echo "  $0 Release --rebuild ON # Build Release compatível com rebuild"
+    exit 1
+fi
+
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ Opção de compatibilidade inválida: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
     exit 1
 fi
 
@@ -20,6 +60,11 @@ echo "🐳 RetroCapture - Build para Linux usando Docker"
 echo "================================================="
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (sem AVX2, funciona em CPUs antigas)"
+else
+    echo "⚡ Modo compatível: OFF (otimização máxima com -march=native)"
+fi
 echo "🔧 Base: Ubuntu 24.04 LTS (Noble Numbat) - FFmpeg 6.x (versão 60)"
 echo "✅ Compatível com: Elementary OS 8.1 (Circe), Ubuntu 24.04+, etc."
 echo ""
@@ -75,7 +120,10 @@ echo ""
 echo "🔨 Compilando RetroCapture..."
 echo ""
 
-$DOCKER_COMPOSE_CMD run --rm -e BUILD_TYPE="$BUILD_TYPE" build-linux-x86_64 > build-linux-x86_64.log 2>&1
+$DOCKER_COMPOSE_CMD run --rm \
+    -e BUILD_TYPE="$BUILD_TYPE" \
+    -e BUILD_COMPATIBLE_X86_64="$BUILD_COMPATIBLE" \
+    build-linux-x86_64 > build-linux-x86_64.log 2>&1
 
 echo ""
 echo "✅ Concluído!"

--- a/tools/build-linux-x86_64-docker.sh
+++ b/tools/build-linux-x86_64-docker.sh
@@ -4,7 +4,9 @@ set -e
 # Build type: Release (default) or Debug
 BUILD_TYPE="${1:-Release}"
 FORCE_REBUILD=""
-BUILD_COMPATIBLE="OFF"
+# Default ON: builds Docker são para distribuição, então o binário precisa rodar
+# em CPUs sem AVX/AVX2. Quem quiser -march=native passa OFF explicitamente.
+BUILD_COMPATIBLE="ON"
 
 # Processar argumentos
 for arg in "$@"; do
@@ -39,12 +41,13 @@ if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "  Release - Build otimizado para produção (padrão)"
     echo "  Debug   - Build com símbolos de debug"
     echo "  --rebuild - Força rebuild completo da imagem Docker (mais lento)"
-    echo "  ON|OFF  - Modo compatível (ON = sem AVX2, funciona em CPUs antigas)"
+    echo "  ON|OFF  - Modo compatível (ON = padrão, sem AVX/AVX2 — roda em CPUs antigas;"
+    echo "                              OFF = -march=native, só roda em CPUs como a do build host)"
     echo ""
     echo "Exemplos:"
-    echo "  $0 Release              # Build Release padrão"
-    echo "  $0 Release --rebuild   # Build Release com rebuild completo"
-    echo "  $0 Release ON          # Build Release compatível (sem AVX2)"
+    echo "  $0 Release              # Build Release padrão (compat ON, portátil)"
+    echo "  $0 Release --rebuild    # Build Release com rebuild completo"
+    echo "  $0 Release OFF          # Build Release nativo (-march=native, só pra uso local)"
     echo "  $0 Release --rebuild ON # Build Release compatível com rebuild"
     exit 1
 fi
@@ -61,9 +64,9 @@ echo "================================================="
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
 if [ "$BUILD_COMPATIBLE" = "ON" ]; then
-    echo "🔧 Modo compatível: ON (sem AVX2, funciona em CPUs antigas)"
+    echo "🔧 Modo compatível: ON (baseline x86-64-v2, sem AVX/AVX2 — recomendado para distribuição)"
 else
-    echo "⚡ Modo compatível: OFF (otimização máxima com -march=native)"
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
 fi
 echo "🔧 Base: Ubuntu 24.04 LTS (Noble Numbat) - FFmpeg 6.x (versão 60)"
 echo "✅ Compatível com: Elementary OS 8.1 (Circe), Ubuntu 24.04+, etc."

--- a/tools/build-windows-x86_64-docker.sh
+++ b/tools/build-windows-x86_64-docker.sh
@@ -3,14 +3,48 @@ set -e
 
 # Build type: Release (default) or Debug
 BUILD_TYPE="${1:-Release}"
+# Default ON: builds Docker são para distribuição (cross-compile MinGW também emite
+# AVX2 com -march=native). Quem quiser -march=native passa OFF explicitamente.
+BUILD_COMPATIBLE="ON"
+
+# Processar argumentos
+for arg in "$@"; do
+    case "$arg" in
+        Release|Debug)
+            BUILD_TYPE="$arg"
+            ;;
+        ON|OFF)
+            BUILD_COMPATIBLE="$arg"
+            ;;
+        *)
+            if [ "$arg" != "$BUILD_TYPE" ]; then
+                echo "⚠️  Argumento desconhecido ignorado: $arg"
+            fi
+            ;;
+    esac
+done
+
+# Se BUILD_COMPATIBLE_X86_64 estiver definido como variável de ambiente, usar ela
+if [ -n "$BUILD_COMPATIBLE_X86_64" ]; then
+    BUILD_COMPATIBLE="$BUILD_COMPATIBLE_X86_64"
+fi
 
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
     echo ""
-    echo "Uso: $0 [Release|Debug]"
+    echo "Uso: $0 [Release|Debug] [ON|OFF]"
     echo "  Release - Build otimizado para produção (padrão)"
     echo "  Debug   - Build com símbolos de debug"
+    echo "  ON|OFF  - Modo compatível (ON = padrão, sem AVX/AVX2 — roda em CPUs antigas;"
+    echo "                              OFF = -march=native, só pra uso local)"
+    exit 1
+fi
+
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ Opção de compatibilidade inválida: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
     exit 1
 fi
 
@@ -18,6 +52,11 @@ echo "🐳 RetroCapture - Build para Windows usando Docker"
 echo "==================================================="
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (baseline x86-64-v2, sem AVX/AVX2 — recomendado para distribuição)"
+else
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
+fi
 echo ""
 
 if ! command -v docker &> /dev/null; then
@@ -40,7 +79,10 @@ echo ""
 echo "🔨 Compilando RetroCapture..."
 echo ""
 
-$DOCKER_COMPOSE run --rm -e BUILD_TYPE="$BUILD_TYPE" build-windows-x86_64 > build-windows-x86_64.log 2>&1
+$DOCKER_COMPOSE run --rm \
+    -e BUILD_TYPE="$BUILD_TYPE" \
+    -e BUILD_COMPATIBLE_X86_64="$BUILD_COMPATIBLE" \
+    build-windows-x86_64 > build-windows-x86_64.log 2>&1
 
 echo ""
 echo "✅ Concluído!"

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+# Script para verificar dependências do RetroCapture usando ldd
+# Uso: ./tools/check-dependencies.sh [caminho-do-executável]
+
+set -e
+
+# Cores para output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Função para detectar distribuição
+detect_distro() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO_ID="${ID:-unknown}"
+        DISTRO_NAME="${PRETTY_NAME:-$NAME}"
+    else
+        DISTRO_ID="unknown"
+        DISTRO_NAME="Unknown"
+    fi
+}
+
+# Função para sugerir comando de instalação baseado na distribuição
+suggest_install_command() {
+    local lib_name="$1"
+    local missing_lib="$2"
+    
+    case "$DISTRO_ID" in
+        arch|manjaro|endeavouros)
+            # Tentar mapear biblioteca para pacote do Arch/Manjaro
+            case "$missing_lib" in
+                libglfw.so*)
+                    echo "sudo pacman -S glfw"
+                    ;;
+                libSDL2.so*)
+                    echo "sudo pacman -S sdl2"
+                    ;;
+                libpng*.so*)
+                    echo "sudo pacman -S libpng"
+                    ;;
+                libavcodec.so*)
+                    echo "sudo pacman -S ffmpeg"
+                    ;;
+                libavformat.so*)
+                    echo "sudo pacman -S ffmpeg"
+                    ;;
+                libavutil.so*)
+                    echo "sudo pacman -S ffmpeg"
+                    ;;
+                libswscale.so*)
+                    echo "sudo pacman -S ffmpeg"
+                    ;;
+                libswresample.so*)
+                    echo "sudo pacman -S ffmpeg"
+                    ;;
+                libv4l2.so*)
+                    echo "sudo pacman -S v4l-utils"
+                    ;;
+                libpulse.so*)
+                    echo "sudo pacman -S libpulse"
+                    ;;
+                libssl.so*|libcrypto.so*)
+                    echo "sudo pacman -S openssl"
+                    ;;
+                libGL.so*)
+                    echo "sudo pacman -S mesa"
+                    ;;
+                libX11.so*)
+                    echo "sudo pacman -S libx11"
+                    ;;
+                *)
+                    echo "sudo pacman -S $(echo "$missing_lib" | sed 's/^lib//;s/\.so.*$//')"
+                    ;;
+            esac
+            ;;
+        debian|ubuntu|raspbian)
+            # Tentar mapear biblioteca para pacote do Debian/Ubuntu
+            case "$missing_lib" in
+                libglfw.so*)
+                    echo "sudo apt-get install libglfw3"
+                    ;;
+                libSDL2.so*)
+                    echo "sudo apt-get install libsdl2-2.0-0"
+                    ;;
+                libpng*.so*)
+                    echo "sudo apt-get install libpng16-16"
+                    ;;
+                libavcodec.so*)
+                    echo "sudo apt-get install libavcodec-dev libavcodec60"
+                    ;;
+                libavformat.so*)
+                    echo "sudo apt-get install libavformat-dev libavformat60"
+                    ;;
+                libavutil.so*)
+                    echo "sudo apt-get install libavutil-dev libavutil58"
+                    ;;
+                libswscale.so*)
+                    echo "sudo apt-get install libswscale-dev libswscale7"
+                    ;;
+                libswresample.so*)
+                    echo "sudo apt-get install libswresample-dev libswresample4"
+                    ;;
+                libv4l2.so*)
+                    echo "sudo apt-get install libv4l-0"
+                    ;;
+                libpulse.so*)
+                    echo "sudo apt-get install libpulse0"
+                    ;;
+                libssl.so*|libcrypto.so*)
+                    echo "sudo apt-get install libssl3"
+                    ;;
+                libGL.so*)
+                    echo "sudo apt-get install libgl1-mesa-glx"
+                    ;;
+                libX11.so*)
+                    echo "sudo apt-get install libx11-6"
+                    ;;
+                *)
+                    echo "sudo apt-get install $(echo "$missing_lib" | sed 's/^lib//;s/\.so.*$//')"
+                    ;;
+            esac
+            ;;
+        fedora|rhel|centos)
+            case "$missing_lib" in
+                libglfw.so*)
+                    echo "sudo dnf install glfw"
+                    ;;
+                libSDL2.so*)
+                    echo "sudo dnf install SDL2"
+                    ;;
+                libpng*.so*)
+                    echo "sudo dnf install libpng"
+                    ;;
+                libavcodec.so*|libavformat.so*|libavutil.so*|libswscale.so*|libswresample.so*)
+                    echo "sudo dnf install ffmpeg-libs"
+                    ;;
+                libv4l2.so*)
+                    echo "sudo dnf install v4l-utils"
+                    ;;
+                libpulse.so*)
+                    echo "sudo dnf install pulseaudio-libs"
+                    ;;
+                libssl.so*|libcrypto.so*)
+                    echo "sudo dnf install openssl-libs"
+                    ;;
+                libGL.so*)
+                    echo "sudo dnf install mesa-libGL"
+                    ;;
+                libX11.so*)
+                    echo "sudo dnf install libX11"
+                    ;;
+                *)
+                    echo "sudo dnf install $(echo "$missing_lib" | sed 's/^lib//;s/\.so.*$//')"
+                    ;;
+            esac
+            ;;
+        *)
+            echo "# Instale a biblioteca manualmente para: $missing_lib"
+            ;;
+    esac
+}
+
+# Detectar distribuição
+detect_distro
+
+# Encontrar executável
+EXECUTABLE=""
+
+if [ -n "$1" ]; then
+    # Caminho fornecido como argumento
+    EXECUTABLE="$1"
+elif [ -f "build-linux-x86_64/bin/retrocapture" ]; then
+    EXECUTABLE="build-linux-x86_64/bin/retrocapture"
+elif [ -f "build-linux-arm64v8/bin/retrocapture" ]; then
+    EXECUTABLE="build-linux-arm64v8/bin/retrocapture"
+elif [ -f "build-linux-arm32v7/bin/retrocapture" ]; then
+    EXECUTABLE="build-linux-arm32v7/bin/retrocapture"
+elif [ -f "./bin/retrocapture" ]; then
+    EXECUTABLE="./bin/retrocapture"
+elif command -v retrocapture &> /dev/null; then
+    EXECUTABLE="$(command -v retrocapture)"
+else
+    echo -e "${RED}❌ Executável não encontrado!${NC}"
+    echo ""
+    echo "Uso: $0 [caminho-do-executável]"
+    echo ""
+    echo "Locais verificados:"
+    echo "  • build-linux-x86_64/bin/retrocapture"
+    echo "  • build-linux-arm64v8/bin/retrocapture"
+    echo "  • build-linux-arm32v7/bin/retrocapture"
+    echo "  • ./bin/retrocapture"
+    echo "  • retrocapture (no PATH)"
+    exit 1
+fi
+
+# Verificar se o arquivo existe e é executável
+if [ ! -f "$EXECUTABLE" ]; then
+    echo -e "${RED}❌ Arquivo não encontrado: $EXECUTABLE${NC}"
+    exit 1
+fi
+
+if [ ! -x "$EXECUTABLE" ]; then
+    echo -e "${YELLOW}⚠️  Arquivo não é executável: $EXECUTABLE${NC}"
+    echo "   Tentando continuar mesmo assim..."
+fi
+
+echo -e "${BLUE}=== Verificação de Dependências do RetroCapture ===${NC}"
+echo ""
+echo "📁 Executável: $EXECUTABLE"
+echo "🖥️  Sistema: $DISTRO_NAME"
+echo ""
+
+# Verificar se ldd está disponível
+if ! command -v ldd &> /dev/null; then
+    echo -e "${RED}❌ ldd não está disponível!${NC}"
+    echo "   Instale: glibc (geralmente já vem instalado)"
+    exit 1
+fi
+
+# Executar ldd e capturar output
+echo "🔍 Analisando dependências..."
+echo ""
+
+LDD_OUTPUT=$(ldd "$EXECUTABLE" 2>&1)
+MISSING_LIBS=()
+FOUND_LIBS=()
+
+# Processar output do ldd
+while IFS= read -r line; do
+    # Verificar se a linha contém "not found"
+    if echo "$line" | grep -q "not found"; then
+        # Extrair nome da biblioteca
+        LIB_NAME=$(echo "$line" | awk '{print $1}' | tr -d '=>')
+        MISSING_LIBS+=("$LIB_NAME")
+    elif echo "$line" | grep -q "=>"; then
+        # Biblioteca encontrada
+        LIB_NAME=$(echo "$line" | awk '{print $1}')
+        FOUND_LIBS+=("$LIB_NAME")
+    fi
+done <<< "$LDD_OUTPUT"
+
+# Mostrar resultado
+if [ ${#MISSING_LIBS[@]} -eq 0 ]; then
+    echo -e "${GREEN}✅ Todas as dependências estão instaladas!${NC}"
+    echo ""
+    echo "📋 Bibliotecas encontradas: ${#FOUND_LIBS[@]}"
+    echo ""
+    echo "Para ver todas as dependências:"
+    echo "   ldd $EXECUTABLE"
+else
+    echo -e "${RED}❌ Encontradas ${#MISSING_LIBS[@]} dependência(s) faltando:${NC}"
+    echo ""
+    
+    for lib in "${MISSING_LIBS[@]}"; do
+        echo -e "${RED}   ✗ $lib${NC}"
+    done
+    
+    echo ""
+    echo -e "${YELLOW}💡 Comandos sugeridos para instalar as dependências faltantes:${NC}"
+    echo ""
+    
+    # Agrupar sugestões por biblioteca
+    for lib in "${MISSING_LIBS[@]}"; do
+        INSTALL_CMD=$(suggest_install_command "$lib" "$lib")
+        echo -e "${BLUE}   $INSTALL_CMD${NC}"
+    done
+    
+    echo ""
+    echo -e "${YELLOW}📋 Ou use o script de instalação automática:${NC}"
+    case "$DISTRO_ID" in
+        arch|manjaro|endeavouros)
+            echo "   ./tools/install-deps-manjaro.sh"
+            ;;
+        debian|ubuntu|raspbian)
+            echo "   ./tools/install-deps-raspberry-pi.sh"
+            ;;
+        *)
+            echo "   Verifique a documentação para sua distribuição"
+            ;;
+    esac
+fi
+
+echo ""
+echo -e "${BLUE}=== Informações Adicionais ===${NC}"
+echo ""
+echo "Para ver todas as dependências (incluindo caminhos):"
+echo "   ldd $EXECUTABLE"
+echo ""
+echo "Para ver apenas bibliotecas necessárias:"
+echo "   readelf -d $EXECUTABLE | grep NEEDED"
+echo ""
+echo "Para verificar arquitetura do executável:"
+echo "   file $EXECUTABLE"

--- a/tools/clean-build.sh
+++ b/tools/clean-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Script para limpar completamente um build anterior
+# Uso: ./tools/clean-build.sh [diretório-do-build]
+
+set -e
+
+BUILD_DIR="${1:-build-linux-x86_64}"
+
+if [ ! -d "$BUILD_DIR" ]; then
+    echo "⚠️  Diretório de build não encontrado: $BUILD_DIR"
+    echo "   Nada para limpar."
+    exit 0
+fi
+
+echo "🧹 Limpando build anterior: $BUILD_DIR"
+echo ""
+
+# Confirmar antes de deletar
+read -p "Tem certeza que deseja deletar $BUILD_DIR? (s/N): " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Ss]$ ]]; then
+    echo "❌ Operação cancelada."
+    exit 0
+fi
+
+echo "🗑️  Removendo $BUILD_DIR..."
+rm -rf "$BUILD_DIR"
+
+echo "✅ Build limpo com sucesso!"
+echo ""
+echo "💡 Agora você pode recompilar:"
+echo "   mkdir -p $BUILD_DIR"
+echo "   cd $BUILD_DIR"
+echo "   cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_COMPATIBLE_X86_64=ON"
+echo "   cmake --build . -j\$(nproc)"

--- a/tools/diagnose-cpu-compatibility.sh
+++ b/tools/diagnose-cpu-compatibility.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Script para diagnosticar problemas de compatibilidade de CPU
+# Uso: ./tools/diagnose-cpu-compatibility.sh [caminho-do-executável]
+
+set -e
+
+# Cores para output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== Diagnóstico de Compatibilidade de CPU ===${NC}"
+echo ""
+
+# Encontrar executável
+EXECUTABLE=""
+
+if [ -n "$1" ]; then
+    EXECUTABLE="$1"
+    elif [ -f "build-linux-x86_64/bin/retrocapture" ]; then
+    EXECUTABLE="build-linux-x86_64/bin/retrocapture"
+    elif [ -f "./bin/retrocapture" ]; then
+    EXECUTABLE="./bin/retrocapture"
+    elif command -v retrocapture &> /dev/null; then
+    EXECUTABLE="$(command -v retrocapture)"
+else
+    echo -e "${RED}❌ Executável não encontrado!${NC}"
+    echo ""
+    echo "Uso: $0 [caminho-do-executável]"
+    exit 1
+fi
+
+if [ ! -f "$EXECUTABLE" ]; then
+    echo -e "${RED}❌ Arquivo não encontrado: $EXECUTABLE${NC}"
+    exit 1
+fi
+
+echo "📁 Executável: $EXECUTABLE"
+echo ""
+
+# Informações da CPU atual
+echo -e "${BLUE}=== Informações da CPU Atual ===${NC}"
+if [ -f /proc/cpuinfo ]; then
+    CPU_MODEL=$(grep -m1 "model name" /proc/cpuinfo | cut -d: -f2 | sed 's/^[ \t]*//')
+    CPU_FLAGS=$(grep -m1 "flags" /proc/cpuinfo | cut -d: -f2 | sed 's/^[ \t]*//')
+    echo "   Modelo: $CPU_MODEL"
+    echo ""
+    echo "   Flags suportadas:"
+    echo "$CPU_FLAGS" | tr ' ' '\n' | grep -E "(avx|sse|mmx|fma)" | sed 's/^/     • /' || echo "     (nenhuma flag relevante encontrada)"
+else
+    echo "   Não foi possível ler informações da CPU"
+fi
+
+echo ""
+
+# Verificar instruções usadas no binário
+echo -e "${BLUE}=== Instruções Detectadas no Binário ===${NC}"
+
+if ! command -v objdump &> /dev/null; then
+    echo -e "${YELLOW}⚠️  objdump não está disponível. Instale: binutils${NC}"
+    echo ""
+else
+    # Função auxiliar para contar instruções de forma segura
+    count_instructions() {
+        local pattern="$1"
+        local count=$(objdump -d "$EXECUTABLE" 2>/dev/null | grep -c "$pattern" 2>/dev/null || echo "0")
+        # Garantir que é um número válido (remover quebras de linha e espaços)
+        count=$(echo "$count" | tr -d '\n\r ' | head -1)
+        # Se vazio ou não numérico, retornar 0
+        if [ -z "$count" ] || ! echo "$count" | grep -qE '^[0-9]+$'; then
+            echo "0"
+        else
+            echo "$count"
+        fi
+    }
+    
+    # Verificar instruções AVX2
+    AVX2_COUNT=$(count_instructions "vpbroadcast\|vpmulld\|vpermd\|vpaddd\|vpsubd")
+    if [ "$AVX2_COUNT" -gt 0 ] 2>/dev/null; then
+        echo -e "${RED}   ❌ AVX2 detectado: $AVX2_COUNT instruções${NC}"
+        echo "      O binário requer AVX2 (não suportado em CPUs antigas)"
+    else
+        echo -e "${GREEN}   ✅ AVX2 não detectado${NC}"
+        AVX2_COUNT=0
+    fi
+    
+    # Verificar instruções AVX-512
+    AVX512_COUNT=$(count_instructions "vpbroadcast.*zmm\|vpmulld.*zmm")
+    if [ "$AVX512_COUNT" -gt 0 ] 2>/dev/null; then
+        echo -e "${RED}   ❌ AVX-512 detectado: $AVX512_COUNT instruções${NC}"
+        echo "      O binário requer AVX-512 (apenas CPUs muito recentes)"
+    else
+        echo -e "${GREEN}   ✅ AVX-512 não detectado${NC}"
+        AVX512_COUNT=0
+    fi
+    
+    # Verificar instruções AVX (básico)
+    AVX_COUNT=$(count_instructions "vaddps\|vmulps\|vsubps")
+    if [ "$AVX_COUNT" -gt 0 ] 2>/dev/null; then
+        echo -e "${YELLOW}   ⚠️  AVX detectado: $AVX_COUNT instruções${NC}"
+        echo "      Requer CPU com suporte AVX (Sandy Bridge/AMD Bulldozer ou mais novo)"
+    else
+        AVX_COUNT=0
+    fi
+    
+    # Verificar SSE4.2
+    SSE42_COUNT=$(count_instructions "pcmpgtq\|crc32")
+    if [ "$SSE42_COUNT" -gt 0 ] 2>/dev/null; then
+        echo -e "${GREEN}   ✅ SSE4.2 detectado: $SSE42_COUNT instruções${NC}"
+        echo "      Compatível com CPUs desde Core 2 (2006)"
+    else
+        SSE42_COUNT=0
+    fi
+fi
+
+echo ""
+
+# Verificar se a CPU suporta as instruções necessárias
+echo -e "${BLUE}=== Compatibilidade ===${NC}"
+
+if [ -f /proc/cpuinfo ]; then
+    # Verificar suporte AVX2
+    if echo "$CPU_FLAGS" | grep -q "avx2"; then
+        echo -e "${GREEN}   ✅ CPU suporta AVX2${NC}"
+    else
+        echo -e "${RED}   ❌ CPU NÃO suporta AVX2${NC}"
+        if [ "$AVX2_COUNT" -gt 0 ]; then
+            echo -e "${RED}      ⚠️  PROBLEMA: Binário requer AVX2 mas CPU não suporta!${NC}"
+        fi
+    fi
+    
+    # Verificar suporte AVX
+    if echo "$CPU_FLAGS" | grep -q " avx "; then
+        echo -e "${GREEN}   ✅ CPU suporta AVX${NC}"
+    else
+        echo -e "${YELLOW}   ⚠️  CPU não suporta AVX (muito antiga)${NC}"
+    fi
+    
+    # Verificar suporte SSE4.2
+    if echo "$CPU_FLAGS" | grep -q "sse4_2"; then
+        echo -e "${GREEN}   ✅ CPU suporta SSE4.2${NC}"
+    else
+        echo -e "${RED}   ❌ CPU não suporta SSE4.2 (muito antiga, pré-2006)${NC}"
+    fi
+fi
+
+echo ""
+
+# Soluções
+echo -e "${BLUE}=== Soluções ===${NC}"
+echo ""
+
+if [ "$AVX2_COUNT" -gt 0 ] && [ -f /proc/cpuinfo ] && ! echo "$CPU_FLAGS" | grep -q "avx2"; then
+    echo -e "${YELLOW}🔧 SOLUÇÃO: Recompilar com flags compatíveis${NC}"
+    echo ""
+    echo "O binário foi compilado com -march=native em uma CPU mais nova."
+    echo "Para compatibilidade com CPUs mais antigas, recompile com:"
+    echo ""
+    echo "   mkdir -p build-linux-x86_64-compatible"
+    echo "   cd build-linux-x86_64-compatible"
+    echo "   cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_COMPATIBLE_X86_64=ON"
+    echo "   cmake --build . -j\$(nproc)"
+    echo ""
+    echo "Ou compile diretamente na máquina antiga (recomendado)."
+else
+    echo -e "${GREEN}✅ Binário parece compatível com a CPU atual${NC}"
+    echo ""
+    echo "Se ainda houver problemas, tente:"
+    echo "   1. Verificar dependências: ./tools/check-dependencies.sh"
+    echo "   2. Recompilar na máquina atual"
+    echo "   3. Verificar logs de erro para mais detalhes"
+fi
+
+echo ""
+echo -e "${BLUE}=== Informações Adicionais ===${NC}"
+echo ""
+echo "Para ver todas as instruções do binário:"
+echo "   objdump -d $EXECUTABLE | grep -E '(vpbroadcast|vpmulld|vpermd)'"
+echo ""
+echo "Para verificar arquitetura do binário:"
+echo "   file $EXECUTABLE"
+echo "   readelf -h $EXECUTABLE | grep Machine"

--- a/tools/docker-build-linux-arm64v8.sh
+++ b/tools/docker-build-linux-arm64v8.sh
@@ -4,6 +4,13 @@ set -e
 # Build type: Release (default) or Debug
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 
+# Compatibilidade: builds Docker são pra distribuição, então default ON
+# (baseline ARMv8-A sem extensões opcionais — roda em Pi 3/4/5). Para -march=native
+# (uso local em hardware específico) passe BUILD_COMPATIBLE_ARM64=OFF.
+# Sob qemu-user-static, -march=native pode resolver pra um modelo "max" com SVE/SVE2
+# que crasha em hardware real.
+BUILD_COMPATIBLE="${BUILD_COMPATIBLE_ARM64:-ON}"
+
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
@@ -11,9 +18,21 @@ if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     exit 1
 fi
 
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ BUILD_COMPATIBLE_ARM64 inválido: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
+    exit 1
+fi
+
 echo "🚀 Compilando RetroCapture para Linux ARM64 (Raspberry Pi 4/5)..."
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: ARM64 (aarch64)"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (baseline ARMv8-A, sem SVE/crypto — recomendado para distribuição)"
+else
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
+fi
 echo ""
 
 # Verificar se estamos no diretório correto
@@ -74,16 +93,23 @@ if [ "$NUM_CPUS" -gt 20 ]; then
     NUM_CPUS=20
 fi
 
+CMAKE_EXTRA_ARGS=""
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    CMAKE_EXTRA_ARGS="-DBUILD_COMPATIBLE_ARM64=ON"
+fi
+
 if [ "$BUILD_WITH_SDL2" = "ON" ]; then
     echo "   🔧 Compilando com SDL2 (suporte DirectFB/framebuffer)"
     cmake .. \
         -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
         -DBUILD_WITH_SDL2=ON \
+        $CMAKE_EXTRA_ARGS \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 else
     cmake .. \
         -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+        $CMAKE_EXTRA_ARGS \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 fi

--- a/tools/docker-build-linux-x86_64.sh
+++ b/tools/docker-build-linux-x86_64.sh
@@ -4,6 +4,9 @@ set -e
 # Build type: Release (default) or Debug
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 
+# Compatibilidade: se BUILD_COMPATIBLE_X86_64 estiver definido, usar flags compatíveis
+BUILD_COMPATIBLE="${BUILD_COMPATIBLE_X86_64:-OFF}"
+
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
@@ -11,9 +14,21 @@ if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     exit 1
 fi
 
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ BUILD_COMPATIBLE_X86_64 inválido: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
+    exit 1
+fi
+
 echo "🚀 Compilando RetroCapture para Linux x86_64..."
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (sem AVX2, funciona em CPUs antigas)"
+else
+    echo "⚡ Modo compatível: OFF (otimização máxima com -march=native)"
+fi
 echo ""
 
 # Verificar se estamos no diretório correto
@@ -47,8 +62,14 @@ if [ -d "_deps" ]; then
 fi
 
 echo "⚙️  Configurando CMake..."
-cmake .. \
--DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    cmake .. \
+        -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+        -DBUILD_COMPATIBLE_X86_64=ON
+else
+    cmake .. \
+        -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+fi
 
 echo ""
 echo "🔨 Compilando..."

--- a/tools/docker-build-linux-x86_64.sh
+++ b/tools/docker-build-linux-x86_64.sh
@@ -4,8 +4,9 @@ set -e
 # Build type: Release (default) or Debug
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 
-# Compatibilidade: se BUILD_COMPATIBLE_X86_64 estiver definido, usar flags compatíveis
-BUILD_COMPATIBLE="${BUILD_COMPATIBLE_X86_64:-OFF}"
+# Compatibilidade: builds dentro do Docker são pra distribuição, então default ON
+# (baseline x86-64-v2, sem AVX/AVX2). Para -march=native passe BUILD_COMPATIBLE_X86_64=OFF.
+BUILD_COMPATIBLE="${BUILD_COMPATIBLE_X86_64:-ON}"
 
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
@@ -25,9 +26,9 @@ echo "🚀 Compilando RetroCapture para Linux x86_64..."
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
 if [ "$BUILD_COMPATIBLE" = "ON" ]; then
-    echo "🔧 Modo compatível: ON (sem AVX2, funciona em CPUs antigas)"
+    echo "🔧 Modo compatível: ON (baseline x86-64-v2, sem AVX/AVX2 — recomendado para distribuição)"
 else
-    echo "⚡ Modo compatível: OFF (otimização máxima com -march=native)"
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
 fi
 echo ""
 

--- a/tools/docker-build-windows-x86_64.sh
+++ b/tools/docker-build-windows-x86_64.sh
@@ -4,6 +4,12 @@ set -e
 # Build type: Release (default) or Debug
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 
+# Compatibilidade: builds Docker são pra distribuição, então default ON
+# (baseline x86-64-v2, sem AVX/AVX2). Para -march=native passe BUILD_COMPATIBLE_X86_64=OFF.
+# A flag aqui é a MESMA do build Linux (CMake só conhece BUILD_COMPATIBLE_X86_64,
+# independente do alvo): o cross-compile MinGW também emite AVX2 com -march=native.
+BUILD_COMPATIBLE="${BUILD_COMPATIBLE_X86_64:-ON}"
+
 # Validar build type
 if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     echo "❌ Build type inválido: $BUILD_TYPE"
@@ -11,9 +17,21 @@ if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
     exit 1
 fi
 
+# Validar opção de compatibilidade
+if [ "$BUILD_COMPATIBLE" != "ON" ] && [ "$BUILD_COMPATIBLE" != "OFF" ]; then
+    echo "❌ BUILD_COMPATIBLE_X86_64 inválido: $BUILD_COMPATIBLE"
+    echo "   Use: ON ou OFF"
+    exit 1
+fi
+
 echo "🚀 Compilando RetroCapture para Windows x86_64..."
 echo "📦 Build type: $BUILD_TYPE"
 echo "🏗️  Arquitetura: x86_64 (amd64)"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    echo "🔧 Modo compatível: ON (baseline x86-64-v2, sem AVX/AVX2 — recomendado para distribuição)"
+else
+    echo "⚡ Modo compatível: OFF (-march=native — só roda em CPUs equivalentes à do build host)"
+fi
 echo ""
 
 # dockcross monta o código em /work
@@ -30,9 +48,16 @@ cd build-windows-x86_64
 echo "⚙️  Configurando CMake..."
 # dockcross usa MXE em /usr/src/mxe com target static
 export PKG_CONFIG_PATH=/usr/src/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig
-cmake .. \
--DCMAKE_TOOLCHAIN_FILE=/usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake \
--DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+if [ "$BUILD_COMPATIBLE" = "ON" ]; then
+    cmake .. \
+    -DCMAKE_TOOLCHAIN_FILE=/usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DBUILD_COMPATIBLE_X86_64=ON
+else
+    cmake .. \
+    -DCMAKE_TOOLCHAIN_FILE=/usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+fi
 
 echo ""
 echo "🔨 Compilando..."

--- a/tools/install-deps-manjaro.sh
+++ b/tools/install-deps-manjaro.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Script para instalar dependências do RetroCapture no Manjaro/Arch Linux
+# Uso: ./tools/install-deps-manjaro.sh
+
+set -e
+
+echo "🔍 Detectando sistema..."
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    echo "   Sistema: $PRETTY_NAME"
+    echo "   Versão: $VERSION_ID"
+fi
+
+# Verificar se está rodando como root (necessário para pacman)
+if [ "$EUID" -eq 0 ]; then
+    echo "❌ Não execute este script como root/sudo."
+    echo "   O script pedirá senha quando necessário."
+    exit 1
+fi
+
+echo ""
+echo "📦 Instalando dependências do RetroCapture no Manjaro/Arch Linux..."
+echo ""
+
+# Atualizar banco de dados de pacotes
+echo "🔄 Atualizando banco de dados de pacotes..."
+sudo pacman -Sy
+
+# Ferramentas de build
+echo ""
+echo "🔨 Instalando ferramentas de build..."
+sudo pacman -S --needed --noconfirm \
+    base-devel \
+    cmake \
+    pkgconf \
+    git
+
+# Dependências gráficas e de janela
+echo ""
+echo "🖼️  Instalando dependências gráficas..."
+sudo pacman -S --needed --noconfirm \
+    mesa \
+    libgl \
+    glfw \
+    libx11 \
+    libxrandr \
+    libxinerama \
+    libxcursor \
+    libxi
+
+# SDL2 (opcional, para suporte a DirectFB/framebuffer)
+echo ""
+echo "🎮 Instalando SDL2 (opcional, para framebuffer/DirectFB)..."
+sudo pacman -S --needed --noconfirm sdl2
+
+# PNG
+echo ""
+echo "🖼️  Instalando libpng..."
+sudo pacman -S --needed --noconfirm libpng
+
+# FFmpeg
+echo ""
+echo "🎬 Instalando FFmpeg..."
+sudo pacman -S --needed --noconfirm \
+    ffmpeg
+
+# V4L2 (Video4Linux2 - para captura de vídeo no Linux)
+echo ""
+echo "📹 Instalando V4L2..."
+sudo pacman -S --needed --noconfirm \
+    v4l-utils
+
+# PulseAudio (para captura de áudio no Linux)
+echo ""
+echo "🔊 Instalando PulseAudio..."
+sudo pacman -S --needed --noconfirm \
+    libpulse
+
+# OpenSSL (para suporte HTTPS)
+echo ""
+echo "🔒 Instalando OpenSSL..."
+sudo pacman -S --needed --noconfirm \
+    openssl
+
+echo ""
+echo "✅ Todas as dependências foram instaladas!"
+echo ""
+echo "📋 Resumo das dependências instaladas:"
+echo "   • Ferramentas de build: base-devel, cmake, pkgconf, git"
+echo "   • Gráficas: mesa, libgl, glfw, libx11, libxrandr, libxinerama, libxcursor, libxi"
+echo "   • SDL2: sdl2 (opcional)"
+echo "   • Imagens: libpng"
+echo "   • Mídia: ffmpeg"
+echo "   • Captura de vídeo: v4l-utils"
+echo "   • Captura de áudio: libpulse"
+echo "   • Segurança: openssl"
+echo ""
+echo "🚀 Agora você pode compilar o RetroCapture:"
+echo "   mkdir -p build-linux-x86_64"
+echo "   cd build-linux-x86_64"
+echo "   cmake .. -DCMAKE_BUILD_TYPE=Release"
+echo "   cmake --build . -j\$(nproc)"
+echo ""
+echo "💡 Dica: Se você quiser usar SDL2 em vez de GLFW (para framebuffer/DirectFB),"
+echo "   use: cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_SDL2=ON"
+echo ""


### PR DESCRIPTION
- Add BUILD_COMPATIBLE_X86_64 CMake option to build binaries compatible with older CPUs
- Apply compatible flags (-march=x86-64 -mtune=generic -msse4.2 -mno-avx -mno-avx2) to both retrocapture and ImGui
- Update Docker build scripts to support compatibility mode
- Add diagnose-cpu-compatibility.sh script to detect CPU instruction set requirements
- Add check-dependencies.sh script to verify shared library dependencies
- Add install-deps-manjaro.sh script for Manjaro/Arch Linux dependency installation
- Add clean-build.sh script to clean build directories
- Update Dockerfile to use Ubuntu 22.04 for better compatibility

This allows RetroCapture to run on older CPUs like AMD A8 PRO-7600B that don't support AVX2.