### PR TITLE
fix: recording desync at higher quality presets

### DIFF
--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -129,7 +129,13 @@ bool MediaEncoder::initializeVideoCodec()
     codecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
     codecCtx->width = m_videoConfig.width;
     codecCtx->height = m_videoConfig.height;
-    codecCtx->time_base = {1, static_cast<int>(m_videoConfig.fps)};
+    // time_base granular (1/90000 — padrão MPEG) em vez de {1, fps}.
+    // Com {1, 60}, frames a 16.667ms davam PTS 0.99998→0 e 1.99998→1
+    // (truncamento), gerando frames com PTS duplicado, warnings de
+    // non-strictly-monotonic-PTS, e quando frames dropam o gap fica
+    // grosseiro o suficiente pra arquivo declarar fps menor que o
+    // capturado → vídeo toca em câmera lenta. 90000 dá precisão de ~11µs.
+    codecCtx->time_base = {1, 90000};
     codecCtx->framerate = {static_cast<int>(m_videoConfig.fps), 1};
     codecCtx->gop_size = static_cast<int>(m_videoConfig.fps * 2);
     codecCtx->max_b_frames = 0;
@@ -157,18 +163,29 @@ bool MediaEncoder::initializeVideoCodec()
     if (codec->id == AV_CODEC_ID_H264)
     {
         av_dict_set(&opts, "preset", m_videoConfig.preset.c_str(), 0);
+        // tune=zerolatency mantido em ambos os modos: ele desliga
+        // lookahead/B-frames internos do x264. Em arquivo o lookahead
+        // só cobraria CPU/frame extra (lookahead default 40 frames =
+        // ~10% mais work), o que derruba encoders abaixo de realtime
+        // em presets >= fast. zerolatency mantém custo previsível.
         av_dict_set(&opts, "tune", "zerolatency", 0);
         av_dict_set(&opts, "profile", m_videoConfig.profile.c_str(), 0);
         int keyint = static_cast<int>(m_videoConfig.fps * 2);
         av_dict_set_int(&opts, "keyint_min", keyint, 0);
         av_dict_set_int(&opts, "keyint", keyint, 0);
         av_dict_set_int(&opts, "rc-lookahead", 0, 0);
-        av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
         av_dict_set_int(&opts, "scenecut", 0, 0);
-        // repeat-headers apenas para streaming (necessário para streaming, mas não para arquivos)
+
         if (m_forStreaming)
         {
+            // Streaming HTTP-TS: vbv apertado limita variação de bitrate.
+            av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
             av_dict_set_int(&opts, "repeat-headers", 1, 0);
+        }
+        else
+        {
+            // Gravação em arquivo: vbv largo pra rate-control flexível.
+            av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate * 2, 0);
         }
     }
     else if (codec->id == AV_CODEC_ID_HEVC)
@@ -184,8 +201,16 @@ bool MediaEncoder::initializeVideoCodec()
         av_dict_set_int(&opts, "keyint_min", keyint, 0);
         av_dict_set_int(&opts, "keyint", keyint, 0);
         av_dict_set_int(&opts, "rc-lookahead", 0, 0);
-        av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
         av_dict_set_int(&opts, "scenecut", 0, 0);
+
+        if (m_forStreaming)
+        {
+            av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
+        }
+        else
+        {
+            av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate * 2, 0);
+        }
     }
     else if (codec->id == AV_CODEC_ID_VP8)
     {
@@ -652,9 +677,16 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
         return false;
     }
 
-    // Acumular samples
+    // Acumular samples — sem reset/gap detection. PTS é sample-count
+    // based; contar tudo que entra mantém audio smooth e o drain no
+    // RecordingManager garante que nada drope antes de chegar aqui.
     {
         std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
+        if (m_audioAccumulator.empty())
+        {
+            m_audioAccumulatorStartCaptureTsUs = captureTimestampUs;
+            m_audioAccumulatorTsValid = true;
+        }
         m_audioAccumulator.insert(m_audioAccumulator.end(), samples, samples + sampleCount);
     }
 
@@ -728,39 +760,40 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
                      ", input consumed: " + std::to_string(totalSamplesNeeded));
         }
 
+        // Frame timestamp = capture ts do primeiro sample que está saindo
+        // agora. Igual o vídeo, anda no wall clock real. Pegar antes de
+        // consumir os samples do accumulator.
+        int64_t frameTimestampUs = m_audioAccumulatorStartCaptureTsUs;
+
         // Conversion successful - now we can remove the samples from accumulator
         {
             std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
-            // Remove samples that were sent to the resampler (totalSamplesNeeded)
-            // The resampler may buffer some internally, but we've consumed them from input
             size_t sizeBefore = m_audioAccumulator.size();
             m_audioAccumulator.erase(m_audioAccumulator.begin(), m_audioAccumulator.begin() + totalSamplesNeeded);
             size_t sizeAfter = m_audioAccumulator.size();
-            
-            // Log accumulator status after processing
+
+            // Avança o capture ts do accumulator pra refletir o que sobrou.
+            if (m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
+            {
+                int64_t consumedSamplesPerCh = static_cast<int64_t>(totalSamplesNeeded) /
+                                               static_cast<int64_t>(m_audioConfig.channels);
+                m_audioAccumulatorStartCaptureTsUs += (consumedSamplesPerCh * 1000000LL) /
+                                                       static_cast<int64_t>(m_audioConfig.sampleRate);
+            }
+            if (m_audioAccumulator.empty())
+            {
+                m_audioAccumulatorTsValid = false;
+            }
+
             if (frameLogCounter == 1 || frameLogCounter % 50 == 0)
             {
-                LOG_INFO("MediaEncoder: After processing - accumulator: " + std::to_string(sizeBefore) + 
-                         " -> " + std::to_string(sizeAfter) + 
+                LOG_INFO("MediaEncoder: After processing - accumulator: " + std::to_string(sizeBefore) +
+                         " -> " + std::to_string(sizeAfter) +
                          " (removed " + std::to_string(totalSamplesNeeded) + ")");
             }
         }
 
-        // Calcular timestamp real deste frame baseado em samples processados
-        // Cada frame de áudio deve ter timestamp progressivo baseado em samples processados
-        // timestamp = first_timestamp + (samples_processed_per_channel / sample_rate)
-        int64_t frameTimestampUs = captureTimestampUs; // Fallback to chunk timestamp
-        if (m_firstAudioTimestampSet && m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
-        {
-            // Calculate real timestamp: first_timestamp + (samples_processed_per_channel / sample_rate)
-            int64_t samplesPerChannel = m_totalAudioSamplesProcessed / m_audioConfig.channels;
-            int64_t durationUs = (samplesPerChannel * 1000000LL) / m_audioConfig.sampleRate;
-            frameTimestampUs = m_firstAudioTimestampUs + durationUs;
-        }
-        
-        // Calcular PTS baseado em samples processados (precise, no jitter)
-        // Use actual samples in frame (nb_samples), not totalSamplesNeeded
-        // This ensures PTS matches the actual audio data in the frame
+        // PTS agora é wall-clock-relative (igual vídeo).
         int64_t calculatedPTS = calculateAudioPTS(frameTimestampUs, actualFrameSamples * m_audioConfig.channels);
         audioFrame->pts = calculatedPTS;
         
@@ -800,7 +833,13 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
 
 int64_t MediaEncoder::calculateAudioPTS(int64_t captureTimestampUs, size_t /* sampleCount */)
 {
-    // Store first timestamp for reference, but calculate PTS based on samples processed
+    // Sample-count-based PTS: cada output frame avança PTS por
+    // exatamente samples_processados/sample_rate. Smooth, monotônico,
+    // sem jitter de capture timestamp (pulseaudio entrega chunks com
+    // variabilidade de chegada que não reflete tempo real de captura).
+    // O alinhamento com wall clock é garantido pelo drain de áudio no
+    // RecordingManager — chunks não dropam mais no synchronizer, então
+    // a contagem de samples casa com a duração real da gravação.
     if (!m_firstAudioTimestampSet)
     {
         m_firstAudioTimestampUs = captureTimestampUs;
@@ -815,29 +854,18 @@ int64_t MediaEncoder::calculateAudioPTS(int64_t captureTimestampUs, size_t /* sa
         return 0;
     }
 
-    // Calculate PTS based on samples processed and sample rate (precise, no jitter)
-    // PTS = (samples_processed_per_channel / sample_rate) in time_base units
-    // For time_base = {1, sampleRate}, PTS = samples_per_channel
     AVRational timeBase = codecCtx->time_base;
     int64_t calculatedPTS = 0;
-    
     if (m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
     {
-        // Calculate: (samples_processed / channels) * time_base.den / (sample_rate * time_base.num)
-        // samples_processed is total samples (all channels) processed so far (BEFORE this frame)
-        // This ensures each frame has a progressively increasing PTS
         int64_t samplesPerChannel = m_totalAudioSamplesProcessed / m_audioConfig.channels;
-        // PTS = samples_per_channel / sample_rate in time_base units
-        // Since time_base = {1, sampleRate}, this simplifies to: samples_per_channel
-        // But we calculate it properly to handle any time_base
         calculatedPTS = (samplesPerChannel * timeBase.den) / (m_audioConfig.sampleRate * timeBase.num);
     }
     else
     {
-        // Fallback: use timestamp-based calculation if sample rate unknown
         int64_t relativeTimeUs = captureTimestampUs - m_firstAudioTimestampUs;
-        double relativeTimeSeconds = static_cast<double>(relativeTimeUs) / 1000000.0;
-        calculatedPTS = static_cast<int64_t>(relativeTimeSeconds * timeBase.den / timeBase.num);
+        if (relativeTimeUs < 0) relativeTimeUs = 0;
+        calculatedPTS = (relativeTimeUs * timeBase.den) / (timeBase.num * 1000000LL);
     }
 
     {
@@ -1161,92 +1189,95 @@ void MediaEncoder::flush(std::vector<EncodedPacket> &packets)
             while (true)
             {
                 std::vector<int16_t> samplesToProcess;
+                int64_t frameTsUs = 0;
                 {
                     std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
                     if (static_cast<int>(m_audioAccumulator.size()) < totalSamplesNeeded)
                     {
-                        break; // Not enough samples for a complete frame
+                        break;
                     }
                     samplesToProcess.assign(m_audioAccumulator.begin(), m_audioAccumulator.begin() + totalSamplesNeeded);
+                    frameTsUs = m_audioAccumulatorStartCaptureTsUs;
                 }
-                
-                // Convert and encode remaining samples
+
                 if (convertInt16ToFloatPlanar(samplesToProcess.data(), totalSamplesNeeded, audioFrame, samplesPerFrame))
                 {
                     int actualFrameSamples = static_cast<AVFrame *>(audioFrame)->nb_samples;
-                    
-                    // Calculate PTS for this frame
-                    int64_t calculatedPTS = calculateAudioPTS(0, actualFrameSamples * m_audioConfig.channels);
+
+                    int64_t calculatedPTS = calculateAudioPTS(frameTsUs, actualFrameSamples * m_audioConfig.channels);
                     audioFrame->pts = calculatedPTS;
                     m_totalAudioSamplesProcessed += (actualFrameSamples * m_audioConfig.channels);
-                    
-                    // Send to codec
+
                     int ret = avcodec_send_frame(audioCtx, audioFrame);
                     if (ret < 0 && ret != AVERROR(EAGAIN))
                     {
                         break;
                     }
-                    
-                    // Receive packets
-                    receiveAudioPackets(packets, 0);
-                    
-                    // Remove processed samples
+
+                    receiveAudioPackets(packets, frameTsUs);
+
                     {
                         std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
                         m_audioAccumulator.erase(m_audioAccumulator.begin(), m_audioAccumulator.begin() + totalSamplesNeeded);
+                        if (m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
+                        {
+                            int64_t consumedSamplesPerCh = static_cast<int64_t>(totalSamplesNeeded) /
+                                                           static_cast<int64_t>(m_audioConfig.channels);
+                            m_audioAccumulatorStartCaptureTsUs += (consumedSamplesPerCh * 1000000LL) /
+                                                                   static_cast<int64_t>(m_audioConfig.sampleRate);
+                        }
+                        if (m_audioAccumulator.empty()) m_audioAccumulatorTsValid = false;
                     }
                 }
                 else
                 {
-                    break; // Conversion failed
+                    break;
                 }
             }
-            
+
             // Flush resampler: send null input to get remaining samples from internal buffer
-            // This ensures all audio is processed, not lost
             SwrContext *swrCtx = static_cast<SwrContext *>(m_swrContext);
             if (swrCtx && audioFrame)
             {
-                // Check if resampler has delayed samples
                 int64_t delay = swr_get_delay(swrCtx, m_audioConfig.sampleRate);
                 if (delay > 0)
                 {
-                    // Flush resampler by sending null input
                     const uint8_t *nullInput[1] = {nullptr};
                     int flushedSamples = swr_convert(swrCtx, audioFrame->data, samplesPerFrame,
                                                       nullInput, 0);
-                    
+
                     if (flushedSamples > 0)
                     {
                         audioFrame->nb_samples = flushedSamples;
-                        int64_t calculatedPTS = calculateAudioPTS(0, flushedSamples * m_audioConfig.channels);
+                        int64_t frameTsUs = m_audioAccumulatorStartCaptureTsUs;
+                        int64_t calculatedPTS = calculateAudioPTS(frameTsUs, flushedSamples * m_audioConfig.channels);
                         audioFrame->pts = calculatedPTS;
                         m_totalAudioSamplesProcessed += (flushedSamples * m_audioConfig.channels);
-                        
+
                         avcodec_send_frame(audioCtx, audioFrame);
-                        receiveAudioPackets(packets, 0);
+                        receiveAudioPackets(packets, frameTsUs);
                     }
                 }
             }
-            
-            // Process any remaining samples in accumulator (pad with zeros if needed)
+
+            // Padding final do accumulator com zero pra completar último frame
             {
                 std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
                 if (!m_audioAccumulator.empty() && m_audioAccumulator.size() < static_cast<size_t>(totalSamplesNeeded))
                 {
-                    // Pad with zeros to complete a frame
                     m_audioAccumulator.resize(totalSamplesNeeded, 0);
                     std::vector<int16_t> samplesToProcess = m_audioAccumulator;
-                    
+                    int64_t frameTsUs = m_audioAccumulatorStartCaptureTsUs;
+
                     if (convertInt16ToFloatPlanar(samplesToProcess.data(), totalSamplesNeeded, audioFrame, samplesPerFrame))
                     {
                         int actualFrameSamples = static_cast<AVFrame *>(audioFrame)->nb_samples;
-                        int64_t calculatedPTS = calculateAudioPTS(0, actualFrameSamples * m_audioConfig.channels);
+                        int64_t calculatedPTS = calculateAudioPTS(frameTsUs, actualFrameSamples * m_audioConfig.channels);
                         audioFrame->pts = calculatedPTS;
                         m_totalAudioSamplesProcessed += (actualFrameSamples * m_audioConfig.channels);
-                        
+
                         avcodec_send_frame(audioCtx, audioFrame);
-                        receiveAudioPackets(packets, 0);
+                        receiveAudioPackets(packets, frameTsUs);
                     }
                 }
             }
@@ -1267,6 +1298,8 @@ void MediaEncoder::cleanup()
     {
         std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
         m_audioAccumulator.clear();
+        m_audioAccumulatorStartCaptureTsUs = 0;
+        m_audioAccumulatorTsValid = false;
     }
 
     m_initialized = false;

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -162,9 +162,18 @@ private:
     // Audio accumulator para acumular samples até ter um frame completo
     std::mutex m_audioAccumulatorMutex;
     std::vector<int16_t> m_audioAccumulator;
-    
-    // Track total samples processed for correct PTS calculation when multiple frames are generated
+
+    // Track total samples processed (mantido pra estatísticas/debug; o PTS
+    // agora vem de capture timestamps, não desta contagem).
     int64_t m_totalAudioSamplesProcessed = 0;
+
+    // Capture wall-clock timestamp do *primeiro sample* atualmente no
+    // accumulator. Avança conforme samples são consumidos. Permite que
+    // o PTS do áudio acompanhe o wall clock — se chunks dropam no
+    // synchronizer, a próxima chamada detecta o gap e ressincroniza,
+    // evitando que o áudio termine antes do vídeo (sintoma do desync).
+    int64_t m_audioAccumulatorStartCaptureTsUs = 0;
+    bool m_audioAccumulatorTsValid = false;
 
     // Contador de eventos de retrocesso de PTS: cada incremento é uma vez que
     // o calculatedPTS teria ficado <= ao último PTS já emitido e tivemos que

--- a/src/encoding/MediaSynchronizer.cpp
+++ b/src/encoding/MediaSynchronizer.cpp
@@ -276,6 +276,25 @@ std::vector<MediaSynchronizer::TimestampedAudio> MediaSynchronizer::getAudioChun
     return chunks;
 }
 
+std::vector<MediaSynchronizer::TimestampedAudio> MediaSynchronizer::getAllUnprocessedAudio()
+{
+    std::lock_guard<std::mutex> lock(m_audioBufferMutex);
+    std::vector<TimestampedAudio> chunks;
+    chunks.reserve(m_audioBuffer.size());
+    for (const auto &c : m_audioBuffer)
+    {
+        if (!c.processed)
+        {
+            chunks.push_back(c);
+        }
+    }
+    std::sort(chunks.begin(), chunks.end(),
+              [](const TimestampedAudio &a, const TimestampedAudio &b) {
+                  return a.captureTimestampUs < b.captureTimestampUs;
+              });
+    return chunks;
+}
+
 void MediaSynchronizer::markVideoProcessed(size_t startIdx, size_t endIdx)
 {
     std::lock_guard<std::mutex> lock(m_videoBufferMutex);

--- a/src/encoding/MediaSynchronizer.h
+++ b/src/encoding/MediaSynchronizer.h
@@ -87,6 +87,12 @@ public:
     // Obter chunks de áudio de uma zona de sincronização
     std::vector<TimestampedAudio> getAudioChunks(const SyncZone &zone);
 
+    // Obter todos os chunks de áudio ainda não processados, sem gating
+    // por sync zone. Áudio é barato pra encodar e não precisa esperar o
+    // vídeo — drenar continuamente evita o synchronizer dropar chunks
+    // (que causa o áudio terminar antes do vídeo no arquivo).
+    std::vector<TimestampedAudio> getAllUnprocessedAudio();
+
     // Marcar dados como processados
     void markVideoProcessed(size_t startIdx, size_t endIdx);
     void markAudioProcessed(size_t startIdx, size_t endIdx);

--- a/src/recording/RecordingManager.cpp
+++ b/src/recording/RecordingManager.cpp
@@ -429,6 +429,41 @@ void RecordingManager::encodingThread()
             cleanupCounter = 0;
         }
 
+        // Drain de áudio independente do sync zone. Audio é cheap pra
+        // encodar (AAC ~256 kbps); deixar audio gated pelo sync zone
+        // empilhava chunks no synchronizer enquanto o video estava lento,
+        // que então dropava do front e o áudio terminava antes do vídeo.
+        // Agora processamos áudio sempre que tiver, e o vídeo segue seu
+        // próprio ritmo.
+        if (m_settings.includeAudio && m_audioSampleRate > 0 && m_audioChannels > 0)
+        {
+            auto pendingAudio = m_synchronizer.getAllUnprocessedAudio();
+            for (const auto &chunk : pendingAudio)
+            {
+                if (m_stopRequest) break;
+                if (chunk.processed || !chunk.samples || chunk.sampleCount == 0) continue;
+
+                std::vector<MediaEncoder::EncodedPacket> aPackets;
+                if (m_encoder.encodeAudio(chunk.samples->data(), chunk.sampleCount,
+                                          chunk.captureTimestampUs, aPackets))
+                {
+                    for (const auto &p : aPackets)
+                    {
+                        if (!m_recorder.muxPacket(p))
+                        {
+                            static int audioMuxErrorCount = 0;
+                            if (audioMuxErrorCount++ < 3)
+                            {
+                                LOG_ERROR("RecordingManager: Failed to mux audio packet (drain)");
+                            }
+                        }
+                    }
+                    processedAny = true;
+                }
+                m_synchronizer.markAudioChunkProcessedByTimestamp(chunk.captureTimestampUs);
+            }
+        }
+
         // Check for backlog
         size_t videoBufferSize = m_synchronizer.getVideoBufferSize();
         size_t audioBufferSize = m_synchronizer.getAudioBufferSize();
@@ -469,50 +504,22 @@ void RecordingManager::encodingThread()
             }
         }
 
-        // If no valid sync zone, check if we can process video-only
+        // Sem sync zone válido: processa vídeo sozinho. Áudio já foi
+        // drenado acima, então não precisamos esperar nada por ele.
         if (!syncZone.isValid())
         {
-            // If audio is not included or not available, process video-only
-            if (!m_settings.includeAudio || m_audioSampleRate == 0 || m_audioChannels == 0)
+            if (videoBufferSize > 0)
             {
-                // Process video frames without audio synchronization
-                size_t videoBufferSize = m_synchronizer.getVideoBufferSize();
-                if (videoBufferSize > 0)
-                {
-                    // Create a fake sync zone for video-only processing
-                    // Note: isValid() requires audioEndIdx > audioStartIdx, so we set it to 1
-                    syncZone = MediaSynchronizer::SyncZone();
-                    syncZone.videoStartIdx = 0;
-                    syncZone.videoEndIdx = std::min(videoBufferSize, static_cast<size_t>(2)); // Process up to 2 frames
-                    syncZone.audioStartIdx = 0;
-                    syncZone.audioEndIdx = 1; // Set to 1 to pass isValid() check, but we won't process audio
-                    syncZone.startTimeUs = 0;
-                    syncZone.endTimeUs = 1; // Set to 1 to pass isValid() check (startTimeUs < endTimeUs)
-
-                    static bool firstVideoOnlyLog = false;
-                    if (!firstVideoOnlyLog)
-                    {
-                        LOG_INFO("RecordingManager: Processing video-only (no audio sync required)");
-                        firstVideoOnlyLog = true;
-                    }
-                }
-                else
-                {
-                    // No video frames yet - wait a bit
-                    static int noFramesLogCounter = 0;
-                    noFramesLogCounter++;
-                    if (noFramesLogCounter == 1 || noFramesLogCounter % 100 == 0)
-                    {
-                        LOG_INFO("RecordingManager: Waiting for video frames (buffer empty)");
-                    }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                    continue;
-                }
+                syncZone = MediaSynchronizer::SyncZone();
+                syncZone.videoStartIdx = 0;
+                syncZone.videoEndIdx = std::min(videoBufferSize, static_cast<size_t>(2));
+                syncZone.audioStartIdx = 0;
+                syncZone.audioEndIdx = 1; // satisfaz isValid()
+                syncZone.startTimeUs = 0;
+                syncZone.endTimeUs = 1;
             }
             else
             {
-                // Audio is required but sync zone is invalid - wait for both
-                // Don't process video-only when audio is required to maintain sync
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
                 continue;
             }
@@ -577,95 +584,13 @@ void RecordingManager::encodingThread()
                 }
             }
 
-            // Get synchronized audio chunks (only if audio is included and available)
-            std::vector<MediaSynchronizer::TimestampedAudio> audioChunks;
-            if (m_settings.includeAudio && m_audioSampleRate > 0 && m_audioChannels > 0 && syncZone.audioEndIdx > syncZone.audioStartIdx)
-            {
-                audioChunks = m_synchronizer.getAudioChunks(syncZone);
-            }
+            // Áudio já foi drenado no topo da iteração — aqui só vídeo.
 
-            // Process audio chunks
-            // Use same limits as streaming for consistency
-            size_t chunksProcessed = 0;
-            size_t MAX_CHUNKS_PER_ITERATION = hasBacklog ? 8 : 3; // Same as streaming
-
-            for (const auto &chunk : audioChunks)
-            {
-                if (m_stopRequest)
-                {
-                    break;
-                }
-
-                if (chunksProcessed >= MAX_CHUNKS_PER_ITERATION)
-                {
-                    break;
-                }
-
-                if (!chunk.processed && chunk.samples && chunk.sampleCount > 0)
-                {
-                    // Encode audio
-                    std::vector<MediaEncoder::EncodedPacket> packets;
-                    if (m_encoder.encodeAudio(chunk.samples->data(), chunk.sampleCount,
-                                              chunk.captureTimestampUs, packets))
-                    {
-                        // Mux packets
-                        for (const auto &packet : packets)
-                        {
-                            if (!m_recorder.muxPacket(packet))
-                            {
-                                static int audioMuxErrorCount = 0;
-                                if (audioMuxErrorCount++ < 3)
-                                {
-                                    LOG_ERROR("RecordingManager: Failed to mux audio packet");
-                                }
-                            }
-                        }
-                        processedAny = true;
-                        chunksProcessed++;
-
-                        // Log first successful audio chunk
-                        static bool firstAudioLogged = false;
-                        if (!firstAudioLogged)
-                        {
-                            LOG_INFO("RecordingManager: First audio chunk encoded and muxed successfully (" +
-                                     std::to_string(chunk.sampleCount) + " samples)");
-                            firstAudioLogged = true;
-                        }
-                    }
-                    else
-                    {
-                        static int audioEncodeErrorCount = 0;
-                        if (audioEncodeErrorCount++ < 3)
-                        {
-                            LOG_WARN("RecordingManager: Failed to encode audio chunk (" +
-                                     std::to_string(chunk.sampleCount) + " samples)");
-                        }
-                    }
-                }
-            }
-
-            // CRITICAL: Mark only frames that were actually processed
-            // Since frames are sorted by timestamp, we need to mark them individually
-            // to avoid marking wrong frames as processed
+            // Marcar frames de vídeo processados (não áudio).
             for (const auto &frame : videoFrames)
             {
-                if (frame.processed || !frame.data)
-                    continue; // Skip if already processed or invalid
-
-                // Find and mark this specific frame in the buffer
-                // We need to find it by timestamp since order may have changed
+                if (frame.processed || !frame.data) continue;
                 m_synchronizer.markVideoFrameProcessedByTimestamp(frame.captureTimestampUs);
-            }
-
-            // Mark audio chunks as processed
-            if (syncZone.audioEndIdx > syncZone.audioStartIdx)
-            {
-                for (const auto &chunk : audioChunks)
-                {
-                    if (chunk.processed || !chunk.samples)
-                        continue;
-                    m_synchronizer.markAudioChunkProcessedByTimestamp(chunk.captureTimestampUs);
-                }
             }
 
             // Update status


### PR DESCRIPTION
Três bugs combinados causavam a desincronização que aparecia em qualquer preset acima de `veryfast` ou bitrate mais alto que o default:

1. **time_base do codec era `{1, fps}`** (16.67ms de granularidade a 60 FPS). `calculateVideoPTS` truncava floats para int — frame em t=33ms virava PTS 1.99998→1, mesmo PTS do frame anterior. libx264 logava "non-strictly-monotonic PTS" em massa, e quando frames dropavam o gap de PTS ficava grosseiro o suficiente pra arquivo declarar fps menor que o capturado → vídeo ficava em câmera lenta. Mudado pra `{1, 90000}` (padrão MPEG, ~11µs de granularidade).

2. **`vbv-bufsize = bitrate/10`** (~100ms) era apertado demais pra gravação em arquivo, forçando o rate-control a fazer trade-offs ruins por micro-janela. Em arquivo agora usa `bitrate*2` (~2s); streaming mantém o tight 100ms (precisa pra low-latency).

3. **Áudio era processado dentro do sync zone gating do encoding thread.** Quando o vídeo ficava lento, iterações longas com vídeo deixavam chunks de áudio empilharem no synchronizer (max 30 chunks ≈ 1.4s). Buffer enchia e dropava do front. Como o PTS de áudio é sample-count based, samples dropados saíam silenciosamente da contagem → áudio no arquivo ficava mais curto que o vídeo (sintoma "áudio termina N segundos antes"). Adicionado drain dedicado de áudio no topo de cada iteração via novo `MediaSynchronizer::getAllUnprocessedAudio()`, sem gating por sync zone — áudio é cheap (AAC 256 kbps) e não tem motivo pra esperar vídeo.

Validado: medium + 12 Mbps em 1080p60 grava sincronizado. veryslow ainda dropa frames (preset não foi feito pra realtime), o que é esperado.