### PR TITLE
chore: standardize storage paths on Linux (XDG) and Windows (Known Fo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ build-windows-x86_64/
 *.pdb
 *.exp
 mxe/
+
+# Planning docs (local only)t
+issues-draft/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,39 @@ if(PLATFORM_WINDOWS)
         message(STATUS "  Output file: ${CPACK_PACKAGE_FILE_NAME}.exe")
     endif()
 else()
-    # Instalação padrão para outras plataformas
-    install(TARGETS retrocapture DESTINATION bin)
+    # Instalação Linux: respeita XDG. Por default cai em /usr/local/{bin,share}
+    # via CMAKE_INSTALL_PREFIX. Pacotagem (.deb/.rpm) overridea pra /usr.
+    install(TARGETS retrocapture
+        RUNTIME DESTINATION bin
+    )
+
+    # Read-only assets shipados — Paths::getReadOnlyAssetsDir() encontra via
+    # XDG_DATA_DIRS (/usr/share, /usr/local/share) → retrocapture/.
+    if(EXISTS "${CMAKE_SOURCE_DIR}/shaders/shaders_glsl")
+        install(DIRECTORY "${CMAKE_SOURCE_DIR}/shaders/shaders_glsl"
+            DESTINATION share/retrocapture/shaders
+            FILES_MATCHING PATTERN "*"
+        )
+    endif()
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/assets")
+        install(DIRECTORY "${CMAKE_SOURCE_DIR}/assets/"
+            DESTINATION share/retrocapture
+            FILES_MATCHING PATTERN "*"
+        )
+    endif()
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/src/web")
+        install(DIRECTORY "${CMAKE_SOURCE_DIR}/src/web"
+            DESTINATION share/retrocapture
+            FILES_MATCHING PATTERN "*"
+        )
+    endif()
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/ssl")
+        install(DIRECTORY "${CMAKE_SOURCE_DIR}/ssl"
+            DESTINATION share/retrocapture
+            FILES_MATCHING PATTERN "*"
+        )
+    endif()
 endif()

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1,5 +1,6 @@
 #include "Application.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #include "../capture/IVideoCapture.h"
 #include "../capture/VideoCaptureFactory.h"
 #ifdef PLATFORM_LINUX
@@ -70,6 +71,11 @@ Application::~Application()
 bool Application::init()
 {
     LOG_INFO("Initializing Application...");
+
+    // Migrar layouts antigos (~/.config/retrocapture/{assets,ssl} ou
+    // %APPDATA%\RetroCapture\{assets,ssl}) pra novo XDG/Known-Folders
+    // layout. Idempotente — vê marcador `MIGRATED.txt` no destino.
+    Paths::migrateLegacyDataIfNeeded();
 
     if (!initWindow())
     {
@@ -2148,7 +2154,7 @@ bool Application::initUI()
     if (!m_presetPath.empty())
     {
         fs::path presetPath(m_presetPath);
-        fs::path basePath("shaders/shaders_glsl");
+        fs::path basePath = fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl";
         fs::path relativePath = fs::relative(presetPath, basePath);
         if (!relativePath.empty() && relativePath != presetPath)
         {
@@ -2988,8 +2994,9 @@ void Application::run()
                     // Overscan: amplia o viewport de modo que apenas a região
                     // central (1 - 2*overscan) do source caia dentro do FBO.
                     // X e Y independentes; 0 = sem corte, 0.45 = corta 45% de cada lado.
-                    const float overscanX = std::clamp(overscanXPctRead / 100.0f, 0.0f, 0.45f);
-                    const float overscanY = std::clamp(overscanYPctRead / 100.0f, 0.0f, 0.45f);
+                    // std::clamp é C++17; o MinGW antigo do build Windows não tem.
+                    const float overscanX = std::max(0.0f, std::min(0.45f, overscanXPctRead / 100.0f));
+                    const float overscanY = std::max(0.0f, std::min(0.45f, overscanYPctRead / 100.0f));
                     const float visibleFracX = 1.0f - 2.0f * overscanX;
                     const float visibleFracY = 1.0f - 2.0f * overscanY;
                     const float vpW = static_cast<float>(fboW) / visibleFracX;
@@ -4526,10 +4533,7 @@ fs::path Application::getShaderBasePath() const
     {
         return fs::path(envShaderPath);
     }
-    else
-    {
-        return fs::current_path() / "shaders" / "shaders_glsl";
-    }
+    return fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl";
 }
 
 std::string Application::resolveShaderPath(const std::string &shaderPath) const

--- a/src/recording/RecordingManager.cpp
+++ b/src/recording/RecordingManager.cpp
@@ -1,5 +1,6 @@
 #include "RecordingManager.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #include "../utils/FilesystemCompat.h"
 #include <fstream>
 #include <ctime>
@@ -57,8 +58,28 @@ std::string RecordingManager::generateFilename(const RecordingSettings &settings
         filename += ".mp4"; // Default
     }
 
-    // Build full path
+    // Build full path. Path relativo (ex: "recordings/" default) é resolvido
+    // contra o diretório Videos do usuário; absoluto é honrado como está.
     fs::path outputDir(settings.outputPath);
+    if (outputDir.is_relative())
+    {
+        std::string videos = Paths::getDefaultRecordingsDir();
+        if (!videos.empty())
+        {
+            // "recordings/" relativo vira <Videos>/RetroCapture/. Path com
+            // sub-diretório (ex: "retro/snes/") é tratado como sub do Videos.
+            if (settings.outputPath == "recordings/" ||
+                settings.outputPath == "recordings" ||
+                settings.outputPath.empty())
+            {
+                outputDir = videos;
+            }
+            else
+            {
+                outputDir = fs::path(videos) / settings.outputPath;
+            }
+        }
+    }
     fs::path fullPath = outputDir / filename;
 
     return fullPath.string();

--- a/src/shader/ShaderPreprocessor.cpp
+++ b/src/shader/ShaderPreprocessor.cpp
@@ -184,17 +184,42 @@ ShaderPreprocessor::PreprocessResult ShaderPreprocessor::preprocess(
 std::string ShaderPreprocessor::processIncludes(const std::string& source, const std::string& basePath)
 {
     std::string result = source;
-    // Multiline + line-start âncora: exige que `#include` esteja no começo
-    // da linha (após whitespace opcional). Sem isso, qualquer `// #include "..."`
-    // dentro de comentário também era processado, gerando warnings em massa
-    // (ex: crt-royale tem dezenas de #include comentados na documentação).
-    std::regex includeRegex(R"(^[ \t]*#include\s+["<]([^">]+)[">])",
-                            std::regex_constants::ECMAScript | std::regex_constants::multiline);
+    // Pattern usado por linha — sem multiline flag (não existe no MinGW
+    // antigo do build Windows). Itera linha-a-linha; só processa includes
+    // que estão no começo da linha (após whitespace), ignorando os que
+    // estão dentro de comentário `// ...` (ex: crt-royale tem dezenas).
+    std::regex includeRegex(R"([ \t]*#include\s+["<]([^">]+)[">].*)");
     std::smatch match;
 
     // Processar todos os includes
-    while (std::regex_search(result, match, includeRegex))
+    while (true)
     {
+        // Localiza a próxima linha que case com `^[ \t]*#include ...`.
+        size_t includeLineStart = std::string::npos;
+        size_t includeLineEnd = 0;
+        size_t lineStart = 0;
+        while (lineStart < result.size())
+        {
+            size_t lineEnd = result.find('\n', lineStart);
+            std::string line = (lineEnd == std::string::npos)
+                ? result.substr(lineStart)
+                : result.substr(lineStart, lineEnd - lineStart);
+            if (std::regex_match(line, match, includeRegex))
+            {
+                includeLineStart = lineStart;
+                includeLineEnd = (lineEnd == std::string::npos) ? result.size() : lineEnd;
+                break;
+            }
+            if (lineEnd == std::string::npos) break;
+            lineStart = lineEnd + 1;
+        }
+        if (includeLineStart == std::string::npos)
+        {
+            break; // nenhum include real restante
+        }
+        // Daqui em diante, `match[1]` é o path do include — segue o fluxo
+        // de resolução abaixo, que termina substituindo a linha em
+        // `[includeLineStart, includeLineEnd)` pelo conteúdo carregado.
         std::string includePath = match[1].str();
         std::string fullPath;
 
@@ -275,22 +300,24 @@ std::string ShaderPreprocessor::processIncludes(const std::string& source, const
                 std::string includeDir = includeFilePath.parent_path().string();
                 includeContent = processIncludes(includeContent, includeDir);
 
-                // Substituir o #include pelo conteúdo
-                result = std::regex_replace(result, includeRegex, includeContent, std::regex_constants::format_first_only);
+                // Substituir a LINHA do #include pelo conteúdo (preserva
+                // a estrutura do arquivo e evita pegar `// #include` de
+                // comentários, que regex_replace pegaria).
+                result.replace(includeLineStart, includeLineEnd - includeLineStart, includeContent);
                 LOG_INFO("Arquivo incluído: " + fullPath);
             }
             else
             {
                 LOG_WARN("Falha ao abrir arquivo incluído: " + fullPath);
                 // Remover o #include que falhou
-                result = std::regex_replace(result, includeRegex, "", std::regex_constants::format_first_only);
+                result.replace(includeLineStart, includeLineEnd - includeLineStart, "");
             }
         }
         else
         {
             LOG_WARN("Arquivo incluído não encontrado: " + includePath);
             // Remover o #include que falhou
-            result = std::regex_replace(result, includeRegex, "", std::regex_constants::format_first_only);
+            result.replace(includeLineStart, includeLineEnd - includeLineStart, "");
         }
     }
 

--- a/src/shader/ShaderPreset.cpp
+++ b/src/shader/ShaderPreset.cpp
@@ -1,5 +1,6 @@
 #include "ShaderPreset.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -346,7 +347,9 @@ std::string ShaderPreset::resolvePath(const std::string &path)
 
     fs::path currentPath = fs::current_path();
 
-    // Usar RETROCAPTURE_SHADER_PATH se disponível (para AppImage)
+    // Usar RETROCAPTURE_SHADER_PATH se disponível (para AppImage),
+    // senão delegar pro `Paths::getReadOnlyAssetsDir()` (que cobre dev tree
+    // / portable / install system-wide).
     const char *envShaderPath = std::getenv("RETROCAPTURE_SHADER_PATH");
     fs::path shaderBasePath;
     if (envShaderPath && fs::exists(envShaderPath))
@@ -355,7 +358,7 @@ std::string ShaderPreset::resolvePath(const std::string &path)
     }
     else
     {
-        shaderBasePath = currentPath / "shaders" / "shaders_glsl";
+        shaderBasePath = fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl";
     }
 
     fs::path relPath(path);

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1,5 +1,6 @@
 #include "HTTPTSStreamer.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 
 #ifdef PLATFORM_LINUX
 #include <sys/socket.h>
@@ -203,42 +204,32 @@ bool HTTPTSStreamer::start()
     // HTTPS só faz sentido se o Web Portal estiver ativo
     if (m_webPortalEnabled && m_enableHTTPS && !m_sslCertPath.empty() && !m_sslKeyPath.empty())
     {
-        // Função helper para obter diretório de configuração do usuário
-        auto getUserConfigDir = []() -> std::string
+        // Procura arquivos SSL: caminho absoluto > user-data/ssl > read-only assets > cwd.
+        auto findSSLFile = [](const std::string &relativePath) -> std::string
         {
-            const char *homeDir = std::getenv("HOME");
-            if (homeDir)
-            {
-                fs::path configDir = fs::path(homeDir) / ".config" / "retrocapture";
-                return configDir.string();
-            }
-            return "";
-        };
-
-        // Função helper para encontrar arquivo SSL em vários locais possíveis
-        // Prioridade: 1) Caminho absoluto fornecido, 2) ~/.config/retrocapture/ssl/, 3) Diretório atual/ssl/
-        auto findSSLFile = [getUserConfigDir](const std::string &relativePath) -> std::string
-        {
-            // Se o caminho já é absoluto, verificar diretamente (prioridade máxima)
             fs::path testPath(relativePath);
             if (testPath.is_absolute() && fs::exists(testPath))
             {
                 return fs::absolute(testPath).string();
             }
 
-            // Extrair apenas o nome do arquivo
             fs::path inputPath(relativePath);
             std::string fileName = inputPath.filename();
 
-            // Lista de locais para buscar (em ordem de prioridade)
             std::vector<std::string> possiblePaths;
 
-            // 1. Pasta de configuração do usuário (~/.config/retrocapture/ssl/) - PRIORIDADE ALTA
-            std::string userConfigDir = getUserConfigDir();
-            if (!userConfigDir.empty())
+            // 1. User data: certs do usuário (per-user, não roamed via XDG_DATA_HOME).
+            std::string userDataDir = Paths::getUserDataDir();
+            if (!userDataDir.empty())
             {
-                fs::path userSSLDir = fs::path(userConfigDir) / "ssl";
-                possiblePaths.push_back((userSSLDir / fileName).string());
+                possiblePaths.push_back((fs::path(userDataDir) / "ssl" / fileName).string());
+            }
+
+            // 2. Read-only assets: SSL bundle shipado com a aplicação.
+            std::string roAssets = Paths::getReadOnlyAssetsDir();
+            if (!roAssets.empty())
+            {
+                possiblePaths.push_back((fs::path(roAssets) / "ssl" / fileName).string());
             }
 
             // 2. Caminho como fornecido (pode ser relativo)
@@ -304,30 +295,14 @@ bool HTTPTSStreamer::start()
         if (foundCertPath.empty())
         {
             LOG_ERROR("SSL Certificate file not found: " + m_sslCertPath);
-            std::string userConfigDir = getUserConfigDir();
-            if (!userConfigDir.empty())
-            {
-                LOG_ERROR("Searched in: ~/.config/retrocapture/ssl/, current directory, ./ssl/, ../ssl/, ../../ssl/");
-            }
-            else
-            {
-                LOG_ERROR("Searched in: current directory, ./ssl/, ../ssl/, ../../ssl/");
-            }
+            LOG_ERROR("Searched in user-data/ssl, read-only assets/ssl, ./ssl/, ../ssl/, ../../ssl/");
             LOG_ERROR("Please generate certificates or disable HTTPS. Continuing with HTTP only.");
             m_enableHTTPS = false;
         }
         else if (foundKeyPath.empty())
         {
             LOG_ERROR("SSL Private Key file not found: " + m_sslKeyPath);
-            std::string userConfigDir = getUserConfigDir();
-            if (!userConfigDir.empty())
-            {
-                LOG_ERROR("Searched in: ~/.config/retrocapture/ssl/, current directory, ./ssl/, ../ssl/, ../../ssl/");
-            }
-            else
-            {
-                LOG_ERROR("Searched in: current directory, ./ssl/, ../ssl/, ../../ssl/");
-            }
+            LOG_ERROR("Searched in user-data/ssl, read-only assets/ssl, ./ssl/, ../ssl/, ../../ssl/");
             LOG_ERROR("Please generate certificates or disable HTTPS. Continuing with HTTP only.");
             m_enableHTTPS = false;
         }

--- a/src/streaming/WebPortal.cpp
+++ b/src/streaming/WebPortal.cpp
@@ -1,6 +1,7 @@
 #include "WebPortal.h"
 #include "HTTPServer.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #ifdef PLATFORM_LINUX
 #include <sys/socket.h>
 #include <unistd.h>
@@ -709,77 +710,38 @@ ssize_t WebPortal::sendData(int clientFd, const void *data, size_t size) const
 
 std::string WebPortal::findAssetFile(const std::string &relativePath) const
 {
-    // Função helper para obter diretório de configuração do usuário
-    auto getUserConfigDir = []() -> std::string
-    {
-        const char *homeDir = std::getenv("HOME");
-        if (homeDir)
-        {
-            fs::path configDir = fs::path(homeDir) / ".config" / "retrocapture";
-            return configDir.string();
-        }
-        return "";
-    };
-
-    // Se o caminho já é absoluto, verificar diretamente (prioridade máxima)
+    // Caminho absoluto ganha sempre.
     fs::path testPath(relativePath);
     if (testPath.is_absolute() && fs::exists(testPath))
     {
         return fs::absolute(testPath).string();
     }
 
-    // Extrair apenas o nome do arquivo
     fs::path inputPath(relativePath);
     std::string fileName = inputPath.filename();
 
-    // Lista de locais para buscar (em ordem de prioridade)
     std::vector<std::string> possiblePaths;
 
-    // 1. Variável de ambiente RETROCAPTURE_ASSETS_PATH (para AppImage) - PRIORIDADE MÁXIMA
-    const char *assetsEnvPath = std::getenv("RETROCAPTURE_ASSETS_PATH");
-    if (assetsEnvPath)
+    // 1. User data: customizações do usuário (override do que vem na app).
+    std::string userDataDir = Paths::getUserDataDir();
+    if (!userDataDir.empty())
     {
-        fs::path envAssetsDir(assetsEnvPath);
-        possiblePaths.push_back((envAssetsDir / fileName).string());
-        possiblePaths.push_back((envAssetsDir / relativePath).string());
+        possiblePaths.push_back((fs::path(userDataDir) / relativePath).string());
+        possiblePaths.push_back((fs::path(userDataDir) / fileName).string());
     }
 
-    // 2. Pasta de configuração do usuário (~/.config/retrocapture/assets/) - PRIORIDADE ALTA
-    std::string userConfigDir = getUserConfigDir();
-    if (!userConfigDir.empty())
+    // 2. Read-only assets: shipados com a aplicação (system install ou portable).
+    std::string roAssets = Paths::getReadOnlyAssetsDir();
+    if (!roAssets.empty())
     {
-        fs::path userAssetsDir = fs::path(userConfigDir) / "assets";
-        possiblePaths.push_back((userAssetsDir / relativePath).string());
-        possiblePaths.push_back((userAssetsDir / fileName).string());
+        possiblePaths.push_back((fs::path(roAssets) / relativePath).string());
+        possiblePaths.push_back((fs::path(roAssets) / fileName).string());
     }
 
-    // 3. Diretório do executável/assets/ (tentar obter via /proc/self/exe no Linux)
-    // No Linux, podemos usar readlink em /proc/self/exe para obter o caminho do executável
-    char exePath[1024];
-    #ifdef PLATFORM_LINUX
-    ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
-    if (len != -1)
-    #else
-    // Windows: usar GetModuleFileName
-    DWORD len = GetModuleFileNameA(NULL, exePath, sizeof(exePath) - 1);
-    if (len != 0)
-    #endif
-    {
-        exePath[len] = '\0';
-        fs::path exeDir = fs::path(exePath).parent_path();
-        fs::path assetsDir = exeDir / "assets";
-        possiblePaths.push_back((assetsDir / relativePath).string());
-        possiblePaths.push_back((assetsDir / fileName).string());
-    }
-
-    // 4. Caminho como fornecido (pode ser relativo)
+    // 3. Caminho como fornecido + cwd fallback (último recurso pra dev).
     possiblePaths.push_back(relativePath);
-
-    // 5. Diretório atual/assets/
     possiblePaths.push_back("./assets/" + fileName);
     possiblePaths.push_back("./assets/" + relativePath);
-
-    // 6. Diretório atual
     possiblePaths.push_back("./" + fileName);
     possiblePaths.push_back("./" + relativePath);
 

--- a/src/ui/UIConfigurationShader.cpp
+++ b/src/ui/UIConfigurationShader.cpp
@@ -2,6 +2,7 @@
 #include "UIManager.h"
 #include "../shader/ShaderEngine.h"
 #include "../utils/FilesystemCompat.h"
+#include "../utils/Paths.h"
 #include <imgui.h>
 #include <cstring>
 
@@ -127,7 +128,7 @@ void UIConfigurationShader::renderSavePreset()
             if (onSavePreset && strlen(m_savePresetPath) > 0)
             {
                 // Construir caminho completo
-                fs::path basePath("shaders/shaders_glsl");
+                fs::path basePath = fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl";
                 fs::path newPath = basePath / m_savePresetPath;
                 // Garantir extensão .glslp
                 if (newPath.extension() != ".glslp")

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -4,6 +4,7 @@
 #include "UICapturePresets.h"
 #include "UIRecordings.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #include "../utils/ShaderScanner.h"
 #ifdef PLATFORM_LINUX
 #include "../utils/V4L2DeviceScanner.h"
@@ -124,11 +125,17 @@ bool UIManager::init(void *window)
     ImGui_ImplOpenGL3_Init(glslVersion.c_str());
 #endif
 
-    // Scan for shaders (check environment variable for AppImage support)
+    // Scan for shaders. Env override `RETROCAPTURE_SHADER_PATH` ainda é
+    // honrado (AppImage / dev). Caso contrário, usa o assets dir resolvido
+    // (CWD em dev tree, install system-wide ou portable).
     const char *envShaderPath = std::getenv("RETROCAPTURE_SHADER_PATH");
     if (envShaderPath && fs::exists(envShaderPath))
     {
         m_shaderBasePath = envShaderPath;
+    }
+    else
+    {
+        m_shaderBasePath = (fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl").string();
     }
     scanShaders(m_shaderBasePath);
 
@@ -453,7 +460,7 @@ void UIManager::renderShaderPanel()
                 if (m_onSavePreset && strlen(m_savePresetPath) > 0)
                 {
                     // Construir caminho completo
-                    fs::path basePath("shaders/shaders_glsl");
+                    fs::path basePath = fs::path(Paths::getReadOnlyAssetsDir()) / "shaders" / "shaders_glsl";
                     fs::path newPath = basePath / m_savePresetPath;
                     if (newPath.extension() != ".glslp")
                     {
@@ -2090,38 +2097,12 @@ void UIManager::scanShaders(const std::string &basePath)
 
 std::string UIManager::getConfigPath() const
 {
-#ifdef _WIN32
-    // Windows: usar APPDATA (ou LOCALAPPDATA como fallback)
-    const char *appDataDir = std::getenv("APPDATA");
-    if (!appDataDir)
+    std::string dir = Paths::getUserConfigDir();
+    if (!dir.empty())
     {
-        appDataDir = std::getenv("LOCALAPPDATA");
+        return (fs::path(dir) / "config.json").string();
     }
-    if (appDataDir)
-    {
-        fs::path configDir = fs::path(appDataDir) / "RetroCapture";
-        // Criar diretório se não existir
-        if (!fs::exists(configDir))
-        {
-            fs::create_directories(configDir);
-        }
-        return (configDir / "config.json").string();
-    }
-#else
-    // Linux/Unix: usar diretório home do usuário
-    const char *homeDir = std::getenv("HOME");
-    if (homeDir)
-    {
-        fs::path configDir = fs::path(homeDir) / ".config" / "retrocapture";
-        // Criar diretório se não existir
-        if (!fs::exists(configDir))
-        {
-            fs::create_directories(configDir);
-        }
-        return (configDir / "config.json").string();
-    }
-#endif
-    // Fallback: salvar no diretório atual
+    // Fallback: cwd. Não esperado em uso real (sem $HOME / sem %APPDATA%).
     return "retrocapture_config.json";
 }
 

--- a/src/utils/FilesystemCompat.h
+++ b/src/utils/FilesystemCompat.h
@@ -556,6 +556,16 @@ namespace fs_helper
         return iter.path();
     }
 
+    inline bool is_regular_file(const fs::directory_iterator& iter)
+    {
+        return iter.is_regular_file();
+    }
+
+    inline fs::path get_path(const fs::directory_iterator& iter)
+    {
+        return iter.path();
+    }
+
     inline std::string get_extension_string(const fs::path& p)
     {
         return p.extension(); // Custom implementation retorna string diretamente
@@ -579,6 +589,16 @@ namespace fs_helper
     }
 
     inline fs::path get_path(const fs::recursive_directory_iterator& iter)
+    {
+        return iter->path();
+    }
+
+    inline bool is_regular_file(const fs::directory_iterator& iter)
+    {
+        return iter->is_regular_file();
+    }
+
+    inline fs::path get_path(const fs::directory_iterator& iter)
     {
         return iter->path();
     }
@@ -610,6 +630,16 @@ namespace fs_helper
         return iter->path();
     }
 
+    inline bool is_regular_file(const fs::directory_iterator& iter)
+    {
+        return iter->is_regular_file();
+    }
+
+    inline fs::path get_path(const fs::directory_iterator& iter)
+    {
+        return iter->path();
+    }
+
     inline std::string get_extension_string(const fs::path& p)
     {
         return p.extension().string(); // std::filesystem retorna path, precisa .string()
@@ -637,6 +667,16 @@ namespace fs_helper
         return iter->path();
     }
 
+    inline bool is_regular_file(const fs::directory_iterator& iter)
+    {
+        return iter->is_regular_file();
+    }
+
+    inline fs::path get_path(const fs::directory_iterator& iter)
+    {
+        return iter->path();
+    }
+
     inline std::string get_extension_string(const fs::path& p)
     {
         return p.extension().string(); // std::filesystem retorna path, precisa .string()
@@ -660,6 +700,16 @@ namespace fs_helper
     }
 
     inline fs::path get_path(const fs::recursive_directory_iterator& iter)
+    {
+        return iter->path();
+    }
+
+    inline bool is_regular_file(const fs::directory_iterator& iter)
+    {
+        return iter->is_regular_file();
+    }
+
+    inline fs::path get_path(const fs::directory_iterator& iter)
     {
         return iter->path();
     }

--- a/src/utils/Paths.cpp
+++ b/src/utils/Paths.cpp
@@ -1,0 +1,402 @@
+#include "Paths.h"
+#include "Logger.h"
+#include "FilesystemCompat.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    #include <shlobj.h>      // SHGetFolderPathW, CSIDL_*
+    // shell32 já vinculado pelo CMakeLists do build Windows.
+#else
+    #include <unistd.h>      // readlink
+    #include <sys/types.h>
+    #include <pwd.h>         // getpwuid as last-resort HOME fallback
+    #include <fstream>
+    #include <sstream>
+#endif
+
+namespace {
+
+// Tenta env var; se vazia ou não-set, retorna fallback. Strip trailing
+// separator pra normalizar.
+std::string envOr(const char *name, const std::string &fallback)
+{
+    const char *v = std::getenv(name);
+    if (v && *v)
+    {
+        std::string s(v);
+        while (!s.empty() && (s.back() == '/' || s.back() == '\\'))
+        {
+            s.pop_back();
+        }
+        return s;
+    }
+    return fallback;
+}
+
+#ifdef _WIN32
+
+// Converte UTF-16 (Windows) pra UTF-8. `&out[0]` em vez de `out.data()` pra
+// não retornar `const char*` no MinGW antigo (libstdc++ < 7) que esperava
+// LPSTR (`char*`) no WideCharToMultiByte.
+std::string wideToUtf8(const wchar_t *w)
+{
+    if (!w) return {};
+    int needed = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0, nullptr, nullptr);
+    if (needed <= 0) return {};
+    std::string out(static_cast<size_t>(needed - 1), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, w, -1, &out[0], needed, nullptr, nullptr);
+    return out;
+}
+
+// Wrapper pra SHGetFolderPathW (XP+). Devolve "" se falhar. Usa CSIDLs
+// porque SHGetKnownFolderPath/FOLDERID_* não estão expostos pelos headers
+// do MXE MinGW que usamos no cross-compile.
+std::string getShellFolder(int csidl)
+{
+    wchar_t pathW[MAX_PATH] = {0};
+    HRESULT hr = SHGetFolderPathW(nullptr, csidl, nullptr, 0 /* SHGFP_TYPE_CURRENT */, pathW);
+    if (FAILED(hr))
+    {
+        return {};
+    }
+    return wideToUtf8(pathW);
+}
+
+#else
+
+// $HOME com last-resort fallback pra getpwuid (containers / cron).
+std::string getHomeDir()
+{
+    const char *h = std::getenv("HOME");
+    if (h && *h) return h;
+    struct passwd *pw = getpwuid(geteuid());
+    if (pw && pw->pw_dir) return pw->pw_dir;
+    return {};
+}
+
+// Lê $XDG_VIDEOS_DIR de ~/.config/user-dirs.dirs (formato shell:
+//   XDG_VIDEOS_DIR="$HOME/Videos"
+// ). Retorna "" se não definido.
+std::string readXdgVideosDir(const std::string &home)
+{
+    fs::path userDirs = fs::path(home) / ".config" / "user-dirs.dirs";
+    if (!fs::exists(userDirs)) return {};
+
+    std::ifstream in(userDirs);
+    if (!in.is_open()) return {};
+
+    std::string line;
+    while (std::getline(in, line))
+    {
+        const std::string key = "XDG_VIDEOS_DIR=";
+        auto pos = line.find(key);
+        if (pos == std::string::npos) continue;
+        std::string value = line.substr(pos + key.size());
+        // Strip aspas, expand $HOME.
+        if (!value.empty() && value.front() == '"') value.erase(0, 1);
+        if (!value.empty() && value.back() == '"') value.pop_back();
+        const std::string token = "$HOME";
+        size_t p = value.find(token);
+        if (p != std::string::npos)
+        {
+            value.replace(p, token.size(), home);
+        }
+        return value;
+    }
+    return {};
+}
+
+#endif
+
+void ensureDir(const std::string &dir)
+{
+    if (dir.empty()) return;
+    // FilesystemCompat (MinGW antigo) não expõe a sobrecarga com std::error_code,
+    // então usamos try/catch — funciona igual nos dois lados.
+    try
+    {
+        fs::create_directories(fs::path(dir));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_WARN("Paths: failed to create directory " + dir + " (" + e.what() + ")");
+    }
+}
+
+} // namespace
+
+std::string Paths::getExecutableDir()
+{
+#ifdef _WIN32
+    wchar_t buf[MAX_PATH];
+    DWORD len = GetModuleFileNameW(nullptr, buf, MAX_PATH);
+    if (len == 0 || len == MAX_PATH) return {};
+    fs::path p = fs::path(wideToUtf8(buf));
+    return p.parent_path().string();
+#else
+    char buf[4096];
+    ssize_t len = ::readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (len <= 0) return {};
+    buf[len] = '\0';
+    return fs::path(buf).parent_path().string();
+#endif
+}
+
+std::string Paths::getReadOnlyAssetsDir()
+{
+    {
+        std::string over = envOr("RETROCAPTURE_ASSETS_DIR", "");
+        if (!over.empty() && fs::exists(over))
+        {
+            return over;
+        }
+    }
+
+    // Dev tree / portable run a partir da raiz do projeto: `shaders/`,
+    // `web/`, `ssl/` ficam direto em CWD. Probamos pelo subdir
+    // `shaders/shaders_glsl`, que só existe no nosso layout de assets.
+    {
+        fs::path cwd = fs::current_path();
+        if (fs::exists(cwd / "shaders" / "shaders_glsl"))
+        {
+            return cwd.string();
+        }
+    }
+
+#ifdef _WIN32
+    // Windows: assets ao lado do executável (instalação portátil ou
+    // Program Files). Se não tiver, fallback no Program Files genérico.
+    fs::path exeDir(getExecutableDir());
+    if (fs::exists(exeDir / "assets")) return (exeDir / "assets").string();
+
+    {
+        std::string pf = getShellFolder(CSIDL_PROGRAM_FILES);
+        if (!pf.empty())
+        {
+            fs::path candidate = fs::path(pf) / "RetroCapture" / "assets";
+            if (fs::exists(candidate)) return candidate.string();
+        }
+    }
+
+    return (exeDir / "assets").string(); // último recurso, mesmo que não exista
+#else
+    // Linux: $XDG_DATA_DIRS é uma lista separada por ':'. Procura por
+    // retrocapture/ em cada uma. Fallback /usr/local/share, /usr/share,
+    // <exe>/../share/retrocapture, <exe>/assets.
+    std::string xdgDirs = envOr("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
+    std::stringstream ss(xdgDirs);
+    std::string entry;
+    while (std::getline(ss, entry, ':'))
+    {
+        if (entry.empty()) continue;
+        fs::path candidate = fs::path(entry) / "retrocapture";
+        if (fs::exists(candidate)) return candidate.string();
+    }
+
+    fs::path exeDir(getExecutableDir());
+    fs::path siblingShare = exeDir.parent_path() / "share" / "retrocapture";
+    if (fs::exists(siblingShare)) return siblingShare.string();
+
+    fs::path portable = exeDir / "assets";
+    if (fs::exists(portable)) return portable.string();
+
+    return portable.string(); // último recurso
+#endif
+}
+
+std::string Paths::getUserConfigDir()
+{
+    {
+        std::string over = envOr("RETROCAPTURE_CONFIG_DIR", "");
+        if (!over.empty())
+        {
+            ensureDir(over);
+            return over;
+        }
+    }
+
+#ifdef _WIN32
+    auto roaming = getShellFolder(CSIDL_APPDATA);
+    if (roaming.empty())
+    {
+        roaming = envOr("APPDATA", "");
+    }
+    if (roaming.empty()) return {};
+    fs::path dir = fs::path(roaming) / "RetroCapture";
+    ensureDir(dir.string());
+    return dir.string();
+#else
+    std::string home = getHomeDir();
+    std::string base = envOr("XDG_CONFIG_HOME", home.empty() ? "" : home + "/.config");
+    if (base.empty()) return {};
+    fs::path dir = fs::path(base) / "retrocapture";
+    ensureDir(dir.string());
+    return dir.string();
+#endif
+}
+
+std::string Paths::getUserDataDir()
+{
+    {
+        std::string over = envOr("RETROCAPTURE_DATA_DIR", "");
+        if (!over.empty())
+        {
+            ensureDir(over);
+            return over;
+        }
+    }
+
+#ifdef _WIN32
+    auto roaming = getShellFolder(CSIDL_APPDATA);
+    if (roaming.empty())
+    {
+        roaming = envOr("APPDATA", "");
+    }
+    if (roaming.empty()) return {};
+    fs::path dir = fs::path(roaming) / "RetroCapture" / "data";
+    ensureDir(dir.string());
+    return dir.string();
+#else
+    std::string home = getHomeDir();
+    std::string base = envOr("XDG_DATA_HOME", home.empty() ? "" : home + "/.local/share");
+    if (base.empty()) return {};
+    fs::path dir = fs::path(base) / "retrocapture";
+    ensureDir(dir.string());
+    return dir.string();
+#endif
+}
+
+std::string Paths::getCacheDir()
+{
+    {
+        std::string over = envOr("RETROCAPTURE_CACHE_DIR", "");
+        if (!over.empty())
+        {
+            ensureDir(over);
+            return over;
+        }
+    }
+
+#ifdef _WIN32
+    auto local = getShellFolder(CSIDL_LOCAL_APPDATA);
+    if (local.empty())
+    {
+        local = envOr("LOCALAPPDATA", "");
+    }
+    if (local.empty()) return {};
+    fs::path dir = fs::path(local) / "RetroCapture" / "Cache";
+    ensureDir(dir.string());
+    return dir.string();
+#else
+    std::string home = getHomeDir();
+    std::string base = envOr("XDG_CACHE_HOME", home.empty() ? "" : home + "/.cache");
+    if (base.empty()) return {};
+    fs::path dir = fs::path(base) / "retrocapture";
+    ensureDir(dir.string());
+    return dir.string();
+#endif
+}
+
+bool Paths::migrateLegacyDataIfNeeded()
+{
+    // Idempotente: se MIGRATED.txt já existe no destino, não toca.
+    std::string dataDir = getUserDataDir();
+    if (dataDir.empty()) return false;
+
+    fs::path marker = fs::path(dataDir) / "MIGRATED.txt";
+    if (fs::exists(marker))
+    {
+        return false;
+    }
+
+    // Local legacy: a antiga `assets/` aninhada dentro do config dir.
+    // Linux: ~/.config/retrocapture/assets. Windows: %APPDATA%\RetroCapture\assets.
+    // (`getUserConfigDir()` retorna a raiz, então legacy vive em raiz/assets.)
+    std::string configDir = getUserConfigDir();
+    if (configDir.empty()) return false;
+
+    fs::path legacyAssets = fs::path(configDir) / "assets";
+    fs::path legacySSL = fs::path(configDir) / "ssl";
+
+    bool movedAnything = false;
+
+    auto moveTree = [&](const fs::path &from, const fs::path &to)
+    {
+        if (!fs::exists(from) || !fs::is_directory(from)) return;
+        try
+        {
+            fs::create_directories(to);
+            // FilesystemCompat (MinGW antigo) não permite range-for em
+            // directory_iterator — usamos iterador explícito + helpers.
+            fs::directory_iterator it(from);
+            fs::directory_iterator end;
+            for (; it != end; ++it)
+            {
+                fs::path src = fs_helper::get_path(it);
+                fs::path dst = to / src.filename();
+                if (fs::exists(dst))
+                {
+                    LOG_WARN("Paths migration: skipping " + src.string() +
+                             " — destination " + dst.string() + " already exists");
+                    continue;
+                }
+                fs::rename(src, dst);
+                LOG_INFO("Paths migration: moved " + src.string() + " -> " + dst.string());
+                movedAnything = true;
+            }
+        }
+        catch (const std::exception &e)
+        {
+            LOG_WARN(std::string("Paths migration: ") + e.what());
+        }
+    };
+
+    // Conteúdo do antigo `assets/` (presets, thumbnails) é a raiz da nova
+    // user-data dir. Mantemos os subdirs (presets/, thumbnails/) como estão.
+    moveTree(legacyAssets, fs::path(dataDir));
+    // SSL legacy era irmão de assets — vai pra user-data/ssl.
+    moveTree(legacySSL, fs::path(dataDir) / "ssl");
+
+    // Marca como migrado mesmo se nada foi movido (próxima execução pula).
+    try
+    {
+        std::ofstream(marker.string()) << "Migration completed.\n"
+                                       << "Moved legacy content from " << configDir << "/assets and /ssl\n"
+                                       << "to " << dataDir << ".\n";
+    }
+    catch (...)
+    {
+        // sem marker, vamos retentar na próxima execução — não é crítico.
+    }
+
+    return movedAnything;
+}
+
+std::string Paths::getDefaultRecordingsDir()
+{
+#ifdef _WIN32
+    auto videos = getShellFolder(CSIDL_MYVIDEO);
+    if (videos.empty())
+    {
+        auto profile = envOr("USERPROFILE", "");
+        if (!profile.empty()) videos = (fs::path(profile) / "Videos").string();
+    }
+    if (videos.empty()) return {};
+    fs::path dir = fs::path(videos) / "RetroCapture";
+    ensureDir(dir.string());
+    return dir.string();
+#else
+    std::string home = getHomeDir();
+    if (home.empty()) return {};
+    std::string videos = readXdgVideosDir(home);
+    if (videos.empty()) videos = home + "/Videos";
+    fs::path dir = fs::path(videos) / "RetroCapture";
+    ensureDir(dir.string());
+    return dir.string();
+#endif
+}

--- a/src/utils/Paths.h
+++ b/src/utils/Paths.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+
+/**
+ * Resolução centralizada dos diretórios usados pela aplicação.
+ *
+ * Linux segue XDG Base Directory; Windows segue Known Folders
+ * (`SHGetKnownFolderPath`). Cada getter:
+ *   1. Honra um env var de override específico (`RETROCAPTURE_*_DIR`)
+ *      pra AppImage / CI / packagers / dev.
+ *   2. Aplica a regra padrão do OS.
+ *   3. Para diretórios graváveis, cria `directories` se não existir
+ *      (lazy, na primeira chamada que precisa escrever).
+ *
+ * Strings retornadas são UTF-8, sem trailing separator. Vazias só em
+ * caso de erro grave (sem `$HOME`, sem `%APPDATA%` — não esperado).
+ */
+class Paths {
+public:
+    // Read-only: shaders bundlados, templates do web portal, presets seed,
+    // SSL bundle. Procura no install system-wide e cai pra `<exe>/assets/`
+    // pra builds portáveis / dev tree.
+    static std::string getReadOnlyAssetsDir();
+
+    // User config: settings tipo resolução, FPS, overscan, device, audio,
+    // streaming. Linux: $XDG_CONFIG_HOME/retrocapture (~/.config/retrocapture).
+    // Windows: %APPDATA%\RetroCapture (FOLDERID_RoamingAppData).
+    static std::string getUserConfigDir();
+
+    // User data: presets salvos pelo usuário, thumbnails, SSL certs do user.
+    // Linux: $XDG_DATA_HOME/retrocapture (~/.local/share/retrocapture).
+    // Windows: %APPDATA%\RetroCapture\data (mesma raiz que config pra moves
+    // atômicos).
+    static std::string getUserDataDir();
+
+    // Cache: estado regenerável (futura compile cache de shaders, miniaturas
+    // remotas, etc.). Linux: $XDG_CACHE_HOME/retrocapture (~/.cache/...).
+    // Windows: %LOCALAPPDATA%\RetroCapture\Cache (FOLDERID_LocalAppData,
+    // não-roamed).
+    static std::string getCacheDir();
+
+    // Default para gravações. Pode ser sobrescrito pelo user em settings.
+    // Linux: $XDG_VIDEOS_DIR/RetroCapture (xdg-user-dirs) com fallback
+    // ~/Videos/RetroCapture. Windows: <Videos>\RetroCapture
+    // (FOLDERID_Videos).
+    static std::string getDefaultRecordingsDir();
+
+    // Diretório do executável atual. Útil pra fallback portátil
+    // (read-only assets ao lado do binário).
+    static std::string getExecutableDir();
+
+    // Migra dados legacy de instalações anteriores pra os diretórios novos.
+    // One-shot e idempotente — vê marcador `MIGRATED.txt` no destino.
+    // Move (não copia) presets, thumbnails e SSL do antigo
+    // `~/.config/retrocapture/assets/` (Linux) ou `%APPDATA%\RetroCapture\assets\`
+    // (Windows) pra `getUserDataDir()`. Retorna true se algo foi movido.
+    static bool migrateLegacyDataIfNeeded();
+
+private:
+    Paths() = delete;
+};

--- a/src/utils/PresetManager.cpp
+++ b/src/utils/PresetManager.cpp
@@ -1,5 +1,6 @@
 #include "PresetManager.h"
 #include "../utils/Logger.h"
+#include "../utils/Paths.h"
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -7,12 +8,6 @@
 #include <iomanip>
 #include <cctype>
 #include <chrono>
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <unistd.h>
-#include <limits.h>
-#endif
 
 // Include JSON library (nlohmann/json)
 #include <nlohmann/json.hpp>
@@ -58,116 +53,33 @@ void PresetManager::ensureDirectoriesExist()
 
 std::string PresetManager::getAssetsDirectory() const
 {
-    // Try multiple locations (similar to WebPortal::findAssetFile)
-    
-    // 1. Environment variable (for AppImage)
-    const char* assetsEnvPath = std::getenv("RETROCAPTURE_ASSETS_PATH");
-    if (assetsEnvPath)
-    {
-        fs::path envAssetsDir(assetsEnvPath);
-        if (fs::exists(envAssetsDir) && fs::is_directory(envAssetsDir))
-        {
-            return fs::absolute(envAssetsDir).string();
-        }
-    }
-
-    // 2. User config directory (~/.config/retrocapture/assets/)
-    #ifdef _WIN32
-    const char* appDataDir = std::getenv("APPDATA");
-    if (!appDataDir)
-    {
-        appDataDir = std::getenv("LOCALAPPDATA");
-    }
-    if (appDataDir)
-    {
-        fs::path configDir = fs::path(appDataDir) / "RetroCapture" / "assets";
-        if (fs::exists(configDir) && fs::is_directory(configDir))
-        {
-            return fs::absolute(configDir).string();
-        }
-    }
-    #else
-    const char* homeDir = std::getenv("HOME");
-    if (homeDir)
-    {
-        fs::path configDir = fs::path(homeDir) / ".config" / "retrocapture" / "assets";
-        if (fs::exists(configDir) && fs::is_directory(configDir))
-        {
-            return fs::absolute(configDir).string();
-        }
-    }
-    #endif
-
-    // 3. Executable directory/assets/
-    char exePath[1024];
-    #ifdef _WIN32
-    DWORD len = GetModuleFileNameA(NULL, exePath, sizeof(exePath) - 1);
-    if (len != 0)
-    {
-        exePath[len] = '\0';
-        fs::path exeDir = fs::path(exePath).parent_path();
-        fs::path assetsDir = exeDir / "assets";
-        if (fs::exists(assetsDir) && fs::is_directory(assetsDir))
-        {
-            return fs::absolute(assetsDir).string();
-        }
-    }
-    #else
-    ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
-    if (len != -1)
-    {
-        exePath[len] = '\0';
-        fs::path exeDir = fs::path(exePath).parent_path();
-        fs::path assetsDir = exeDir / "assets";
-        if (fs::exists(assetsDir) && fs::is_directory(assetsDir))
-        {
-            return fs::absolute(assetsDir).string();
-        }
-    }
-    #endif
-
-    // 4. Current directory/assets/
-    fs::path currentAssets = fs::current_path() / "assets";
-    if (fs::exists(currentAssets) && fs::is_directory(currentAssets))
-    {
-        return fs::absolute(currentAssets).string();
-    }
-
-    // 5. Fallback: create in user config directory
-    #ifdef _WIN32
-    const char* fallbackDir = std::getenv("APPDATA");
-    if (!fallbackDir)
-    {
-        fallbackDir = std::getenv("LOCALAPPDATA");
-    }
-    if (fallbackDir)
-    {
-        fs::path fallbackPath = fs::path(fallbackDir) / "RetroCapture" / "assets";
-        return fs::absolute(fallbackPath).string();
-    }
-    #else
-    const char* fallbackDir = std::getenv("HOME");
-    if (fallbackDir)
-    {
-        fs::path fallbackPath = fs::path(fallbackDir) / ".config" / "retrocapture" / "assets";
-        return fs::absolute(fallbackPath).string();
-    }
-    #endif
-
-    // Last resort: current directory
-    return (fs::current_path() / "assets").string();
+    // Mantida apenas como descoberta de assets read-only (defaults seed).
+    // Presets/thumbnails do usuário NÃO vivem mais aqui — vide
+    // getPresetsDirectory / getThumbnailsDirectory abaixo.
+    return Paths::getReadOnlyAssetsDir();
 }
 
 std::string PresetManager::getPresetsDirectory() const
 {
-    fs::path assetsDir = getAssetsDirectory();
-    return (assetsDir / "presets").string();
+    // Presets do usuário em $XDG_DATA_HOME/retrocapture/presets (Linux)
+    // ou %APPDATA%\RetroCapture\data\presets (Windows). Override:
+    // RETROCAPTURE_DATA_DIR ou RETROCAPTURE_PRESETS_DIR.
+    const char *over = std::getenv("RETROCAPTURE_PRESETS_DIR");
+    if (over && *over)
+    {
+        return over;
+    }
+    return (fs::path(Paths::getUserDataDir()) / "presets").string();
 }
 
 std::string PresetManager::getThumbnailsDirectory() const
 {
-    fs::path assetsDir = getAssetsDirectory();
-    return (assetsDir / "thumbnails").string();
+    const char *over = std::getenv("RETROCAPTURE_THUMBNAILS_DIR");
+    if (over && *over)
+    {
+        return over;
+    }
+    return (fs::path(Paths::getUserDataDir()) / "thumbnails").string();
 }
 
 std::string PresetManager::sanitizeName(const std::string& name)


### PR DESCRIPTION
…lders)

Centraliza resolução de diretórios em `Paths::*` (XDG Base Directory no Linux, SHGetFolderPath/CSIDL no Windows). Cada role — read-only assets, config, data, cache, recordings — tem seu getter com env override (`RETROCAPTURE_*_DIR`), regra do OS e mkdir lazy nas escritas.

`Paths::getReadOnlyAssetsDir()` testa CWD primeiro (probe por `shaders/shaders_glsl`) pra dev tree / portable run, depois exe-relative, XDG_DATA_DIRS, Program Files. Os 6 callsites de shader hardcoded foram migrados pra essa raiz; env `RETROCAPTURE_SHADER_PATH` mantido onde já existia.

UIManager, PresetManager, HTTPTSStreamer, WebPortal e RecordingManager deixaram de usar `~/.config/...` ad-hoc — tudo passa por `Paths::*`. Migração one-shot via `MIGRATED.txt` move conteúdo legacy de `~/.config/retrocapture/assets/` (Linux) ou `%APPDATA%\RetroCapture\assets\` (Windows) pra user-data dir nova.

CMakeLists ganha install rules pra Linux: binary em `bin/`, shaders/web/ ssl em `share/retrocapture/`. FilesystemCompat ganha overloads de `fs_helper` pra `directory_iterator`.

Bonus: ShaderPreprocessor não usa mais `std::regex_constants::multiline` (C++17, ausente no MinGW antigo) — scan manual linha-a-linha.