### PR TITLE
chore: streaming audit and harden — drain audio, non-blocking send, s…

### DIFF
--- a/src/streaming/HTTPServer.cpp
+++ b/src/streaming/HTTPServer.cpp
@@ -453,7 +453,17 @@ ssize_t HTTPServer::sendData(int clientFd, const void *data, size_t size)
     }
 #endif
 #ifdef PLATFORM_LINUX
-    return send(clientFd, data, size, MSG_NOSIGNAL);
+    // MSG_DONTWAIT keeps us non-blocking on a per-call basis without
+    // having to flip the socket itself. On EAGAIN/EWOULDBLOCK we return
+    // 0 (matching the Windows WSAEWOULDBLOCK path) so the streamer
+    // treats a slow client as transient instead of blocking the encoder
+    // thread (which holds the broadcast mutex).
+    ssize_t result = send(clientFd, data, size, MSG_NOSIGNAL | MSG_DONTWAIT);
+    if (result < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    {
+        return 0;
+    }
+    return result;
 #else
     // Windows: send retorna SOCKET_ERROR (-1) em caso de erro
     // SOCKET_ERROR é definido como -1 em winsock2.h

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -966,18 +966,14 @@ int HTTPTSStreamer::writeToClients(const uint8_t *buf, int buf_size)
             }
             else if (sent == 0)
             {
-                // No Windows, sent == 0 pode significar WSAEWOULDBLOCK (socket temporariamente bloqueado)
-                // Não é um erro fatal, apenas continuar (dados serão enviados na próxima tentativa)
-                // No Linux, sent == 0 geralmente significa conexão fechada
-#ifdef PLATFORM_LINUX
-                m_httpServer.closeClient(clientFd);
-                it = m_clientSockets.erase(it);
-                m_clientCount = m_clientSockets.size();
-#else
-                // Windows: sent == 0 pode ser temporário (WSAEWOULDBLOCK), apenas continuar
-                // Não remover cliente, dados serão enviados na próxima tentativa
+                // sent == 0 now means "would block" on both platforms:
+                // Linux uses MSG_DONTWAIT and maps EAGAIN to 0; Windows
+                // maps WSAEWOULDBLOCK to 0. Treat as transient — the
+                // packet is dropped for this client this round, but the
+                // client stays connected and gets the next one. Keeps a
+                // slow client from blocking the encoder thread (which
+                // holds the broadcast mutex).
                 ++it;
-#endif
             }
             else if (static_cast<size_t>(sent) < static_cast<size_t>(buf_size))
             {
@@ -2666,12 +2662,37 @@ void HTTPTSStreamer::encodingThread()
             cleanupCounter = 0;
         }
 
-        // Verificar se há backlog (muitos frames pendentes)
+        // Drain audio independently of the sync zone. AAC is cheap and
+        // doesn't need to wait for video — same fix applied to recording
+        // in #34. Without this, slow video iterations let the audio buffer
+        // overflow and chunks get dropped at the synchronizer; since the
+        // audio PTS is sample-count based, the resulting stream's audio
+        // ends up shorter than its video.
+        {
+            auto pendingAudio = m_streamSynchronizer.getAllUnprocessedAudio();
+            for (const auto &chunk : pendingAudio)
+            {
+                if (m_stopRequest) break;
+                if (chunk.processed || !chunk.samples || chunk.sampleCount == 0) continue;
+
+                std::vector<MediaEncoder::EncodedPacket> aPackets;
+                if (m_mediaEncoder.encodeAudio(chunk.samples->data(), chunk.sampleCount,
+                                               chunk.captureTimestampUs, aPackets))
+                {
+                    for (const auto &p : aPackets)
+                    {
+                        m_mediaMuxer.muxPacket(p);
+                    }
+                    processedAny = true;
+                }
+                m_streamSynchronizer.markAudioChunkProcessedByTimestamp(chunk.captureTimestampUs);
+            }
+        }
+
         size_t videoBufferSize = m_streamSynchronizer.getVideoBufferSize();
         size_t audioBufferSize = m_streamSynchronizer.getAudioBufferSize();
         bool hasBacklog = (videoBufferSize > 5 || audioBufferSize > 10);
 
-        // Calcular zona de sincronização
         MediaSynchronizer::SyncZone syncZone = m_streamSynchronizer.calculateSyncZone();
 
         if (syncZone.isValid())
@@ -2715,48 +2736,11 @@ void HTTPTSStreamer::encodingThread()
                 }
             }
 
-            // Obter chunks de áudio da zona sincronizada
-            auto audioChunks = m_streamSynchronizer.getAudioChunks(syncZone);
+            // Audio was already drained at the top of the loop, no need
+            // to process it again here.
 
-            // Processar chunks de áudio (com limite para evitar aceleração)
-            // Aumentar limite quando há backlog para evitar perda de chunks
-            size_t chunksProcessed = 0;
-            size_t MAX_CHUNKS_PER_ITERATION = hasBacklog ? 8 : 3; // Mais chunks quando há backlog
-
-            for (const auto &chunk : audioChunks)
-            {
-                if (m_stopRequest)
-                {
-                    break;
-                }
-
-                // Limitar número de chunks processados por iteração
-                if (chunksProcessed >= MAX_CHUNKS_PER_ITERATION)
-                {
-                    break;
-                }
-
-                if (!chunk.processed && chunk.samples && chunk.sampleCount > 0)
-                {
-                    // Encodar áudio usando MediaEncoder
-                    std::vector<MediaEncoder::EncodedPacket> packets;
-                    if (m_mediaEncoder.encodeAudio(chunk.samples->data(), chunk.sampleCount,
-                                                   chunk.captureTimestampUs, packets))
-                    {
-                        // Muxar pacotes usando MediaMuxer
-                        for (const auto &packet : packets)
-                        {
-                            m_mediaMuxer.muxPacket(packet);
-                        }
-                        processedAny = true;
-                        chunksProcessed++;
-                    }
-                }
-            }
-
-            // Marcar dados como processados
+            // Marcar frames de vídeo processados
             m_streamSynchronizer.markVideoProcessed(syncZone.videoStartIdx, syncZone.videoEndIdx);
-            m_streamSynchronizer.markAudioProcessed(syncZone.audioStartIdx, syncZone.audioEndIdx);
 
             // Capturar header do formato se disponível
             {

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -27,8 +27,9 @@ void UIConfigurationStreaming::render()
     ImGui::Separator();
     renderBitrateSettings();
     ImGui::Separator();
-    renderAdvancedBufferSettings();
-    ImGui::Separator();
+    // Buffer tuning (max video/audio buffer, max buffer time, AVIO buffer)
+    // is not surfaced in the UI anymore — defaults work for the vast
+    // majority of cases. Power users can still override via config.json.
     renderStartStopButton();
 }
 

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -761,8 +761,12 @@ private:
     bool m_streamingProcessing = false;         // Flag para indicar que start/stop está sendo processado
 
     // Buffer configuration (para economizar memória, especialmente em ARM)
-    size_t m_streamingMaxVideoBufferSize = 10;     // Máximo de frames no buffer de vídeo (1-50)
-    size_t m_streamingMaxAudioBufferSize = 20;     // Máximo de chunks no buffer de áudio (5-100)
+    // Default video buffer raised from 10 to 15 frames (~250ms at 60fps)
+    // to give a bit more cushion against client/network jitter — small
+    // frame loss showed up under load even on capable hardware. Audio
+    // bumped to match. Still overridable from config.json.
+    size_t m_streamingMaxVideoBufferSize = 15;     // Máximo de frames no buffer de vídeo (1-50)
+    size_t m_streamingMaxAudioBufferSize = 30;     // Máximo de chunks no buffer de áudio (5-100)
     int64_t m_streamingMaxBufferTimeSeconds = 5;   // Tempo máximo de buffer em segundos (1-30)
     size_t m_streamingAVIOBufferSize = 256 * 1024; // 256KB para buffer AVIO do FFmpeg (64KB-1MB)
 


### PR DESCRIPTION
…impler UI

Carries the recording-pipeline lessons (#34) over to the HTTP-TS streamer, which uses the same MediaEncoder + MediaSynchronizer stack:

* **Audio drain at the top of each iteration**, ungated by the sync zone. Without it, slow-video iterations let the audio queue overflow and the synchronizer dropped chunks; since audio PTS is sample-count based, the streamed audio ended up shorter than the video. Mirrors the fix landed for recording.

* **Non-blocking client writes**. `HTTPServer::sendData` now sets `MSG_DONTWAIT` on Linux and maps `EAGAIN`/`EWOULDBLOCK` to the same "transient, try again" return code Windows already uses on `WSAEWOULDBLOCK`. `HTTPTSStreamer::writeToClients` no longer disconnects a client on `sent == 0`. Previously a single slow client with a full TCP send buffer blocked `send()` while holding the broadcast mutex, which stalled the encoder thread and starved every other client; now a slow client just misses the in-flight packet for one round and stays connected.

* **UI simplification**: the four advanced buffer knobs (max video frames, max audio chunks, max buffer time, AVIO buffer) are no longer surfaced in the streaming panel. They confused setup more than they helped. The fields stay in `UIManager` and `config.json` for advanced overrides.

* **Default streaming buffers bumped**: video 10 -> 15 frames (~250ms cushion at 60fps), audio 20 -> 30 chunks. Smooths out small client jitter without noticeable extra latency.

Items deferred to follow-up issues if pain reappears: per-client send queue with bounded backpressure, snappier reconnect via shorter keyframe interval.