### PR TITLE
feat: streaming profiles — save/load complete streaming settings

### DIFF
--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -153,6 +153,14 @@ bool APIController::handleRequest(int clientFd, const std::string &request)
                 return handleDeleteRecordingProfile(clientFd, name);
             }
         }
+        else if (path.find("/api/v1/streaming/profiles/") == 0)
+        {
+            std::string name = path.substr(27); // length of "/api/v1/streaming/profiles/"
+            if (!name.empty())
+            {
+                return handleDeleteStreamingProfile(clientFd, name);
+            }
+        }
         else if (path.find("/api/v1/recordings/") == 0)
         {
             std::string recordingId = path.substr(19); // Length of "/api/v1/recordings/"
@@ -458,6 +466,10 @@ bool APIController::handleGET(int clientFd, const std::string &path, const std::
     {
         return handleGETRecordingProfiles(clientFd);
     }
+    else if (path == "/api/v1/streaming/profiles")
+    {
+        return handleGETStreamingProfiles(clientFd);
+    }
 
     send404(clientFd);
     return true;
@@ -559,6 +571,21 @@ bool APIController::handlePOST(int clientFd, const std::string &path, const std:
         {
             std::string name = path.substr(prefixLen, applyPos - prefixLen);
             if (!name.empty()) return handleApplyRecordingProfile(clientFd, name);
+        }
+    }
+    else if (path == "/api/v1/streaming/profiles")
+    {
+        return handleSaveStreamingProfile(clientFd, body);
+    }
+    else if (path.find("/api/v1/streaming/profiles/") == 0 && path.find("/apply") != std::string::npos)
+    {
+        // /api/v1/streaming/profiles/{name}/apply
+        constexpr size_t prefixLen = 27; // length of "/api/v1/streaming/profiles/"
+        size_t applyPos = path.find("/apply");
+        if (applyPos != std::string::npos && applyPos > prefixLen)
+        {
+            std::string name = path.substr(prefixLen, applyPos - prefixLen);
+            if (!name.empty()) return handleApplyStreamingProfile(clientFd, name);
         }
     }
 
@@ -1805,6 +1832,99 @@ bool APIController::handleDeleteRecordingProfile(int clientFd, const std::string
     if (!m_uiManager->deleteRecordingProfile(name))
     {
         sendErrorResponse(clientFd, 404, "Recording profile not found: " + name);
+        return true;
+    }
+    std::ostringstream out;
+    out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
+}
+
+// ----------------------------------------------------------------------
+// Streaming profiles
+// ----------------------------------------------------------------------
+
+bool APIController::handleGETStreamingProfiles(int clientFd)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    auto names = m_uiManager->listStreamingProfiles();
+    std::ostringstream out;
+    out << "{\"profiles\": [";
+    for (size_t i = 0; i < names.size(); ++i)
+    {
+        if (i) out << ",";
+        out << jsonString(names[i]);
+    }
+    out << "]}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
+}
+
+bool APIController::handleSaveStreamingProfile(int clientFd, const std::string &body)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    try
+    {
+        nlohmann::json j = nlohmann::json::parse(body);
+        if (!j.contains("name") || !j["name"].is_string())
+        {
+            sendErrorResponse(clientFd, 400, "Missing 'name' field");
+            return true;
+        }
+        std::string name = j["name"].get<std::string>();
+        if (!m_uiManager->saveStreamingProfile(name))
+        {
+            sendErrorResponse(clientFd, 500, "Failed to save streaming profile");
+            return true;
+        }
+        std::ostringstream out;
+        out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+        sendJSONResponse(clientFd, 200, out.str());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        sendErrorResponse(clientFd, 400, "Invalid JSON: " + std::string(e.what()));
+        return true;
+    }
+}
+
+bool APIController::handleApplyStreamingProfile(int clientFd, const std::string &name)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    if (!m_uiManager->loadStreamingProfile(name))
+    {
+        sendErrorResponse(clientFd, 404, "Streaming profile not found or failed to load: " + name);
+        return true;
+    }
+    std::ostringstream out;
+    out << "{\"success\": true, \"name\": " << jsonString(name) << "}";
+    sendJSONResponse(clientFd, 200, out.str());
+    return true;
+}
+
+bool APIController::handleDeleteStreamingProfile(int clientFd, const std::string &name)
+{
+    if (!m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "UIManager not available");
+        return true;
+    }
+    if (!m_uiManager->deleteStreamingProfile(name))
+    {
+        sendErrorResponse(clientFd, 404, "Streaming profile not found: " + name);
         return true;
     }
     std::ostringstream out;

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -154,6 +154,12 @@ private:
     bool handleApplyRecordingProfile(int clientFd, const std::string &name);
     bool handleDeleteRecordingProfile(int clientFd, const std::string &name);
 
+    // Streaming profiles (saved snapshots of streaming configuration)
+    bool handleGETStreamingProfiles(int clientFd);
+    bool handleSaveStreamingProfile(int clientFd, const std::string &body);
+    bool handleApplyStreamingProfile(int clientFd, const std::string &name);
+    bool handleDeleteStreamingProfile(int clientFd, const std::string &name);
+
     Application *m_application = nullptr;
     UIManager *m_uiManager = nullptr;
     HTTPServer *m_httpServer = nullptr; // Ponteiro para HTTPServer

--- a/src/streaming/StreamingProfileManager.cpp
+++ b/src/streaming/StreamingProfileManager.cpp
@@ -1,0 +1,256 @@
+#include "StreamingProfileManager.h"
+#include "../utils/Logger.h"
+#include "../utils/Paths.h"
+#include "../utils/FilesystemCompat.h"
+
+#include <fstream>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <algorithm>
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+namespace {
+
+std::string nowIso8601()
+{
+    auto t = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    std::ostringstream os;
+    os << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return os.str();
+}
+
+} // namespace
+
+StreamingProfileManager::StreamingProfileManager()
+{
+    ensureDirectoryExists();
+}
+
+void StreamingProfileManager::ensureDirectoryExists()
+{
+    m_profilesDir = getProfilesDirectory();
+    if (!fs::exists(m_profilesDir))
+    {
+        try
+        {
+            fs::create_directories(m_profilesDir);
+            LOG_INFO("Created streaming profiles directory: " + m_profilesDir);
+        }
+        catch (const std::exception &e)
+        {
+            LOG_ERROR("Failed to create streaming profiles directory: " + std::string(e.what()));
+        }
+    }
+}
+
+std::string StreamingProfileManager::getProfilesDirectory() const
+{
+    const char *over = std::getenv("RETROCAPTURE_STREAMING_PROFILES_DIR");
+    if (over && *over) return over;
+    return (fs::path(Paths::getUserDataDir()) / "streaming_profiles").string();
+}
+
+std::string StreamingProfileManager::sanitizeName(const std::string &name)
+{
+    std::string out = name;
+    for (char &c : out)
+    {
+        if (c == ' ') c = '_';
+        else if (c == '/' || c == '\\' || c == ':' || c == '*' ||
+                 c == '?' || c == '"' || c == '<' || c == '>' || c == '|')
+        {
+            c = '_';
+        }
+    }
+    while (!out.empty() && (out.front() == '.' || out.front() == ' ' || out.front() == '_')) out.erase(out.begin());
+    while (!out.empty() && (out.back() == '.' || out.back() == ' ' || out.back() == '_')) out.pop_back();
+    return out;
+}
+
+bool StreamingProfileManager::save(const std::string &name, const StreamingSettings &s)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty())
+    {
+        LOG_ERROR("StreamingProfileManager::save: empty/invalid name");
+        return false;
+    }
+
+    json j;
+    j["name"] = clean;
+    j["created"] = nowIso8601();
+    j["version"] = 1;
+
+    j["network"] = {
+        {"port", s.port},
+    };
+    j["video"] = {
+        {"width", s.width},
+        {"height", s.height},
+        {"fps", s.fps},
+        {"bitrate", s.bitrate},
+        {"codec", s.videoCodec},
+        {"h264Preset", s.h264Preset},
+        {"h265Preset", s.h265Preset},
+        {"h265Profile", s.h265Profile},
+        {"h265Level", s.h265Level},
+        {"vp8Speed", s.vp8Speed},
+        {"vp9Speed", s.vp9Speed},
+    };
+    j["audio"] = {
+        {"bitrate", s.audioBitrate},
+        {"codec", s.audioCodec},
+    };
+    j["buffer"] = {
+        {"maxVideoBufferSize", s.maxVideoBufferSize},
+        {"maxAudioBufferSize", s.maxAudioBufferSize},
+        {"maxBufferTimeSeconds", s.maxBufferTimeSeconds},
+        {"avioBufferSize", s.avioBufferSize},
+    };
+
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    try
+    {
+        std::ofstream f(path.string());
+        if (!f.is_open())
+        {
+            LOG_ERROR("StreamingProfileManager::save: cannot open " + path.string());
+            return false;
+        }
+        f << j.dump(2);
+        LOG_INFO("Streaming profile saved: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("StreamingProfileManager::save: ") + e.what());
+        return false;
+    }
+}
+
+bool StreamingProfileManager::load(const std::string &name, StreamingSettings &s)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    if (!fs::exists(path))
+    {
+        LOG_ERROR("StreamingProfileManager::load: not found " + path.string());
+        return false;
+    }
+
+    try
+    {
+        std::ifstream f(path.string());
+        json j; f >> j;
+
+        // Defaults come from the struct itself — any missing field
+        // keeps its default, so older profiles remain loadable.
+        if (j.contains("network"))
+        {
+            const auto &n = j["network"];
+            if (n.contains("port")) s.port = n["port"].get<uint16_t>();
+        }
+        if (j.contains("video"))
+        {
+            const auto &v = j["video"];
+            if (v.contains("width")) s.width = v["width"].get<uint32_t>();
+            if (v.contains("height")) s.height = v["height"].get<uint32_t>();
+            if (v.contains("fps")) s.fps = v["fps"].get<uint32_t>();
+            if (v.contains("bitrate")) s.bitrate = v["bitrate"].get<uint32_t>();
+            if (v.contains("codec")) s.videoCodec = v["codec"].get<std::string>();
+            if (v.contains("h264Preset")) s.h264Preset = v["h264Preset"].get<std::string>();
+            if (v.contains("h265Preset")) s.h265Preset = v["h265Preset"].get<std::string>();
+            if (v.contains("h265Profile")) s.h265Profile = v["h265Profile"].get<std::string>();
+            if (v.contains("h265Level")) s.h265Level = v["h265Level"].get<std::string>();
+            if (v.contains("vp8Speed")) s.vp8Speed = v["vp8Speed"].get<int>();
+            if (v.contains("vp9Speed")) s.vp9Speed = v["vp9Speed"].get<int>();
+        }
+        if (j.contains("audio"))
+        {
+            const auto &a = j["audio"];
+            if (a.contains("bitrate")) s.audioBitrate = a["bitrate"].get<uint32_t>();
+            if (a.contains("codec")) s.audioCodec = a["codec"].get<std::string>();
+        }
+        if (j.contains("buffer"))
+        {
+            const auto &b = j["buffer"];
+            if (b.contains("maxVideoBufferSize")) s.maxVideoBufferSize = b["maxVideoBufferSize"].get<size_t>();
+            if (b.contains("maxAudioBufferSize")) s.maxAudioBufferSize = b["maxAudioBufferSize"].get<size_t>();
+            if (b.contains("maxBufferTimeSeconds")) s.maxBufferTimeSeconds = b["maxBufferTimeSeconds"].get<int64_t>();
+            if (b.contains("avioBufferSize")) s.avioBufferSize = b["avioBufferSize"].get<size_t>();
+        }
+        LOG_INFO("Streaming profile loaded: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("StreamingProfileManager::load: ") + e.what());
+        return false;
+    }
+}
+
+bool StreamingProfileManager::remove(const std::string &name)
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    if (!fs::exists(path)) return false;
+    try
+    {
+        fs::remove(path);
+        LOG_INFO("Streaming profile deleted: " + path.string());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(std::string("StreamingProfileManager::remove: ") + e.what());
+        return false;
+    }
+}
+
+bool StreamingProfileManager::exists(const std::string &name) const
+{
+    std::string clean = sanitizeName(name);
+    if (clean.empty()) return false;
+    fs::path path = fs::path(m_profilesDir) / (clean + ".json");
+    return fs::exists(path);
+}
+
+std::vector<std::string> StreamingProfileManager::list()
+{
+    std::vector<std::string> names;
+    if (!fs::exists(m_profilesDir)) return names;
+
+    try
+    {
+        fs::directory_iterator it(m_profilesDir);
+        fs::directory_iterator end;
+        for (; it != end; ++it)
+        {
+            fs::path p = fs_helper::get_path(it);
+            std::string ext = fs_helper::get_extension_string(p);
+            if (ext != ".json") continue;
+            std::string stem = p.stem();
+            if (!stem.empty()) names.push_back(stem);
+        }
+    }
+    catch (const std::exception &e)
+    {
+        LOG_WARN(std::string("StreamingProfileManager::list: ") + e.what());
+    }
+
+    std::sort(names.begin(), names.end());
+    return names;
+}

--- a/src/streaming/StreamingProfileManager.h
+++ b/src/streaming/StreamingProfileManager.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+/**
+ * Snapshot of the streaming-side settings that get persisted as a
+ * profile. These fields mirror the `m_streaming*` members of
+ * `UIManager` — kept here as a plain struct so the manager and the
+ * REST layer don't need to depend on `UIManager.h`.
+ */
+struct StreamingSettings
+{
+    uint16_t port = 8000;
+    uint32_t width = 640;
+    uint32_t height = 480;
+    uint32_t fps = 30;
+    uint32_t bitrate = 2000000;
+    uint32_t audioBitrate = 128000;
+    std::string videoCodec = "h264";
+    std::string audioCodec = "aac";
+    std::string h264Preset = "veryfast";
+    std::string h265Preset = "veryfast";
+    std::string h265Profile = "main";
+    std::string h265Level = "auto";
+    int vp8Speed = 12;
+    int vp9Speed = 6;
+    size_t maxVideoBufferSize = 15;
+    size_t maxAudioBufferSize = 30;
+    int64_t maxBufferTimeSeconds = 5;
+    size_t avioBufferSize = 256 * 1024;
+};
+
+/**
+ * Persists named StreamingSettings as JSON under
+ * `Paths::getUserDataDir()/streaming_profiles/<name>.json`.
+ *
+ * Mirrors RecordingProfileManager — both expose the same lifecycle
+ * (save/load/list/delete/exists) and follow the same path scheme.
+ */
+class StreamingProfileManager
+{
+public:
+    StreamingProfileManager();
+    ~StreamingProfileManager() = default;
+
+    bool save(const std::string &name, const StreamingSettings &settings);
+    bool load(const std::string &name, StreamingSettings &settings);
+    bool remove(const std::string &name);
+    bool exists(const std::string &name) const;
+    std::vector<std::string> list();
+
+    std::string getProfilesDirectory() const;
+
+    static std::string sanitizeName(const std::string &name);
+
+private:
+    void ensureDirectoryExists();
+
+    std::string m_profilesDir;
+};

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationStreaming.h"
 #include "UIManager.h"
+#include "../utils/Logger.h"
 #include <imgui.h>
 #include <algorithm>
 
@@ -20,6 +21,8 @@ void UIConfigurationStreaming::render()
     }
 
     renderStreamingStatus();
+    ImGui::Separator();
+    renderProfiles();
     ImGui::Separator();
     renderBasicSettings();
     ImGui::Separator();
@@ -60,6 +63,139 @@ void UIConfigurationStreaming::renderStreamingStatus()
             ImGui::Text("URL: %s", url.c_str());
         }
         ImGui::Text("Clientes conectados: %u", m_uiManager->getStreamClientCount());
+    }
+}
+
+void UIConfigurationStreaming::refreshProfiles()
+{
+    m_profileNames = m_uiManager->listStreamingProfiles();
+    m_profilesDirty = false;
+    if (m_selectedProfileIndex >= static_cast<int>(m_profileNames.size()))
+    {
+        m_selectedProfileIndex = m_profileNames.empty() ? -1 : 0;
+    }
+}
+
+void UIConfigurationStreaming::renderProfiles()
+{
+    if (m_profilesDirty) refreshProfiles();
+
+    ImGui::Text("Profiles");
+    ImGui::Separator();
+
+    const char *currentLabel = (m_selectedProfileIndex >= 0 &&
+                                m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+                                   ? m_profileNames[m_selectedProfileIndex].c_str()
+                                   : "(no profile selected)";
+
+    if (ImGui::BeginCombo("##streaming_profile", currentLabel))
+    {
+        for (int i = 0; i < static_cast<int>(m_profileNames.size()); ++i)
+        {
+            bool selected = (i == m_selectedProfileIndex);
+            if (ImGui::Selectable(m_profileNames[i].c_str(), selected))
+            {
+                m_selectedProfileIndex = i;
+            }
+            if (selected) ImGui::SetItemDefaultFocus();
+        }
+        if (m_profileNames.empty())
+        {
+            ImGui::TextDisabled("(no profiles saved)");
+        }
+        ImGui::EndCombo();
+    }
+
+    bool hasSelection = (m_selectedProfileIndex >= 0 &&
+                         m_selectedProfileIndex < static_cast<int>(m_profileNames.size()));
+
+    if (!hasSelection) ImGui::BeginDisabled();
+    if (ImGui::Button("Apply"))
+    {
+        const std::string &name = m_profileNames[m_selectedProfileIndex];
+        if (!m_uiManager->loadStreamingProfile(name))
+        {
+            LOG_ERROR("Failed to load streaming profile: " + name);
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Delete"))
+    {
+        m_showDeleteConfirm = true;
+    }
+    if (!hasSelection) ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    if (ImGui::Button("Save as..."))
+    {
+        m_newProfileName[0] = '\0';
+        m_showSaveDialog = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Refresh"))
+    {
+        m_profilesDirty = true;
+    }
+
+    if (m_showSaveDialog) ImGui::OpenPopup("Save Streaming Profile");
+    if (ImGui::BeginPopupModal("Save Streaming Profile", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::Text("Profile name:");
+        ImGui::InputText("##streaming_profile_name", m_newProfileName, sizeof(m_newProfileName));
+
+        std::string nameStr(m_newProfileName);
+        bool exists = !nameStr.empty() && m_uiManager->streamingProfileExists(nameStr);
+        if (exists)
+        {
+            ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "A profile with this name already exists.");
+        }
+
+        if (ImGui::Button("Save", ImVec2(120, 0)))
+        {
+            if (!nameStr.empty())
+            {
+                if (m_uiManager->saveStreamingProfile(nameStr))
+                {
+                    m_profilesDirty = true;
+                    m_showSaveDialog = false;
+                    ImGui::CloseCurrentPopup();
+                }
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        {
+            m_showSaveDialog = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    if (m_showDeleteConfirm) ImGui::OpenPopup("Delete Streaming Profile");
+    if (ImGui::BeginPopupModal("Delete Streaming Profile", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        if (m_selectedProfileIndex >= 0 && m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+        {
+            ImGui::Text("Delete profile \"%s\"?", m_profileNames[m_selectedProfileIndex].c_str());
+        }
+        if (ImGui::Button("Delete", ImVec2(120, 0)))
+        {
+            if (m_selectedProfileIndex >= 0 && m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
+            {
+                m_uiManager->deleteStreamingProfile(m_profileNames[m_selectedProfileIndex]);
+                m_profilesDirty = true;
+                m_selectedProfileIndex = -1;
+            }
+            m_showDeleteConfirm = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        {
+            m_showDeleteConfirm = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
     }
 }
 

--- a/src/ui/UIConfigurationStreaming.h
+++ b/src/ui/UIConfigurationStreaming.h
@@ -22,6 +22,7 @@ private:
     UIManager *m_uiManager = nullptr;
 
     void renderStreamingStatus();
+    void renderProfiles();
     void renderBasicSettings();
     void renderCodecSettings();
     void renderBitrateSettings();
@@ -33,4 +34,14 @@ private:
     void renderH265Settings();
     void renderVP8Settings();
     void renderVP9Settings();
+
+    // Profile UI state
+    int m_selectedProfileIndex = -1;
+    std::vector<std::string> m_profileNames;
+    bool m_profilesDirty = true;
+    char m_newProfileName[128] = "";
+    bool m_showSaveDialog = false;
+    bool m_showDeleteConfirm = false;
+
+    void refreshProfiles();
 };

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -5,6 +5,7 @@
 #include "UIRecordings.h"
 #include "../recording/RecordingProfileManager.h"
 #include "../recording/RecordingSettings.h"
+#include "../streaming/StreamingProfileManager.h"
 #include "../utils/Logger.h"
 #include "../utils/Paths.h"
 #include "../utils/ShaderScanner.h"
@@ -148,6 +149,7 @@ bool UIManager::init(void *window)
     m_capturePresetsWindow = std::make_unique<UICapturePresets>(this);
     m_recordingsWindow = std::make_unique<UIRecordings>(this);
     m_recordingProfileManager = std::make_unique<RecordingProfileManager>();
+    m_streamingProfileManager = std::make_unique<StreamingProfileManager>();
     m_configWindow->setVisible(true);
     m_configWindow->setJustOpened(true);
 
@@ -3246,5 +3248,92 @@ bool UIManager::loadRecordingProfile(const std::string &name)
     triggerRecordingOutputPathChange(s.outputPath);
     triggerRecordingFilenameTemplateChange(s.filenameTemplate);
     triggerRecordingIncludeAudioChange(s.includeAudio);
+    return true;
+}
+
+// ----------------------------------------------------------------------
+// Streaming profiles
+// ----------------------------------------------------------------------
+
+namespace {
+
+StreamingSettings collectStreamingSettings(const UIManager &ui)
+{
+    StreamingSettings s;
+    s.port = ui.getStreamingPort();
+    s.width = ui.getStreamingWidth();
+    s.height = ui.getStreamingHeight();
+    s.fps = ui.getStreamingFps();
+    s.bitrate = ui.getStreamingBitrate();
+    s.audioBitrate = ui.getStreamingAudioBitrate();
+    s.videoCodec = ui.getStreamingVideoCodec();
+    s.audioCodec = ui.getStreamingAudioCodec();
+    s.h264Preset = ui.getStreamingH264Preset();
+    s.h265Preset = ui.getStreamingH265Preset();
+    s.h265Profile = ui.getStreamingH265Profile();
+    s.h265Level = ui.getStreamingH265Level();
+    s.vp8Speed = ui.getStreamingVP8Speed();
+    s.vp9Speed = ui.getStreamingVP9Speed();
+    s.maxVideoBufferSize = ui.getStreamingMaxVideoBufferSize();
+    s.maxAudioBufferSize = ui.getStreamingMaxAudioBufferSize();
+    s.maxBufferTimeSeconds = ui.getStreamingMaxBufferTimeSeconds();
+    s.avioBufferSize = ui.getStreamingAVIOBufferSize();
+    return s;
+}
+
+} // namespace
+
+std::vector<std::string> UIManager::listStreamingProfiles()
+{
+    if (!m_streamingProfileManager) return {};
+    return m_streamingProfileManager->list();
+}
+
+bool UIManager::streamingProfileExists(const std::string &name)
+{
+    if (!m_streamingProfileManager) return false;
+    return m_streamingProfileManager->exists(name);
+}
+
+bool UIManager::saveStreamingProfile(const std::string &name)
+{
+    if (!m_streamingProfileManager) return false;
+    StreamingSettings s = collectStreamingSettings(*this);
+    return m_streamingProfileManager->save(name, s);
+}
+
+bool UIManager::deleteStreamingProfile(const std::string &name)
+{
+    if (!m_streamingProfileManager) return false;
+    return m_streamingProfileManager->remove(name);
+}
+
+bool UIManager::loadStreamingProfile(const std::string &name)
+{
+    if (!m_streamingProfileManager) return false;
+    StreamingSettings s;
+    if (!m_streamingProfileManager->load(name, s)) return false;
+
+    // Apply via the existing triggerXxxChange setters so callbacks fire
+    // and the running streamer / persisted config see the update the
+    // same way they would if the user moved each control by hand.
+    triggerStreamingPortChange(s.port);
+    triggerStreamingVideoCodecChange(s.videoCodec);
+    triggerStreamingH264PresetChange(s.h264Preset);
+    triggerStreamingH265PresetChange(s.h265Preset);
+    triggerStreamingH265ProfileChange(s.h265Profile);
+    triggerStreamingH265LevelChange(s.h265Level);
+    triggerStreamingVP8SpeedChange(s.vp8Speed);
+    triggerStreamingVP9SpeedChange(s.vp9Speed);
+    triggerStreamingWidthChange(s.width);
+    triggerStreamingHeightChange(s.height);
+    triggerStreamingFpsChange(s.fps);
+    triggerStreamingBitrateChange(s.bitrate);
+    triggerStreamingAudioCodecChange(s.audioCodec);
+    triggerStreamingAudioBitrateChange(s.audioBitrate);
+    triggerStreamingMaxVideoBufferSizeChange(s.maxVideoBufferSize);
+    triggerStreamingMaxAudioBufferSizeChange(s.maxAudioBufferSize);
+    triggerStreamingMaxBufferTimeSecondsChange(s.maxBufferTimeSeconds);
+    triggerStreamingAVIOBufferSizeChange(s.avioBufferSize);
     return true;
 }

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -24,6 +24,7 @@ class UICredits;
 class UICapturePresets;
 class UIRecordings;
 class RecordingProfileManager;
+class StreamingProfileManager;
 
 class UIManager
 {
@@ -448,6 +449,15 @@ public:
     bool deleteRecordingProfile(const std::string& name);
     bool recordingProfileExists(const std::string& name);
 
+    // Streaming profiles — analogous to recording profiles, persisting
+    // the streaming configuration (codec, preset, bitrate, port, audio,
+    // buffer tuning) under $XDG_DATA_HOME/retrocapture/streaming_profiles.
+    std::vector<std::string> listStreamingProfiles();
+    bool saveStreamingProfile(const std::string& name);
+    bool loadStreamingProfile(const std::string& name);
+    bool deleteStreamingProfile(const std::string& name);
+    bool streamingProfileExists(const std::string& name);
+
     // Recording callbacks
     void setOnRecordingStartStop(std::function<void(bool)> callback) { m_onRecordingStartStop = callback; }
     void setOnRecordingWidthChanged(std::function<void(uint32_t)> callback) { m_onRecordingWidthChanged = callback; }
@@ -638,6 +648,7 @@ private:
     std::unique_ptr<class UICapturePresets> m_capturePresetsWindow;
     std::unique_ptr<class UIRecordings> m_recordingsWindow;
     std::unique_ptr<RecordingProfileManager> m_recordingProfileManager;
+    std::unique_ptr<StreamingProfileManager> m_streamingProfileManager;
     void *m_window = nullptr; // GLFWwindow* or SDL_Window*
 
     // Shader selection


### PR DESCRIPTION
Mirrors the recording profiles feature (#37) for streaming. Lets the user save the full streaming configuration (codec, x264 preset, bitrate, port, audio, buffer tuning) as named profiles and switch between them from a dropdown at the top of the Streaming panel.

Storage: $XDG_DATA_HOME/retrocapture/streaming_profiles/<name>.json on Linux, %APPDATA%\RetroCapture\data\streaming_profiles\<name>.json on Windows. Overridable via the RETROCAPTURE_STREAMING_PROFILES_DIR env.

Apply propagates through the existing `triggerStreamingXxxChange` setters, so the running streamer and the persisted config see the update the same way they would if the user had moved each control by hand.

A matching REST API lives under `/api/v1/streaming/profiles` (GET list, POST save, POST .../apply, DELETE) for future parity with the web portal (#35).