### PR TITLE
feat: recording profiles — save/load complete recording settings

### DIFF
--- a/src/recording/RecordingProfileManager.cpp
+++ b/src/recording/RecordingProfileManager.cpp
@@ -1,0 +1,265 @@
+#include "RecordingProfileManager.h"
+#include "../utils/Logger.h"
+#include "../utils/Paths.h"
+#include "../utils/FilesystemCompat.h"
+
+#include <fstream>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <algorithm>
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+namespace {
+
+std::string nowIso8601()
+{
+    auto t = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    std::ostringstream os;
+    os << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return os.str();
+}
+
+} // namespace
+
+RecordingProfileManager::RecordingProfileManager()
+{
+    ensureDirectoryExists();
+}
+
+void RecordingProfileManager::ensureDirectoryExists()
+{
+    m_profilesDir = getProfilesDirectory();
+    if (!fs::exists(m_profilesDir))
+    {
+        try
+        {
+            fs::create_directories(m_profilesDir);
+            LOG_INFO("Created recording profiles directory: " + m_profilesDir);
+        }
+        catch (const std::exception &e)
+        {
+            LOG_ERROR("Failed to create recording profiles directory: " + std::string(e.what()));
+        }
+    }
+}
+
+std::string RecordingProfileManager::getProfilesDirectory() const
+{
+    const char *over = std::getenv("RETROCAPTURE_RECORDING_PROFILES_DIR");
+    if (over && *over) return over;
+    return (fs::path(Paths::getUserDataDir()) / "recording_profiles").string();
+}
+
+std::string RecordingProfileManager::sanitizeName(const std::string &name)
+{
+    std::string out = name;
+    for (char &c : out)
+    {
+        if (c == ' ') c = '_';
+        else if (c == '/' || c == '\\' || c == ':' || c == '*' ||
+                 c == '?' || c == '"' || c == '<' || c == '>' || c == '|')
+        {
+            c = '_';
+        }
+    }
+    // Trim leading/trailing dots/spaces/underscores
+    while (!out.empty() && (out.front() == '.' || out.front() == ' ' || out.front() == '_')) out.erase(out.begin());
+    while (!out.empty() && (out.back() == '.' || out.back() == ' ' || out.back() == '_')) out.pop_back();
+    return out;
+}
+
+bool RecordingProfileManager::save(const std::string &name, const RecordingSettings &s)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty())
+    {
+        LOG_ERROR("RecordingProfileManager::save: empty/invalid name");
+        return false;
+    }
+
+    json j;
+    j["name"] = clean;
+    j["created"] = nowIso8601();
+    j["version"] = 1;
+
+    j["video"] = {
+        {"width", s.width},
+        {"height", s.height},
+        {"fps", s.fps},
+        {"bitrate", s.bitrate},
+        {"codec", s.codec},
+        {"preset", s.preset},
+        {"h265Profile", s.h265Profile},
+        {"h265Level", s.h265Level},
+        {"vp8Speed", s.vp8Speed},
+        {"vp9Speed", s.vp9Speed},
+    };
+    j["audio"] = {
+        {"bitrate", s.audioBitrate},
+        {"codec", s.audioCodec},
+        {"include", s.includeAudio},
+    };
+    j["container"] = {
+        {"format", s.container},
+        {"outputPath", s.outputPath},
+        {"filenameTemplate", s.filenameTemplate},
+    };
+    j["limits"] = {
+        {"maxDurationUs", s.maxDurationUs},
+        {"maxFileSize", s.maxFileSize},
+    };
+    j["options"] = {
+        {"autoStart", s.autoStart},
+    };
+
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    try
+    {
+        std::ofstream f(path.string());
+        if (!f.is_open())
+        {
+            LOG_ERROR("RecordingProfileManager::save: cannot open " + path.string());
+            return false;
+        }
+        f << j.dump(2);
+        LOG_INFO("Recording profile saved: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("RecordingProfileManager::save: ") + e.what());
+        return false;
+    }
+}
+
+bool RecordingProfileManager::load(const std::string &name, RecordingSettings &s)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    if (!fs::exists(path))
+    {
+        LOG_ERROR("RecordingProfileManager::load: not found " + path.string());
+        return false;
+    }
+
+    try
+    {
+        std::ifstream f(path.string());
+        json j; f >> j;
+
+        // Defaults come from the struct itself — any missing field
+        // keeps its default, so older profiles remain loadable.
+        if (j.contains("video"))
+        {
+            const auto &v = j["video"];
+            if (v.contains("width")) s.width = v["width"].get<uint32_t>();
+            if (v.contains("height")) s.height = v["height"].get<uint32_t>();
+            if (v.contains("fps")) s.fps = v["fps"].get<uint32_t>();
+            if (v.contains("bitrate")) s.bitrate = v["bitrate"].get<uint32_t>();
+            if (v.contains("codec")) s.codec = v["codec"].get<std::string>();
+            if (v.contains("preset")) s.preset = v["preset"].get<std::string>();
+            if (v.contains("h265Profile")) s.h265Profile = v["h265Profile"].get<std::string>();
+            if (v.contains("h265Level")) s.h265Level = v["h265Level"].get<std::string>();
+            if (v.contains("vp8Speed")) s.vp8Speed = v["vp8Speed"].get<int>();
+            if (v.contains("vp9Speed")) s.vp9Speed = v["vp9Speed"].get<int>();
+        }
+        if (j.contains("audio"))
+        {
+            const auto &a = j["audio"];
+            if (a.contains("bitrate")) s.audioBitrate = a["bitrate"].get<uint32_t>();
+            if (a.contains("codec")) s.audioCodec = a["codec"].get<std::string>();
+            if (a.contains("include")) s.includeAudio = a["include"].get<bool>();
+        }
+        if (j.contains("container"))
+        {
+            const auto &c = j["container"];
+            if (c.contains("format")) s.container = c["format"].get<std::string>();
+            if (c.contains("outputPath")) s.outputPath = c["outputPath"].get<std::string>();
+            if (c.contains("filenameTemplate")) s.filenameTemplate = c["filenameTemplate"].get<std::string>();
+        }
+        if (j.contains("limits"))
+        {
+            const auto &l = j["limits"];
+            if (l.contains("maxDurationUs")) s.maxDurationUs = l["maxDurationUs"].get<uint64_t>();
+            if (l.contains("maxFileSize")) s.maxFileSize = l["maxFileSize"].get<uint64_t>();
+        }
+        if (j.contains("options"))
+        {
+            const auto &o = j["options"];
+            if (o.contains("autoStart")) s.autoStart = o["autoStart"].get<bool>();
+        }
+        LOG_INFO("Recording profile loaded: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("RecordingProfileManager::load: ") + e.what());
+        return false;
+    }
+}
+
+bool RecordingProfileManager::remove(const std::string &name)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    if (!fs::exists(path)) return false;
+    try
+    {
+        fs::remove(path);
+        LOG_INFO("Recording profile deleted: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("RecordingProfileManager::remove: ") + e.what());
+        return false;
+    }
+}
+
+bool RecordingProfileManager::exists(const std::string &name) const
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    return fs::exists(path);
+}
+
+std::vector<std::string> RecordingProfileManager::list()
+{
+    std::vector<std::string> names;
+    if (!fs::exists(m_profilesDir)) return names;
+
+    try
+    {
+        fs::directory_iterator it(m_profilesDir);
+        fs::directory_iterator end;
+        for (; it != end; ++it)
+        {
+            fs::path p = fs_helper::get_path(it);
+            std::string ext = fs_helper::get_extension_string(p);
+            if (ext != ".json") continue;
+            std::string stem = p.stem();
+            if (!stem.empty()) names.push_back(stem);
+        }
+    }
+    catch (const std::exception &e)
+    {
+        LOG_WARN(std::string("RecordingProfileManager::list: ") + e.what());
+    }
+
+    std::sort(names.begin(), names.end());
+    return names;
+}

--- a/src/recording/RecordingProfileManager.h
+++ b/src/recording/RecordingProfileManager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "RecordingSettings.h"
+#include <string>
+#include <vector>
+
+/**
+ * Persists named RecordingSettings as JSON under
+ * `Paths::getUserDataDir()/recording_profiles/<name>.json`.
+ *
+ * Simplified analogue of PresetManager — kept separate on purpose
+ * because recording profiles are orthogonal to capture presets (the
+ * same capture can be paired with different recording profiles).
+ */
+class RecordingProfileManager
+{
+public:
+    RecordingProfileManager();
+    ~RecordingProfileManager() = default;
+
+    bool save(const std::string &name, const RecordingSettings &settings);
+    bool load(const std::string &name, RecordingSettings &settings);
+    bool remove(const std::string &name);
+    bool exists(const std::string &name) const;
+    std::vector<std::string> list();
+
+    std::string getProfilesDirectory() const;
+
+    static std::string sanitizeName(const std::string &name);
+
+private:
+    void ensureDirectoryExists();
+
+    std::string m_profilesDir;
+};

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -145,6 +145,14 @@ bool APIController::handleRequest(int clientFd, const std::string &request)
                 return handleDeletePreset(clientFd, presetName);
             }
         }
+        else if (path.find("/api/v1/recording/profiles/") == 0)
+        {
+            std::string name = path.substr(27); // length of "/api/v1/recording/profiles/"
+            if (!name.empty())
+            {
+                return handleDeleteRecordingProfile(clientFd, name);
+            }
+        }
         else if (path.find("/api/v1/recordings/") == 0)
         {
             std::string recordingId = path.substr(19); // Length of "/api/v1/recordings/"
@@ -446,6 +454,10 @@ bool APIController::handleGET(int clientFd, const std::string &path, const std::
     {
         return handleGETAudioStatus(clientFd);
     }
+    else if (path == "/api/v1/recording/profiles")
+    {
+        return handleGETRecordingProfiles(clientFd);
+    }
 
     send404(clientFd);
     return true;
@@ -533,6 +545,21 @@ bool APIController::handlePOST(int clientFd, const std::string &path, const std:
     else if (path == "/api/v1/audio/disconnect-input")
     {
         return handleDisconnectAudioInput(clientFd);
+    }
+    else if (path == "/api/v1/recording/profiles")
+    {
+        return handleSaveRecordingProfile(clientFd, body);
+    }
+    else if (path.find("/api/v1/recording/profiles/") == 0 && path.find("/apply") != std::string::npos)
+    {
+        // /api/v1/recording/profiles/{name}/apply
+        constexpr size_t prefixLen = 27; // length of "/api/v1/recording/profiles/"
+        size_t applyPos = path.find("/apply");
+        if (applyPos != std::string::npos && applyPos > prefixLen)
+        {
+            std::string name = path.substr(prefixLen, applyPos - prefixLen);
+            if (!name.empty()) return handleApplyRecordingProfile(clientFd, name);
+        }
     }
 
     send404(clientFd);
@@ -1691,6 +1718,99 @@ bool APIController::handleDeletePreset(int clientFd, const std::string& presetNa
         sendErrorResponse(clientFd, 500, "Error deleting preset: " + std::string(e.what()));
         return true;
     }
+}
+
+// ----------------------------------------------------------------------
+// Recording profiles
+// ----------------------------------------------------------------------
+
+bool APIController::handleGETRecordingProfiles(int clientFd)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    auto names = m_uiManager->listRecordingProfiles();
+    std::ostringstream out;
+    out << "{\"profiles\": [";
+    for (size_t i = 0; i < names.size(); ++i)
+    {
+        if (i) out << ",";
+        out << jsonString(names[i]);
+    }
+    out << "]}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
+}
+
+bool APIController::handleSaveRecordingProfile(int clientFd, const std::string &body)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    try
+    {
+        nlohmann::json j = nlohmann::json::parse(body);
+        if (!j.contains("name") || !j["name"].is_string())
+        {
+            sendErrorResponse(clientFd, 400, "Missing 'name' field");
+            return true;
+        }
+        std::string name = j["name"].get<std::string>();
+        if (!m_uiManager->saveRecordingProfile(name))
+        {
+            sendErrorResponse(clientFd, 500, "Failed to save recording profile");
+            return true;
+        }
+        std::ostringstream out;
+        out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+        sendJSONResponse(clientFd, 200, out.str());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        sendErrorResponse(clientFd, 400, "Invalid JSON: " + std::string(e.what()));
+        return true;
+    }
+}
+
+bool APIController::handleApplyRecordingProfile(int clientFd, const std::string &name)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    if (!m_uiManager->loadRecordingProfile(name))
+    {
+        sendErrorResponse(clientFd, 404, "Recording profile not found or failed to load: " + name);
+        return true;
+    }
+    std::ostringstream out;
+    out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
+}
+
+bool APIController::handleDeleteRecordingProfile(int clientFd, const std::string &name)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    if (!m_uiManager->deleteRecordingProfile(name))
+    {
+        sendErrorResponse(clientFd, 404, "Recording profile not found: " + name);
+        return true;
+    }
+    std::ostringstream out;
+    out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
 }
 
 // Recording handlers

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -148,6 +148,12 @@ private:
     bool handleSetAudioInputSource(int clientFd, const std::string &body);
     bool handleDisconnectAudioInput(int clientFd);
 
+    // Recording profiles (saved snapshots of recording configuration)
+    bool handleGETRecordingProfiles(int clientFd);
+    bool handleSaveRecordingProfile(int clientFd, const std::string &body);
+    bool handleApplyRecordingProfile(int clientFd, const std::string &name);
+    bool handleDeleteRecordingProfile(int clientFd, const std::string &name);
+
     Application *m_application = nullptr;
     UIManager *m_uiManager = nullptr;
     HTTPServer *m_httpServer = nullptr; // Ponteiro para HTTPServer

--- a/src/ui/UIConfigurationRecording.cpp
+++ b/src/ui/UIConfigurationRecording.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationRecording.h"
 #include "UIManager.h"
+#include "../utils/Logger.h"
 #include <imgui.h>
 #include <algorithm>
 #include <iomanip>
@@ -22,6 +23,8 @@ void UIConfigurationRecording::render()
     }
 
     renderRecordingStatus();
+    ImGui::Separator();
+    renderProfiles();
     ImGui::Separator();
     renderBasicSettings();
     ImGui::Separator();
@@ -82,6 +85,141 @@ void UIConfigurationRecording::renderRecordingStatus()
         {
             ImGui::Text("File: %s", filename.c_str());
         }
+    }
+}
+
+void UIConfigurationRecording::refreshProfiles()
+{
+    m_profileNames = m_uiManager->listRecordingProfiles();
+    m_profilesDirty = false;
+    if (m_selectedProfileIndex >= static_cast<int>(m_profileNames.size()))
+    {
+        m_selectedProfileIndex = m_profileNames.empty() ? -1 : 0;
+    }
+}
+
+void UIConfigurationRecording::renderProfiles()
+{
+    if (m_profilesDirty) refreshProfiles();
+
+    ImGui::Text("Profiles");
+    ImGui::Separator();
+
+    const char *currentLabel = (m_selectedProfileIndex >= 0 &&
+                                m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+                                   ? m_profileNames[m_selectedProfileIndex].c_str()
+                                   : "(no profile selected)";
+
+    if (ImGui::BeginCombo("##recording_profile", currentLabel))
+    {
+        for (int i = 0; i < static_cast<int>(m_profileNames.size()); ++i)
+        {
+            bool selected = (i == m_selectedProfileIndex);
+            if (ImGui::Selectable(m_profileNames[i].c_str(), selected))
+            {
+                m_selectedProfileIndex = i;
+            }
+            if (selected) ImGui::SetItemDefaultFocus();
+        }
+        if (m_profileNames.empty())
+        {
+            ImGui::TextDisabled("(no profiles saved)");
+        }
+        ImGui::EndCombo();
+    }
+
+    bool hasSelection = (m_selectedProfileIndex >= 0 &&
+                         m_selectedProfileIndex < static_cast<int>(m_profileNames.size()));
+
+    if (!hasSelection) ImGui::BeginDisabled();
+    if (ImGui::Button("Apply"))
+    {
+        const std::string &name = m_profileNames[m_selectedProfileIndex];
+        if (!m_uiManager->loadRecordingProfile(name))
+        {
+            LOG_ERROR("Failed to load recording profile: " + name);
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Delete"))
+    {
+        m_showDeleteConfirm = true;
+    }
+    if (!hasSelection) ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    if (ImGui::Button("Save as..."))
+    {
+        m_newProfileName[0] = '\0';
+        m_showSaveDialog = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Refresh"))
+    {
+        m_profilesDirty = true;
+    }
+
+    // Save dialog
+    if (m_showSaveDialog) ImGui::OpenPopup("Save Recording Profile");
+    if (ImGui::BeginPopupModal("Save Recording Profile", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::Text("Profile name:");
+        ImGui::InputText("##profile_name", m_newProfileName, sizeof(m_newProfileName));
+
+        std::string nameStr(m_newProfileName);
+        bool exists = !nameStr.empty() && m_uiManager->recordingProfileExists(nameStr);
+        if (exists)
+        {
+            ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "A profile with this name already exists.");
+        }
+
+        if (ImGui::Button("Save", ImVec2(120, 0)))
+        {
+            if (!nameStr.empty())
+            {
+                if (m_uiManager->saveRecordingProfile(nameStr))
+                {
+                    m_profilesDirty = true;
+                    m_showSaveDialog = false;
+                    ImGui::CloseCurrentPopup();
+                }
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        {
+            m_showSaveDialog = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    // Delete confirm
+    if (m_showDeleteConfirm) ImGui::OpenPopup("Delete Recording Profile");
+    if (ImGui::BeginPopupModal("Delete Recording Profile", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        if (m_selectedProfileIndex >= 0 && m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+        {
+            ImGui::Text("Delete profile \"%s\"?", m_profileNames[m_selectedProfileIndex].c_str());
+        }
+        if (ImGui::Button("Delete", ImVec2(120, 0)))
+        {
+            if (m_selectedProfileIndex >= 0 && m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+            {
+                m_uiManager->deleteRecordingProfile(m_profileNames[m_selectedProfileIndex]);
+                m_profilesDirty = true;
+                m_selectedProfileIndex = -1;
+            }
+            m_showDeleteConfirm = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        {
+            m_showDeleteConfirm = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
     }
 }
 

--- a/src/ui/UIConfigurationRecording.h
+++ b/src/ui/UIConfigurationRecording.h
@@ -22,6 +22,7 @@ private:
     UIManager *m_uiManager = nullptr;
 
     void renderRecordingStatus();
+    void renderProfiles();
     void renderBasicSettings();
     void renderCodecSettings();
     void renderBitrateSettings();
@@ -34,4 +35,15 @@ private:
     void renderH265Settings();
     void renderVP8Settings();
     void renderVP9Settings();
+
+    // Profile UI state
+    int m_selectedProfileIndex = -1;
+    std::vector<std::string> m_profileNames;
+    bool m_profilesDirty = true;
+    char m_newProfileName[128] = "";
+    bool m_showSaveDialog = false;
+    bool m_showDeleteConfirm = false;
+    bool m_showOverwriteConfirm = false;
+
+    void refreshProfiles();
 };

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -3,6 +3,8 @@
 #include "UICredits.h"
 #include "UICapturePresets.h"
 #include "UIRecordings.h"
+#include "../recording/RecordingProfileManager.h"
+#include "../recording/RecordingSettings.h"
 #include "../utils/Logger.h"
 #include "../utils/Paths.h"
 #include "../utils/ShaderScanner.h"
@@ -145,6 +147,7 @@ bool UIManager::init(void *window)
     m_creditsWindow = std::make_unique<UICredits>(this);
     m_capturePresetsWindow = std::make_unique<UICapturePresets>(this);
     m_recordingsWindow = std::make_unique<UIRecordings>(this);
+    m_recordingProfileManager = std::make_unique<RecordingProfileManager>();
     m_configWindow->setVisible(true);
     m_configWindow->setJustOpened(true);
 
@@ -3152,4 +3155,96 @@ void UIManager::triggerRecordingStartStop(bool start)
     {
         m_onRecordingStartStop(start);
     }
+}
+
+// ----------------------------------------------------------------------
+// Recording profiles
+// ----------------------------------------------------------------------
+
+namespace {
+
+RecordingSettings collectRecordingSettings(const UIManager &ui)
+{
+    RecordingSettings s;
+    s.width = ui.getRecordingWidth();
+    s.height = ui.getRecordingHeight();
+    s.fps = ui.getRecordingFps();
+    s.bitrate = ui.getRecordingBitrate();
+    s.codec = ui.getRecordingVideoCodec();
+    // The struct has a single `preset` field; map it from the active codec.
+    if (s.codec == "h265" || s.codec == "hevc") s.preset = ui.getRecordingH265Preset();
+    else s.preset = ui.getRecordingH264Preset();
+    s.h265Profile = ui.getRecordingH265Profile();
+    s.h265Level = ui.getRecordingH265Level();
+    s.vp8Speed = ui.getRecordingVP8Speed();
+    s.vp9Speed = ui.getRecordingVP9Speed();
+    s.audioBitrate = ui.getRecordingAudioBitrate();
+    s.audioCodec = ui.getRecordingAudioCodec();
+    s.container = ui.getRecordingContainer();
+    s.outputPath = ui.getRecordingOutputPath();
+    s.filenameTemplate = ui.getRecordingFilenameTemplate();
+    s.includeAudio = ui.getRecordingIncludeAudio();
+    return s;
+}
+
+} // namespace
+
+std::vector<std::string> UIManager::listRecordingProfiles()
+{
+    if (!m_recordingProfileManager) return {};
+    return m_recordingProfileManager->list();
+}
+
+bool UIManager::recordingProfileExists(const std::string &name)
+{
+    if (!m_recordingProfileManager) return false;
+    return m_recordingProfileManager->exists(name);
+}
+
+bool UIManager::saveRecordingProfile(const std::string &name)
+{
+    if (!m_recordingProfileManager) return false;
+    RecordingSettings s = collectRecordingSettings(*this);
+    return m_recordingProfileManager->save(name, s);
+}
+
+bool UIManager::deleteRecordingProfile(const std::string &name)
+{
+    if (!m_recordingProfileManager) return false;
+    return m_recordingProfileManager->remove(name);
+}
+
+bool UIManager::loadRecordingProfile(const std::string &name)
+{
+    if (!m_recordingProfileManager) return false;
+    RecordingSettings s;
+    if (!m_recordingProfileManager->load(name, s)) return false;
+
+    // Apply via triggerXxxChange for each field — that way the
+    // existing callbacks fire and the RecordingManager / on-disk config
+    // see the update exactly as if the user had moved each control by hand.
+    triggerRecordingVideoCodecChange(s.codec);
+    if (s.codec == "h265" || s.codec == "hevc")
+    {
+        triggerRecordingH265PresetChange(s.preset);
+    }
+    else
+    {
+        triggerRecordingH264PresetChange(s.preset);
+    }
+    triggerRecordingH265ProfileChange(s.h265Profile);
+    triggerRecordingH265LevelChange(s.h265Level);
+    triggerRecordingVP8SpeedChange(s.vp8Speed);
+    triggerRecordingVP9SpeedChange(s.vp9Speed);
+    triggerRecordingWidthChange(s.width);
+    triggerRecordingHeightChange(s.height);
+    triggerRecordingFpsChange(s.fps);
+    triggerRecordingBitrateChange(s.bitrate);
+    triggerRecordingAudioCodecChange(s.audioCodec);
+    triggerRecordingAudioBitrateChange(s.audioBitrate);
+    triggerRecordingContainerChange(s.container);
+    triggerRecordingOutputPathChange(s.outputPath);
+    triggerRecordingFilenameTemplateChange(s.filenameTemplate);
+    triggerRecordingIncludeAudioChange(s.includeAudio);
+    return true;
 }

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -23,6 +23,7 @@ class UIConfiguration;
 class UICredits;
 class UICapturePresets;
 class UIRecordings;
+class RecordingProfileManager;
 
 class UIManager
 {
@@ -438,6 +439,15 @@ public:
     void triggerRecordingIncludeAudioChange(bool include);
     void triggerRecordingStartStop(bool start);
 
+    // Recording profiles — save/load/list/delete the full recording
+    // configuration (codec, preset, bitrate, container, audio, etc.)
+    // as named profiles under $XDG_DATA_HOME/retrocapture/recording_profiles.
+    std::vector<std::string> listRecordingProfiles();
+    bool saveRecordingProfile(const std::string& name);
+    bool loadRecordingProfile(const std::string& name);
+    bool deleteRecordingProfile(const std::string& name);
+    bool recordingProfileExists(const std::string& name);
+
     // Recording callbacks
     void setOnRecordingStartStop(std::function<void(bool)> callback) { m_onRecordingStartStop = callback; }
     void setOnRecordingWidthChanged(std::function<void(uint32_t)> callback) { m_onRecordingWidthChanged = callback; }
@@ -627,6 +637,7 @@ private:
     std::unique_ptr<class UICredits> m_creditsWindow;
     std::unique_ptr<class UICapturePresets> m_capturePresetsWindow;
     std::unique_ptr<class UIRecordings> m_recordingsWindow;
+    std::unique_ptr<RecordingProfileManager> m_recordingProfileManager;
     void *m_window = nullptr; // GLFWwindow* or SDL_Window*
 
     // Shader selection


### PR DESCRIPTION
Lets the user save the full recording configuration (codec, x264 preset, bitrate, audio, container, filename template, etc.) as named profiles and switch between them from a dropdown at the top of the Recording panel.

Storage: $XDG_DATA_HOME/retrocapture/recording_profiles/<name>.json on Linux, %APPDATA%\RetroCapture\data\recording_profiles\<name>.json on Windows. Overridable via the RETROCAPTURE_RECORDING_PROFILES_DIR env.

Apply propagates through the existing `triggerRecordingXxxChange` setters, so the RecordingManager and the persisted config see the update the same way they would if the user had moved each control by hand.

A matching REST API lives under `/api/v1/recording/profiles` (GET list, POST save, POST .../apply, DELETE) for future parity with the web portal (#35).