### PR TITLE
feat: shader-preserving distributed playback (closes #47)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,9 +224,13 @@ if(PLATFORM_LINUX)
     pkg_check_modules(V4L2 REQUIRED libv4l2)
 endif()
 
-# PulseAudio (Linux only)
+# PulseAudio (Linux only). pulse-simple provides the synchronous API
+# used by the remote-stream playback sink (AudioPlaybackPulse) — the
+# capture path needs only libpulse, but adding pulse-simple here keeps
+# both linkers happy when the playback code is compiled in.
 if(PLATFORM_LINUX)
     pkg_check_modules(PULSE REQUIRED libpulse)
+    pkg_check_modules(PULSE_SIMPLE REQUIRED libpulse-simple)
 endif()
 
 # OpenSSL for HTTPS support - sempre habilitado se disponível
@@ -535,7 +539,7 @@ if(PLATFORM_LINUX)
         endif()
     endif()
 
-    list(APPEND LINK_LIBS ${V4L2_LIBRARIES} ${PULSE_LIBRARIES})
+    list(APPEND LINK_LIBS ${V4L2_LIBRARIES} ${PULSE_LIBRARIES} ${PULSE_SIMPLE_LIBRARIES})
 elseif(PLATFORM_WINDOWS)
     # Windows DirectShow libraries
     list(APPEND LINK_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,10 @@ elseif(PLATFORM_MACOS)
     target_compile_definitions(retrocapture PRIVATE PLATFORM_MACOS)
 endif()
 
+# Propagar versão do projeto pro código (usado pelo endpoint /meta e afins)
+target_compile_definitions(retrocapture PRIVATE
+    RETROCAPTURE_VERSION="${PROJECT_VERSION}")
+
 # Threading
 find_package(Threads REQUIRED)
 

--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -1,0 +1,139 @@
+# Remote stream protocol
+
+This document describes the wire format between a RetroCapture **server**
+(a host running capture + shader + stream) and a RetroCapture **client**
+that wants to consume the host's stream while applying the shader **locally**
+at its own native resolution.
+
+Status: **Phase 1 — metadata endpoint only.** The `/raw` stream endpoint,
+client mode, asset bundle transport and live-update WebSocket are tracked in
+[issue #47](https://github.com/geldoronie/RetroCapture/issues/47).
+
+---
+
+## Endpoint surface
+
+| Path | Purpose | Phase |
+| --- | --- | --- |
+| `/stream` | Existing post-shader MPEG-TS stream — unchanged, consumed by VLC / mpv / ffplay / the web portal. | already shipped |
+| `/meta` | JSON snapshot of the active shader pipeline + source state. **(this document)** | Phase 1 |
+| `/raw` | Pre-shader MPEG-TS stream, encoded straight from the capture pipeline. | Phase 2 |
+| `/meta/shader-bundle?preset=<name>` | Tarball with the preset file plus every `#include`d file and referenced LUT texture. | Phase 4 |
+
+The client only needs the server's **base URL** (e.g. `http://host:8080`) —
+it discovers the endpoints by convention.
+
+---
+
+## `GET /meta`
+
+Returns a single JSON snapshot of the server's current shader-pipeline and
+source state. Content-type is `application/json`.
+
+### Response schema
+
+```jsonc
+{
+  // Bumped only when the wire format breaks compatibility. A client that
+  // doesn't recognize the value MUST refuse to connect.
+  "protocolVersion": 1,
+
+  // Server build version (matches PROJECT_VERSION in CMakeLists.txt).
+  "serverVersion": "0.6.0",
+
+  // Active shader pipeline state.
+  "shader": {
+    // Whether a preset is currently loaded and engaged.
+    "active": true,
+    // Master pipeline toggle from the UI / web portal.
+    "pipelineEnabled": true,
+    // Preset name relative to the shader root (e.g. "crt/crt-mattias.glslp").
+    // Empty when no preset is loaded.
+    "preset": "crt/crt-mattias.glslp",
+    // Opaque content hash of the preset file. Format: "<algo>:<hex>".
+    // Phase 1 uses FNV-1a 64-bit ("fnv1a64:..."), which is sufficient for
+    // cache-invalidation and not advertised as cryptographic. The client
+    // compares this against its locally-cached preset to decide whether to
+    // refetch via the shader-bundle endpoint (Phase 4).
+    "presetHash": "fnv1a64:1a2b3c4d5e6f7a8b",
+    // Current parameter values + their definitions. Empty array when no
+    // shader is active.
+    "parameters": [
+      {
+        "name":         "CURVATURE",
+        "value":        0.05,
+        "defaultValue": 0.04,
+        "min":          0.0,
+        "max":          0.10,
+        "step":         0.01
+      }
+    ]
+  },
+
+  // Source the server is capturing from. The client will configure its
+  // local viewer to match these dimensions and frame rate.
+  "source": {
+    // One of "none", "v4l2", "directshow".
+    "type":   "v4l2",
+    "width":  640,
+    "height": 480,
+    "fps":    60
+  },
+
+  // Whether /stream and /raw are currently producing frames.
+  "streaming": {
+    "active": true,
+    // Convenience URL for /stream — already adjusted for proxy prefixes.
+    "url":    "http://host:8080/stream"
+  }
+}
+```
+
+### Status codes
+
+- `200 OK` — snapshot returned.
+- `500 Internal Server Error` — server is not fully initialized (e.g. the
+  capture pipeline has not been brought up yet). Body contains a JSON
+  `{ "error": "..." }`.
+
+### Caching
+
+Responses MUST NOT be cached by the client. Phase 6 will add a WebSocket
+upgrade on this same path so the client receives parameter / preset
+deltas without polling; until then the client polls on a short interval
+(suggested: 1 s during steady state).
+
+---
+
+## Versioning
+
+The wire format is versioned via `protocolVersion`. Breaking changes
+bump the integer; additive changes (new optional fields) keep it stable.
+
+| protocolVersion | Notes |
+| --- | --- |
+| 1 | Initial Phase 1 snapshot: `shader`, `source`, `streaming` blocks. |
+
+---
+
+## Example
+
+```console
+$ curl -s http://localhost:8080/meta | jq .
+{
+  "protocolVersion": 1,
+  "serverVersion": "0.6.0",
+  "shader": {
+    "active": true,
+    "pipelineEnabled": true,
+    "preset": "crt/crt-mattias.glslp",
+    "presetHash": "fnv1a64:0123456789abcdef",
+    "parameters": [
+      { "name": "CURVATURE",  "value": 0.05, "defaultValue": 0.04, "min": 0.0, "max": 0.10, "step": 0.01 },
+      { "name": "SCANSPEED",  "value": 1.00, "defaultValue": 1.00, "min": 0.0, "max": 5.00, "step": 0.10 }
+    ]
+  },
+  "source":    { "type": "v4l2", "width": 640, "height": 480, "fps": 60 },
+  "streaming": { "active": true, "url": "http://localhost:8080/stream" }
+}
+```

--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -5,9 +5,9 @@ This document describes the wire format between a RetroCapture **server**
 that wants to consume the host's stream while applying the shader **locally**
 at its own native resolution.
 
-Status: **Phase 1 — metadata endpoint only.** The `/raw` stream endpoint,
-client mode, asset bundle transport and live-update WebSocket are tracked in
-[issue #47](https://github.com/geldoronie/RetroCapture/issues/47).
+Status: **Phases 1–2 landed.** Client-side consumption (remote source mode,
+read-only UI), asset bundle transport and live-update WebSocket are tracked
+in [issue #47](https://github.com/geldoronie/RetroCapture/issues/47).
 
 ---
 
@@ -15,9 +15,9 @@ client mode, asset bundle transport and live-update WebSocket are tracked in
 
 | Path | Purpose | Phase |
 | --- | --- | --- |
-| `/stream` | Existing post-shader MPEG-TS stream — unchanged, consumed by VLC / mpv / ffplay / the web portal. | already shipped |
-| `/meta` | JSON snapshot of the active shader pipeline + source state. **(this document)** | Phase 1 |
-| `/raw` | Pre-shader MPEG-TS stream, encoded straight from the capture pipeline. | Phase 2 |
+| `/stream` | Existing post-shader MPEG-TS stream — unchanged, consumed by VLC / mpv / ffplay / the web portal. May or may not have a shader applied, depending on the host's per-pipeline override. | already shipped |
+| `/meta` | JSON snapshot of the active shader pipeline + source state. | Phase 1 |
+| `/raw` | **Always** pre-shader MPEG-TS stream, encoded from the same capture pipeline as `/stream` but tapped before the shader pass. | Phase 2 |
 | `/meta/shader-bundle?preset=<name>` | Tarball with the preset file plus every `#include`d file and referenced LUT texture. | Phase 4 |
 
 The client only needs the server's **base URL** (e.g. `http://host:8080`) —
@@ -124,6 +124,39 @@ Responses MUST NOT be cached by the client. Phase 6 will add a WebSocket
 upgrade on this same path so the client receives parameter / preset
 deltas without polling; until then the client polls on a short interval
 (suggested: 1 s during steady state).
+
+---
+
+---
+
+## `GET /raw`
+
+Identical to `/stream` in wire format (MPEG-TS over HTTP, `Content-Type:
+video/mp2t`) but the video frames are tapped from the capture pipeline
+**before** the shader pass. Audio is the same as `/stream`. Codec config
+(bitrate, codec, preset) is shared with `/stream` — running a `/raw`
+client at a different bitrate than the host's `/stream` is not supported
+in Phase 2.
+
+Properties:
+
+- The host's per-pipeline shader-bypass toggle ("Apply shader pipeline"
+  in the UI) flips `/stream`'s contents but **does not affect `/raw`** —
+  `/raw` is always pre-shader by contract.
+- The raw encoder is **lazy**: when no clients are connected to `/raw`,
+  no pre-shader frames are pushed into its pipeline. The CPU cost of
+  the second encoder only materializes while a remote client is
+  actively consuming.
+- A single MPEG-TS muxer state per output — a brand-new `/raw` client
+  starts receiving packets from the next keyframe boundary.
+
+```console
+$ ffplay http://host:8080/raw     # raw source feed, no shader
+$ ffplay http://host:8080/stream  # current /stream contents
+```
+
+A future RetroCapture client (Phase 3+) consumes `/raw` and applies the
+shader described in `/meta` locally at its own native render resolution.
 
 ---
 

--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -70,14 +70,50 @@ source state. Content-type is `application/json`.
     ]
   },
 
-  // Source the server is capturing from. The client will configure its
-  // local viewer to match these dimensions and frame rate.
+  // Source the server is capturing from. The client mirrors dimensions,
+  // frame rate, overscan and hardware controls; display-side preferences
+  // (fullscreen / monitor index) are NOT mirrored — those are client-local.
   "source": {
     // One of "none", "v4l2", "directshow".
     "type":   "v4l2",
+    // V4L2 path (e.g. "/dev/video0") or DirectShow device name.
+    // Empty when type == "none".
+    "device": "/dev/video0",
     "width":  640,
     "height": 480,
-    "fps":    60
+    "fps":    60,
+    // Source-side overscan correction (percent on each axis, plus the
+    // X/Y lock toggle from the UI).
+    "overscan": { "x": 0.0, "y": 0.0, "locked": true },
+    // Hardware controls exposed by the active source. Source-type-aware:
+    //   - "v4l2"       — populated from V4L2 ioctls.
+    //   - "directshow" — empty for now; a unified read-only DirectShow
+    //                    controls getter is tracked alongside Phase 2.
+    //   - "none"       — empty.
+    "controls": [
+      {
+        "name":      "brightness",
+        "value":     50,
+        "min":       -100,
+        "max":       100,
+        "step":      1,
+        "available": true
+      }
+    ]
+  },
+
+  // Software image processing applied after capture, before shader. The
+  // client mirrors these because they affect the look of the source frame.
+  "image": {
+    // Multiplicative software brightness / contrast (1.0 = neutral).
+    "brightness":     1.0,
+    "contrast":       1.0,
+    // Whether the renderer preserves the source aspect ratio.
+    "maintainAspect": true,
+    // Output resolution applied after shader, before drawing to window.
+    // 0/0 means "match shader output".
+    "outputWidth":    0,
+    "outputHeight":   0
   },
 
   // Whether /stream and /raw are currently producing frames.
@@ -112,7 +148,7 @@ bump the integer; additive changes (new optional fields) keep it stable.
 
 | protocolVersion | Notes |
 | --- | --- |
-| 1 | Initial Phase 1 snapshot: `shader`, `source`, `streaming` blocks. |
+| 1 | Initial Phase 1 snapshot. Blocks: `shader`, `source` (type, device, dims, overscan, controls), `image`, `streaming`. |
 
 ---
 
@@ -127,13 +163,31 @@ $ curl -s http://localhost:8080/meta | jq .
     "active": true,
     "pipelineEnabled": true,
     "preset": "crt/crt-mattias.glslp",
-    "presetHash": "fnv1a64:0123456789abcdef",
+    "presetHash": "fnv1a64:de5f853079d66290",
     "parameters": [
-      { "name": "CURVATURE",  "value": 0.05, "defaultValue": 0.04, "min": 0.0, "max": 0.10, "step": 0.01 },
-      { "name": "SCANSPEED",  "value": 1.00, "defaultValue": 1.00, "min": 0.0, "max": 5.00, "step": 0.10 }
+      { "name": "CURVATURE", "value": 0.5, "defaultValue": 0.5, "min": 0.0, "max": 1.0,  "step": 0.05 },
+      { "name": "SCANSPEED", "value": 1.0, "defaultValue": 1.0, "min": 0.0, "max": 10.0, "step": 0.5  }
     ]
   },
-  "source":    { "type": "v4l2", "width": 640, "height": 480, "fps": 60 },
+  "source": {
+    "type":     "v4l2",
+    "device":   "/dev/video0",
+    "width":    640,
+    "height":   480,
+    "fps":      60,
+    "overscan": { "x": 0.0, "y": 0.0, "locked": true },
+    "controls": [
+      { "name": "brightness", "value": 50, "min": -100, "max": 100, "step": 1, "available": true },
+      { "name": "contrast",   "value": 40, "min": -100, "max": 100, "step": 1, "available": true }
+    ]
+  },
+  "image": {
+    "brightness":     1.0,
+    "contrast":       1.0,
+    "maintainAspect": true,
+    "outputWidth":    0,
+    "outputHeight":   0
+  },
   "streaming": { "active": true, "url": "http://localhost:8080/stream" }
 }
 ```

--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -70,40 +70,26 @@ source state. Content-type is `application/json`.
     ]
   },
 
-  // Source the server is capturing from. The client mirrors dimensions,
-  // frame rate, overscan and hardware controls; display-side preferences
-  // (fullscreen / monitor index) are NOT mirrored — those are client-local.
+  // Source-frame configuration as it will arrive on /raw.
+  //
+  // The client's "source" is always the remote stream itself — the server's
+  // capture-chain specifics (V4L2 vs. DirectShow, /dev path, hardware ioctl
+  // values) are intentionally NOT carried here, since the client cannot act
+  // on them. What IS carried is the configuration that describes how each
+  // frame is shaped before reaching the wire.
   "source": {
-    // One of "none", "v4l2", "directshow".
-    "type":   "v4l2",
-    // V4L2 path (e.g. "/dev/video0") or DirectShow device name.
-    // Empty when type == "none".
-    "device": "/dev/video0",
     "width":  640,
     "height": 480,
     "fps":    60,
     // Source-side overscan correction (percent on each axis, plus the
     // X/Y lock toggle from the UI).
-    "overscan": { "x": 0.0, "y": 0.0, "locked": true },
-    // Hardware controls exposed by the active source. Source-type-aware:
-    //   - "v4l2"       — populated from V4L2 ioctls.
-    //   - "directshow" — empty for now; a unified read-only DirectShow
-    //                    controls getter is tracked alongside Phase 2.
-    //   - "none"       — empty.
-    "controls": [
-      {
-        "name":      "brightness",
-        "value":     50,
-        "min":       -100,
-        "max":       100,
-        "step":      1,
-        "available": true
-      }
-    ]
+    "overscan": { "x": 0.0, "y": 0.0, "locked": true }
   },
 
-  // Software image processing applied after capture, before shader. The
-  // client mirrors these because they affect the look of the source frame.
+  // Image-processing settings applied between capture and shader. Carried
+  // for client-side display ("this is how the server is configured") and,
+  // depending on where /raw is tapped in Phase 2, possibly for the client
+  // to reproduce locally as well.
   "image": {
     // Multiplicative software brightness / contrast (1.0 = neutral).
     "brightness":     1.0,
@@ -148,7 +134,7 @@ bump the integer; additive changes (new optional fields) keep it stable.
 
 | protocolVersion | Notes |
 | --- | --- |
-| 1 | Initial Phase 1 snapshot. Blocks: `shader`, `source` (type, device, dims, overscan, controls), `image`, `streaming`. |
+| 1 | Initial Phase 1 snapshot. Blocks: `shader`, `source` (dims, fps, overscan), `image`, `streaming`. |
 
 ---
 
@@ -170,16 +156,10 @@ $ curl -s http://localhost:8080/meta | jq .
     ]
   },
   "source": {
-    "type":     "v4l2",
-    "device":   "/dev/video0",
     "width":    640,
     "height":   480,
     "fps":      60,
-    "overscan": { "x": 0.0, "y": 0.0, "locked": true },
-    "controls": [
-      { "name": "brightness", "value": 50, "min": -100, "max": 100, "step": 1, "available": true },
-      { "name": "contrast",   "value": 40, "min": -100, "max": 100, "step": 1, "available": true }
-    ]
+    "overscan": { "x": 0.0, "y": 0.0, "locked": true }
   },
   "image": {
     "brightness":     1.0,

--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -5,9 +5,8 @@ This document describes the wire format between a RetroCapture **server**
 that wants to consume the host's stream while applying the shader **locally**
 at its own native resolution.
 
-Status: **Phases 1–2 landed.** Client-side consumption (remote source mode,
-read-only UI), asset bundle transport and live-update WebSocket are tracked
-in [issue #47](https://github.com/geldoronie/RetroCapture/issues/47).
+Status: **Phases 1–6 landed.** Asset bundle transport is tracked in
+[issue #47](https://github.com/geldoronie/RetroCapture/issues/47).
 
 ---
 
@@ -120,10 +119,28 @@ source state. Content-type is `application/json`.
 
 ### Caching
 
-Responses MUST NOT be cached by the client. Phase 6 will add a WebSocket
-upgrade on this same path so the client receives parameter / preset
-deltas without polling; until then the client polls on a short interval
-(suggested: 1 s during steady state).
+Responses MUST NOT be cached by the client.
+
+### Live updates via Server-Sent Events (Phase 6)
+
+The same `/meta` path accepts an SSE upgrade. When the client sends:
+
+```
+GET /meta HTTP/1.1
+Accept: text/event-stream
+```
+
+…the server responds with `Content-Type: text/event-stream` and keeps
+the connection open, pushing a `data: {snapshot}\n\n` event whenever
+the snapshot changes. The first event sent is the current snapshot
+(equivalent to the regular `GET /meta` body). A `: keepalive\n\n`
+comment is sent every 30 s while idle.
+
+Clients that accept `application/json` (no `Accept: text/event-stream`)
+continue to get the one-shot snapshot — no breaking change for older
+consumers. The reference client (`RemoteMetaSync` in this repo) tries
+SSE first and transparently falls back to short-poll if the server
+doesn't advertise `text/event-stream`.
 
 ---
 

--- a/src/audio/AudioPlaybackPulse.cpp
+++ b/src/audio/AudioPlaybackPulse.cpp
@@ -1,4 +1,7 @@
 #include "AudioPlaybackPulse.h"
+
+#ifdef __linux__
+
 #include "../utils/Logger.h"
 
 #include <pulse/simple.h>
@@ -144,3 +147,5 @@ void AudioPlaybackPulse::flush()
     m_lastSubmittedPtsUs = 0;
     m_anySubmitted       = false;
 }
+
+#endif // __linux__

--- a/src/audio/AudioPlaybackPulse.cpp
+++ b/src/audio/AudioPlaybackPulse.cpp
@@ -1,0 +1,146 @@
+#include "AudioPlaybackPulse.h"
+#include "../utils/Logger.h"
+
+#include <pulse/simple.h>
+#include <pulse/error.h>
+
+AudioPlaybackPulse::AudioPlaybackPulse() = default;
+
+AudioPlaybackPulse::~AudioPlaybackPulse()
+{
+    close();
+}
+
+bool AudioPlaybackPulse::open(uint32_t sampleRate, uint32_t channels)
+{
+    if (m_stream)
+    {
+        close();
+    }
+    if (sampleRate == 0 || channels == 0 || channels > 8)
+    {
+        LOG_ERROR("AudioPlaybackPulse::open — invalid format");
+        return false;
+    }
+
+    pa_sample_spec spec;
+    spec.format   = PA_SAMPLE_FLOAT32LE;
+    spec.rate     = sampleRate;
+    spec.channels = static_cast<uint8_t>(channels);
+
+    // Tight buffering: small target length keeps latency low so video
+    // gating against the audio clock doesn't have to compensate for a
+    // huge hardware buffer. 50 ms is comfortable above network jitter
+    // without making A/V sync look perceptibly behind.
+    pa_buffer_attr attr;
+    attr.maxlength = static_cast<uint32_t>(-1);
+    attr.tlength   = pa_usec_to_bytes(50 * 1000, &spec);
+    attr.prebuf    = static_cast<uint32_t>(-1);
+    attr.minreq    = static_cast<uint32_t>(-1);
+    attr.fragsize  = static_cast<uint32_t>(-1);
+
+    int err = 0;
+    m_stream = pa_simple_new(
+        nullptr,                  // default server
+        "RetroCapture",
+        PA_STREAM_PLAYBACK,
+        nullptr,                  // default device
+        "Remote stream",
+        &spec,
+        nullptr,                  // default channel map
+        &attr,
+        &err);
+    if (!m_stream)
+    {
+        LOG_ERROR(std::string("AudioPlaybackPulse: pa_simple_new failed — ") + pa_strerror(err));
+        return false;
+    }
+
+    m_sampleRate    = sampleRate;
+    m_channels      = channels;
+    {
+        std::lock_guard<std::mutex> lock(m_clockMutex);
+        m_lastSubmittedPtsUs = 0;
+        m_anySubmitted       = false;
+    }
+    LOG_INFO("AudioPlaybackPulse: opened " + std::to_string(sampleRate) +
+             " Hz x " + std::to_string(channels) + " ch");
+    return true;
+}
+
+void AudioPlaybackPulse::close()
+{
+    if (m_stream)
+    {
+        // Best-effort drain so the user doesn't hear a click on
+        // disconnect. Ignored on error — we're tearing down anyway.
+        int err = 0;
+        pa_simple_drain(m_stream, &err);
+        pa_simple_free(m_stream);
+        m_stream = nullptr;
+    }
+    m_sampleRate = 0;
+    m_channels   = 0;
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    m_lastSubmittedPtsUs = 0;
+    m_anySubmitted       = false;
+}
+
+size_t AudioPlaybackPulse::submit(const float *interleaved,
+                                  size_t sampleCount,
+                                  int64_t firstPtsUs)
+{
+    if (!m_stream || !interleaved || sampleCount == 0) return 0;
+
+    const size_t bytes = sampleCount * m_channels * sizeof(float);
+    int err = 0;
+    if (pa_simple_write(m_stream, interleaved, bytes, &err) < 0)
+    {
+        static int logCount = 0;
+        if (logCount++ < 3)
+        {
+            LOG_WARN(std::string("AudioPlaybackPulse: pa_simple_write failed — ") + pa_strerror(err));
+        }
+        return 0;
+    }
+
+    // Advance the playback clock: the END of this submission is at
+    // firstPtsUs + duration. getClockUs returns the END minus the
+    // current hardware latency, which approximates 'PTS being heard
+    // right now'.
+    const int64_t durationUs = (static_cast<int64_t>(sampleCount) * 1'000'000LL) /
+                                static_cast<int64_t>(m_sampleRate);
+    {
+        std::lock_guard<std::mutex> lock(m_clockMutex);
+        m_lastSubmittedPtsUs = firstPtsUs + durationUs;
+        m_anySubmitted       = true;
+    }
+    return sampleCount;
+}
+
+int64_t AudioPlaybackPulse::getClockUs() const
+{
+    if (!m_stream) return 0;
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    if (!m_anySubmitted) return 0;
+
+    int err = 0;
+    pa_usec_t latency = pa_simple_get_latency(m_stream, &err);
+    if (err != 0)
+    {
+        latency = 0;
+    }
+    int64_t clock = m_lastSubmittedPtsUs - static_cast<int64_t>(latency);
+    if (clock < 0) clock = 0;
+    return clock;
+}
+
+void AudioPlaybackPulse::flush()
+{
+    if (!m_stream) return;
+    int err = 0;
+    pa_simple_flush(m_stream, &err);
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    m_lastSubmittedPtsUs = 0;
+    m_anySubmitted       = false;
+}

--- a/src/audio/AudioPlaybackPulse.h
+++ b/src/audio/AudioPlaybackPulse.h
@@ -2,6 +2,8 @@
 
 #include "IAudioPlayback.h"
 
+#ifdef __linux__
+
 #include <atomic>
 #include <cstdint>
 #include <mutex>
@@ -48,3 +50,5 @@ private:
     int64_t            m_lastSubmittedPtsUs = 0;
     bool               m_anySubmitted       = false;
 };
+
+#endif // __linux__

--- a/src/audio/AudioPlaybackPulse.h
+++ b/src/audio/AudioPlaybackPulse.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "IAudioPlayback.h"
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+struct pa_simple;
+
+/**
+ * PulseAudio playback sink implemented via the synchronous pa_simple
+ * API. Each submit() writes directly to the daemon; the daemon
+ * buffers ~the configured tlength worth of audio (~50 ms here) and
+ * blocks the writer if the buffer fills, which gives us natural
+ * back-pressure without a dedicated playback thread.
+ *
+ * The video path queries getClockUs() to discover what timestamp the
+ * speakers are currently emitting, which becomes the A/V master clock.
+ * We track the PTS of the most recently submitted sample and subtract
+ * pa_simple_get_latency() to get the playing-now timestamp.
+ */
+class AudioPlaybackPulse : public IAudioPlayback
+{
+public:
+    AudioPlaybackPulse();
+    ~AudioPlaybackPulse() override;
+
+    bool open(uint32_t sampleRate, uint32_t channels) override;
+    void close() override;
+    bool isOpen() const override { return m_stream != nullptr; }
+
+    size_t submit(const float *interleaved,
+                  size_t sampleCount,
+                  int64_t firstPtsUs) override;
+
+    int64_t getClockUs() const override;
+    void    flush() override;
+
+private:
+    pa_simple        *m_stream      = nullptr;
+    uint32_t          m_sampleRate  = 0;
+    uint32_t          m_channels    = 0;
+    // Last PTS we handed to pa_simple_write, in stream-origin-relative
+    // microseconds. Updated under m_clockMutex so the video thread can
+    // sample it consistently.
+    mutable std::mutex m_clockMutex;
+    int64_t            m_lastSubmittedPtsUs = 0;
+    bool               m_anySubmitted       = false;
+};

--- a/src/audio/AudioPlaybackWASAPI.cpp
+++ b/src/audio/AudioPlaybackWASAPI.cpp
@@ -1,0 +1,264 @@
+#include "AudioPlaybackWASAPI.h"
+
+#ifdef _WIN32
+
+#include "../utils/Logger.h"
+
+#include <windows.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <avrt.h>
+#include <chrono>
+#include <cstring>
+
+#pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "avrt.lib")
+
+namespace
+{
+    constexpr REFERENCE_TIME kBufferDurationHns = 50 * 10000; // 50 ms in 100-ns units
+}
+
+AudioPlaybackWASAPI::AudioPlaybackWASAPI() = default;
+
+AudioPlaybackWASAPI::~AudioPlaybackWASAPI()
+{
+    close();
+}
+
+bool AudioPlaybackWASAPI::open(uint32_t sampleRate, uint32_t channels)
+{
+    if (m_audioClient) close();
+    if (sampleRate == 0 || channels == 0 || channels > 8) return false;
+
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    // S_FALSE = already initialised on this thread; treat as success.
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: CoInitializeEx failed");
+        return false;
+    }
+
+    hr = CoCreateInstance(__uuidof(MMDeviceEnumerator),
+                          nullptr,
+                          CLSCTX_ALL,
+                          __uuidof(IMMDeviceEnumerator),
+                          reinterpret_cast<void **>(&m_enumerator));
+    if (FAILED(hr) || !m_enumerator)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: MMDeviceEnumerator failed");
+        return false;
+    }
+
+    hr = m_enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &m_device);
+    if (FAILED(hr) || !m_device)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: GetDefaultAudioEndpoint failed");
+        return false;
+    }
+
+    hr = m_device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                            reinterpret_cast<void **>(&m_audioClient));
+    if (FAILED(hr) || !m_audioClient)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: IAudioClient activate failed");
+        return false;
+    }
+
+    WAVEFORMATEX fmt = {};
+    fmt.wFormatTag      = WAVE_FORMAT_IEEE_FLOAT;
+    fmt.nChannels       = static_cast<WORD>(channels);
+    fmt.nSamplesPerSec  = sampleRate;
+    fmt.wBitsPerSample  = 32;
+    fmt.nBlockAlign     = static_cast<WORD>((fmt.wBitsPerSample / 8) * fmt.nChannels);
+    fmt.nAvgBytesPerSec = fmt.nSamplesPerSec * fmt.nBlockAlign;
+    fmt.cbSize          = 0;
+
+    hr = m_audioClient->Initialize(
+        AUDCLNT_SHAREMODE_SHARED,
+        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+        kBufferDurationHns,
+        0,
+        &fmt,
+        nullptr);
+    if (FAILED(hr))
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: IAudioClient::Initialize failed");
+        return false;
+    }
+
+    m_eventHandle = CreateEventA(nullptr, FALSE, FALSE, nullptr);
+    if (!m_eventHandle)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: CreateEvent failed");
+        return false;
+    }
+    m_audioClient->SetEventHandle(static_cast<HANDLE>(m_eventHandle));
+
+    hr = m_audioClient->GetBufferSize(&m_bufferFrameCount);
+    if (FAILED(hr))
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: GetBufferSize failed");
+        return false;
+    }
+    hr = m_audioClient->GetService(__uuidof(IAudioRenderClient),
+                                    reinterpret_cast<void **>(&m_renderClient));
+    if (FAILED(hr) || !m_renderClient)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: GetService(IAudioRenderClient) failed");
+        return false;
+    }
+    hr = m_audioClient->GetService(__uuidof(IAudioClock),
+                                    reinterpret_cast<void **>(&m_audioClock));
+    if (FAILED(hr) || !m_audioClock)
+    {
+        LOG_ERROR("AudioPlaybackWASAPI: GetService(IAudioClock) failed");
+        return false;
+    }
+
+    m_sampleRate = sampleRate;
+    m_channels   = channels;
+
+    // Prime the buffer with silence so Start() doesn't drop into
+    // underrun before the decoder catches up.
+    BYTE *priming = nullptr;
+    if (SUCCEEDED(m_renderClient->GetBuffer(m_bufferFrameCount, &priming)))
+    {
+        m_renderClient->ReleaseBuffer(m_bufferFrameCount, AUDCLNT_BUFFERFLAGS_SILENT);
+    }
+
+    m_audioClient->Start();
+
+    m_running.store(true);
+    m_renderThread = std::thread(&AudioPlaybackWASAPI::renderThreadFn, this);
+    LOG_INFO("AudioPlaybackWASAPI: opened " + std::to_string(sampleRate) +
+             " Hz x " + std::to_string(channels) + " ch");
+    return true;
+}
+
+void AudioPlaybackWASAPI::close()
+{
+    m_running.store(false);
+    if (m_eventHandle)
+    {
+        SetEvent(static_cast<HANDLE>(m_eventHandle));
+    }
+    if (m_renderThread.joinable()) m_renderThread.join();
+
+    if (m_audioClient) m_audioClient->Stop();
+
+    if (m_audioClock)   { m_audioClock->Release();   m_audioClock   = nullptr; }
+    if (m_renderClient) { m_renderClient->Release(); m_renderClient = nullptr; }
+    if (m_audioClient)  { m_audioClient->Release();  m_audioClient  = nullptr; }
+    if (m_device)       { m_device->Release();       m_device       = nullptr; }
+    if (m_enumerator)   { m_enumerator->Release();   m_enumerator   = nullptr; }
+    if (m_eventHandle)  { CloseHandle(static_cast<HANDLE>(m_eventHandle)); m_eventHandle = nullptr; }
+
+    m_sampleRate = m_channels = m_bufferFrameCount = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_queue.clear();
+    }
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    m_submittedFrames     = 0;
+    m_firstSubmittedPtsUs = 0;
+    m_anySubmitted        = false;
+}
+
+size_t AudioPlaybackWASAPI::submit(const float *interleaved,
+                                   size_t sampleCount,
+                                   int64_t firstPtsUs)
+{
+    if (!m_audioClient || !interleaved || sampleCount == 0) return 0;
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        const size_t floats = sampleCount * m_channels;
+        m_queue.insert(m_queue.end(), interleaved, interleaved + floats);
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_clockMutex);
+        if (!m_anySubmitted)
+        {
+            m_firstSubmittedPtsUs = firstPtsUs;
+            m_anySubmitted        = true;
+        }
+        m_submittedFrames += sampleCount;
+    }
+    return sampleCount;
+}
+
+int64_t AudioPlaybackWASAPI::getClockUs() const
+{
+    if (!m_audioClock) return 0;
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    if (!m_anySubmitted) return 0;
+
+    UINT64 position = 0, frequency = 0;
+    HRESULT hr1 = m_audioClock->GetPosition(&position, nullptr);
+    HRESULT hr2 = m_audioClock->GetFrequency(&frequency);
+    if (FAILED(hr1) || FAILED(hr2) || frequency == 0) return m_firstSubmittedPtsUs;
+
+    // position / frequency = seconds played since the stream started.
+    const int64_t playedUs = static_cast<int64_t>((position * 1'000'000ULL) / frequency);
+    return m_firstSubmittedPtsUs + playedUs;
+}
+
+void AudioPlaybackWASAPI::flush()
+{
+    if (!m_audioClient) return;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_queue.clear();
+    }
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    m_submittedFrames     = 0;
+    m_firstSubmittedPtsUs = 0;
+    m_anySubmitted        = false;
+}
+
+void AudioPlaybackWASAPI::renderThreadFn()
+{
+    // Bump priority so we don't underrun under heavy CPU load.
+    DWORD taskIndex = 0;
+    HANDLE mmHandle = AvSetMmThreadCharacteristicsA("Pro Audio", &taskIndex);
+
+    while (m_running.load())
+    {
+        DWORD wait = WaitForSingleObject(static_cast<HANDLE>(m_eventHandle), 100);
+        if (!m_running.load()) break;
+        if (wait != WAIT_OBJECT_0) continue;
+
+        UINT32 padding = 0;
+        if (FAILED(m_audioClient->GetCurrentPadding(&padding))) continue;
+        const UINT32 framesAvail = m_bufferFrameCount - padding;
+        if (framesAvail == 0) continue;
+
+        BYTE *dst = nullptr;
+        if (FAILED(m_renderClient->GetBuffer(framesAvail, &dst))) continue;
+
+        size_t floatsNeeded = static_cast<size_t>(framesAvail) * m_channels;
+        size_t floatsCopied = 0;
+        {
+            std::lock_guard<std::mutex> lock(m_queueMutex);
+            floatsCopied = std::min(floatsNeeded, m_queue.size());
+            if (floatsCopied > 0)
+            {
+                std::memcpy(dst, m_queue.data(), floatsCopied * sizeof(float));
+                m_queue.erase(m_queue.begin(), m_queue.begin() + floatsCopied);
+            }
+        }
+        // Pad with silence if the queue ran short — keeps the hardware
+        // happy without a glitch flag the user can hear.
+        if (floatsCopied < floatsNeeded)
+        {
+            std::memset(dst + floatsCopied * sizeof(float), 0,
+                        (floatsNeeded - floatsCopied) * sizeof(float));
+        }
+        m_renderClient->ReleaseBuffer(framesAvail, 0);
+    }
+
+    if (mmHandle) AvRevertMmThreadCharacteristics(mmHandle);
+}
+
+#endif // _WIN32

--- a/src/audio/AudioPlaybackWASAPI.cpp
+++ b/src/audio/AudioPlaybackWASAPI.cpp
@@ -14,6 +14,19 @@
 #pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "avrt.lib")
 
+// The MXE / older mingw-w64 audioclient.h ships with some
+// AUDCLNT_STREAMFLAGS_* constants missing. Their bit values are
+// stable across SDK versions (defined by the Windows API contract),
+// so define them locally when absent. With these flags WASAPI handles
+// rate / channel-count conversion for us in shared mode — without
+// them we'd have to match the device's mix format exactly.
+#ifndef AUDCLNT_STREAMFLAGS_EVENTCALLBACK
+#define AUDCLNT_STREAMFLAGS_EVENTCALLBACK   0x00040000
+#endif
+#ifndef AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
+#define AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM  0x80000000
+#endif
+
 namespace
 {
     constexpr REFERENCE_TIME kBufferDurationHns = 50 * 10000; // 50 ms in 100-ns units
@@ -74,9 +87,19 @@ bool AudioPlaybackWASAPI::open(uint32_t sampleRate, uint32_t channels)
     fmt.nAvgBytesPerSec = fmt.nSamplesPerSec * fmt.nBlockAlign;
     fmt.cbSize          = 0;
 
+    // AUTOCONVERTPCM lets WASAPI insert its own resampler between us
+    // and the device's mix format, so we can submit at whatever rate
+    // the AAC stream uses without matching the OS-selected default.
+    // SRC_DEFAULT_QUALITY would tune the resampler but isn't defined
+    // by the older mingw-w64 headers in the MXE toolchain — the
+    // default quality is fine for streaming use anyway.
+    DWORD streamFlags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM;
+#ifdef AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY
+    streamFlags |= AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+#endif
     hr = m_audioClient->Initialize(
         AUDCLNT_SHAREMODE_SHARED,
-        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+        streamFlags,
         kBufferDurationHns,
         0,
         &fmt,

--- a/src/audio/AudioPlaybackWASAPI.h
+++ b/src/audio/AudioPlaybackWASAPI.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "IAudioPlayback.h"
+
+#ifdef _WIN32
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+struct IMMDevice;
+struct IMMDeviceEnumerator;
+struct IAudioClient;
+struct IAudioRenderClient;
+struct IAudioClock;
+
+/**
+ * Windows / WASAPI render sink. We open a shared-mode rendering
+ * stream against the default playback endpoint with the format the
+ * caller asks for (sample rate / channel count of the incoming /raw
+ * audio); WASAPI handles resampling to the device mix format
+ * automatically in shared mode.
+ *
+ * A background thread services the WASAPI event handle and drains
+ * our intermediate float-PCM queue into the IAudioRenderClient. The
+ * decode-side submit() pushes onto the queue without blocking —
+ * critical because the video decode loop sits in av_read_frame the
+ * rest of the time and can't afford an audio-side stall.
+ *
+ * getClockUs() reads IAudioClock::GetPosition() to find out how many
+ * device frames have actually played, then subtracts that from the
+ * total submitted to derive the timestamp currently emerging from
+ * the speakers (the master A/V clock).
+ */
+class AudioPlaybackWASAPI : public IAudioPlayback
+{
+public:
+    AudioPlaybackWASAPI();
+    ~AudioPlaybackWASAPI() override;
+
+    bool open(uint32_t sampleRate, uint32_t channels) override;
+    void close() override;
+    bool isOpen() const override { return m_audioClient != nullptr; }
+
+    size_t submit(const float *interleaved,
+                  size_t sampleCount,
+                  int64_t firstPtsUs) override;
+
+    int64_t getClockUs() const override;
+    void    flush() override;
+
+private:
+    void renderThreadFn();
+
+    IMMDeviceEnumerator *m_enumerator   = nullptr;
+    IMMDevice           *m_device       = nullptr;
+    IAudioClient        *m_audioClient  = nullptr;
+    IAudioRenderClient  *m_renderClient = nullptr;
+    IAudioClock         *m_audioClock   = nullptr;
+    void                *m_eventHandle  = nullptr; // HANDLE
+
+    uint32_t m_sampleRate = 0;
+    uint32_t m_channels   = 0;
+    uint32_t m_bufferFrameCount = 0;
+
+    // Producer/consumer queue between submit() and the render thread.
+    // Float-interleaved; lengths in *frames* (not floats).
+    mutable std::mutex   m_queueMutex;
+    std::vector<float>   m_queue;            // big circular-ish vector, drained from the front
+    std::atomic<bool>    m_running{false};
+    std::thread          m_renderThread;
+
+    // Clock tracking: 'submitted frames' counts everything we've
+    // queued; 'firstQueuedPtsUs' is the PTS of the first frame still
+    // in the queue. Combined with IAudioClock's played-frames count
+    // they let us compute the PTS currently at the speakers.
+    mutable std::mutex m_clockMutex;
+    uint64_t           m_submittedFrames    = 0;
+    int64_t            m_firstSubmittedPtsUs = 0;
+    bool               m_anySubmitted       = false;
+};
+
+#endif // _WIN32

--- a/src/audio/IAudioPlayback.h
+++ b/src/audio/IAudioPlayback.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * IAudioPlayback — abstract sink for the remote-stream audio path.
+ *
+ * Owned and driven by VideoCaptureRemote: the decode loop pulls audio
+ * packets out of the MPEG-TS demuxer, decodes them into interleaved
+ * float32 PCM, and hands the samples here via submit(). The platform
+ * impl writes them to a system sink (PulseAudio on Linux, WASAPI on
+ * Windows).
+ *
+ * The implementation is responsible for buffering. submit() is
+ * non-blocking and returns the number of samples accepted (may be less
+ * than requested if the buffer is full — caller decides whether to
+ * drop or retry).
+ *
+ * Audio is the A/V master clock for the client: getClockUs() returns
+ * the PTS (microseconds, stream-origin-relative) of the sample that's
+ * currently being played out of the hardware, which the video render
+ * gates against to stay in sync.
+ */
+class IAudioPlayback
+{
+public:
+    virtual ~IAudioPlayback() = default;
+
+    /**
+     * Open the sink with the given PCM format. Samples submitted later
+     * must match this format. Returns false on failure.
+     *
+     * @param sampleRate samples per second per channel (e.g. 44100)
+     * @param channels   1 = mono, 2 = stereo
+     */
+    virtual bool open(uint32_t sampleRate, uint32_t channels) = 0;
+
+    /**
+     * Tear down the sink and discard any buffered samples.
+     */
+    virtual void close() = 0;
+
+    /**
+     * True between a successful open() and the matching close().
+     */
+    virtual bool isOpen() const = 0;
+
+    /**
+     * Submit interleaved float32 PCM samples. sampleCount is the
+     * number of frames (groups of `channels` floats), not the number
+     * of floats. firstPtsUs is the stream-origin-relative timestamp
+     * of the first frame in this submission, used to advance the
+     * playback clock.
+     *
+     * Returns the number of frames actually accepted (may be less
+     * than sampleCount if the buffer is full; caller may drop the
+     * leftovers).
+     */
+    virtual size_t submit(const float *interleaved,
+                          size_t sampleCount,
+                          int64_t firstPtsUs) = 0;
+
+    /**
+     * Approximate PTS (stream-origin-relative microseconds) of the
+     * sample currently being played by the hardware. Returns the
+     * last PTS we submitted minus the hardware-side buffered samples
+     * worth of time. Used by the video path as the master clock.
+     *
+     * Returns 0 if no audio has been submitted yet.
+     */
+    virtual int64_t getClockUs() const = 0;
+
+    /**
+     * Drop any samples currently buffered in the impl-side queue.
+     * Hardware buffer drains on its own. Used on disconnect /
+     * reconnect to avoid playing stale audio from the previous
+     * session.
+     */
+    virtual void flush() = 0;
+};

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -251,13 +251,51 @@ bool VideoCaptureRemote::initDecoder()
                     // but the sink wants packed float32. swr_convert
                     // handles both layout and sample-format conversions
                     // transparently per audio frame.
-                    m_swrCtx = swr_alloc();
-                    FFmpegCompat::setSwrChannelLayout(m_swrCtx, "in_chlayout",  static_cast<int>(channels));
-                    FFmpegCompat::setSwrChannelLayout(m_swrCtx, "out_chlayout", static_cast<int>(channels));
-                    av_opt_set_int(m_swrCtx, "in_sample_rate",     m_audioCodecCtx->sample_rate, 0);
-                    av_opt_set_int(m_swrCtx, "out_sample_rate",    rate,                          0);
-                    av_opt_set_sample_fmt(m_swrCtx, "in_sample_fmt",  m_audioCodecCtx->sample_fmt, 0);
-                    av_opt_set_sample_fmt(m_swrCtx, "out_sample_fmt", AV_SAMPLE_FMT_FLT,          0);
+                    // Resampler setup with explicit channel layout —
+                    // setSwrChannelLayout wrapper was leaving the layout
+                    // unset on some ffmpeg builds ('swr_init failed:
+                    // Input channel count and layout are unset' in the
+                    // user log). swr_alloc_set_opts2 / the input-frame
+                    // path takes the layout directly from the codec
+                    // context, which is what the decoder actually emits,
+                    // so we hand the codec's layout in verbatim and tell
+                    // the output to mirror it.
+#if FFMPEG_USE_NEW_CHANNEL_LAYOUT
+                    int allocRet = swr_alloc_set_opts2(
+                        &m_swrCtx,
+                        &m_audioCodecCtx->ch_layout,   // out layout
+                        AV_SAMPLE_FMT_FLT,             // out fmt
+                        static_cast<int>(rate),        // out rate
+                        &m_audioCodecCtx->ch_layout,   // in layout
+                        m_audioCodecCtx->sample_fmt,   // in fmt
+                        m_audioCodecCtx->sample_rate,  // in rate
+                        0, nullptr);
+                    if (allocRet < 0)
+                    {
+                        LOG_WARN("VideoCaptureRemote: swr_alloc_set_opts2 failed (" + std::to_string(allocRet) + ") — disabling audio");
+                        if (m_swrCtx) swr_free(&m_swrCtx);
+                        m_audioPlayback.reset();
+                        m_swrCtx = nullptr;
+                    }
+                    else
+#else
+                    int64_t layout = av_get_default_channel_layout(static_cast<int>(channels));
+                    m_swrCtx = swr_alloc_set_opts(
+                        nullptr,
+                        layout,                        // out layout
+                        AV_SAMPLE_FMT_FLT,             // out fmt
+                        static_cast<int>(rate),        // out rate
+                        layout,                        // in layout (assume same)
+                        m_audioCodecCtx->sample_fmt,   // in fmt
+                        m_audioCodecCtx->sample_rate,  // in rate
+                        0, nullptr);
+                    if (!m_swrCtx)
+                    {
+                        LOG_WARN("VideoCaptureRemote: swr_alloc_set_opts failed — disabling audio");
+                        m_audioPlayback.reset();
+                    }
+                    else
+#endif
                     if (swr_init(m_swrCtx) < 0)
                     {
                         LOG_WARN("VideoCaptureRemote: swr_init failed — disabling audio");

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -212,6 +212,14 @@ void VideoCaptureRemote::stopCapture()
     }
 }
 
+void VideoCaptureRemote::setTargetResolution(uint32_t width, uint32_t height)
+{
+    // Atomic stores — picked up by the decode thread on the next frame.
+    // sws_getCachedContext detects the size change and rebuilds.
+    m_targetWidth.store(width);
+    m_targetHeight.store(height);
+}
+
 bool VideoCaptureRemote::captureFrame(Frame &frame)
 {
     return captureLatestFrame(frame);
@@ -291,15 +299,26 @@ void VideoCaptureRemote::decodeLoop()
                 break;
             }
 
-            const int w = frame->width;
-            const int h = frame->height;
-            if (w <= 0 || h <= 0) { av_frame_unref(frame); continue; }
+            const int srcW = frame->width;
+            const int srcH = frame->height;
+            if (srcW <= 0 || srcH <= 0) { av_frame_unref(frame); continue; }
+
+            // Apply optional rescale target. When the host reports a source
+            // resolution via /meta that differs from the encoded /raw size,
+            // Application calls setTargetResolution so the shader pipeline
+            // sees frames at the host's logical source dims (so e.g. CRT
+            // scanline density / NTSC artefact spacing match the look the
+            // host renders locally). When unset, pass through at stream size.
+            const uint32_t tgtW32 = m_targetWidth.load();
+            const uint32_t tgtH32 = m_targetHeight.load();
+            const int dstW = (tgtW32 > 0) ? static_cast<int>(tgtW32) : srcW;
+            const int dstH = (tgtH32 > 0) ? static_cast<int>(tgtH32) : srcH;
 
             // (Re)build the sws context if dimensions or pixfmt changed.
             const AVPixelFormat srcFmt = static_cast<AVPixelFormat>(frame->format);
             m_swsCtx = sws_getCachedContext(m_swsCtx,
-                                            w, h, srcFmt,
-                                            w, h, AV_PIX_FMT_RGB24,
+                                            srcW, srcH, srcFmt,
+                                            dstW, dstH, AV_PIX_FMT_RGB24,
                                             SWS_BILINEAR, nullptr, nullptr, nullptr);
             if (!m_swsCtx)
             {
@@ -308,23 +327,23 @@ void VideoCaptureRemote::decodeLoop()
                 continue;
             }
 
-            if (w != rgbW || h != rgbH)
+            if (dstW != rgbW || dstH != rgbH)
             {
-                rgbW = w;
-                rgbH = h;
-                rgbBuf.assign(static_cast<size_t>(w) * static_cast<size_t>(h) * 3, 0);
+                rgbW = dstW;
+                rgbH = dstH;
+                rgbBuf.assign(static_cast<size_t>(dstW) * static_cast<size_t>(dstH) * 3, 0);
             }
 
             // Write rows in reverse (bottom-up) so the resulting RGB buffer
             // matches the orientation the rest of the capture pipeline
             // expects from V4L2 / DirectShow sources — without this, the
             // image renders upside-down on screen.
-            uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(h - 1) * static_cast<size_t>(w) * 3 };
-            int dstStrides[1]     = { -(w * 3) };
-            sws_scale(m_swsCtx, frame->data, frame->linesize, 0, h, dstSlices, dstStrides);
+            uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(dstH - 1) * static_cast<size_t>(dstW) * 3 };
+            int dstStrides[1]     = { -(dstW * 3) };
+            sws_scale(m_swsCtx, frame->data, frame->linesize, 0, srcH, dstSlices, dstStrides);
             av_frame_unref(frame);
 
-            // Publish the new frame.
+            // Publish the new frame at its post-rescale dims.
             {
                 std::lock_guard<std::mutex> lock(m_frameMutex);
                 if (m_latestRGB.size() != rgbBuf.size())
@@ -332,11 +351,11 @@ void VideoCaptureRemote::decodeLoop()
                     m_latestRGB.resize(rgbBuf.size());
                 }
                 std::memcpy(m_latestRGB.data(), rgbBuf.data(), rgbBuf.size());
-                m_latestW = static_cast<uint32_t>(w);
-                m_latestH = static_cast<uint32_t>(h);
+                m_latestW = static_cast<uint32_t>(dstW);
+                m_latestH = static_cast<uint32_t>(dstH);
             }
-            m_width  = static_cast<uint32_t>(w);
-            m_height = static_cast<uint32_t>(h);
+            m_width  = static_cast<uint32_t>(dstW);
+            m_height = static_cast<uint32_t>(dstH);
             m_hasFrame.store(true);
         }
     }

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -183,24 +183,38 @@ bool VideoCaptureRemote::initDecoder()
     // client plays video only. This keeps the audio path additive —
     // a failure here doesn't break the rest of the remote viewer.
     m_audioStreamIdx = -1;
+    LOG_INFO("VideoCaptureRemote: scanning " + std::to_string(m_formatCtx->nb_streams) + " stream(s) for audio");
     for (unsigned int i = 0; i < m_formatCtx->nb_streams; ++i)
     {
-        if (m_formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+        const AVMediaType t = m_formatCtx->streams[i]->codecpar->codec_type;
+        LOG_INFO("VideoCaptureRemote:   stream " + std::to_string(i) + " type=" + std::to_string(static_cast<int>(t)) +
+                 " codec_id=" + std::to_string(m_formatCtx->streams[i]->codecpar->codec_id));
+        if (t == AVMEDIA_TYPE_AUDIO && m_audioStreamIdx < 0)
         {
             m_audioStreamIdx = static_cast<int>(i);
-            break;
         }
+    }
+    if (m_audioStreamIdx < 0)
+    {
+        LOG_WARN("VideoCaptureRemote: no audio stream in /raw — playing video only");
     }
     if (m_audioStreamIdx >= 0)
     {
         AVCodecParameters *aPar = m_formatCtx->streams[m_audioStreamIdx]->codecpar;
         const AVCodec *aCodec = avcodec_find_decoder(aPar->codec_id);
+        if (!aCodec)
+        {
+            LOG_WARN("VideoCaptureRemote: no decoder for audio codec_id=" + std::to_string(aPar->codec_id));
+        }
         if (aCodec)
         {
             m_audioCodecCtx = avcodec_alloc_context3(aCodec);
-            if (m_audioCodecCtx &&
-                avcodec_parameters_to_context(m_audioCodecCtx, aPar) >= 0 &&
-                avcodec_open2(m_audioCodecCtx, aCodec, nullptr) >= 0)
+            const bool gotCtx = m_audioCodecCtx != nullptr;
+            const bool gotParams = gotCtx && avcodec_parameters_to_context(m_audioCodecCtx, aPar) >= 0;
+            const int openRet = gotParams ? avcodec_open2(m_audioCodecCtx, aCodec, nullptr) : -1;
+            LOG_INFO("VideoCaptureRemote: audio codec setup — ctx=" + std::to_string(gotCtx) +
+                     " params=" + std::to_string(gotParams) + " openRet=" + std::to_string(openRet));
+            if (gotCtx && gotParams && openRet >= 0)
             {
                 // Open the system sink at the decoder's native format
                 // (e.g. AAC stereo 44.1 kHz). Shared-mode WASAPI /

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -100,18 +100,19 @@ bool VideoCaptureRemote::initDecoder()
     // initDecoder pass starts with permission to block in I/O.
     m_decodeAborted.store(false);
 
-    // Probing budget: needs to be large enough for ffmpeg to see at
-    // least one packet of EACH expected stream so audio gets
-    // detected alongside video. The original 32 KB / 500 ms values
-    // were tuned for low-latency video-only probing, but they undercut
-    // the audio stream — at 256 kbit/s AAC the first audio packet can
-    // take ~30 ms-100 ms to arrive after the first video packet on a
-    // bursty TCP feed, and the demuxer can chew through 32 KB of
-    // video before that audio packet shows up. Raised to numbers
-    // closer to ffprobe's defaults so audio is consistently found.
+    // Probing budget: must see at least one packet of each expected
+    // stream so audio is detected, but every byte the probe consumes
+    // becomes a packet sitting in the demuxer's internal buffer when
+    // the decode loop starts. Too generous a probe means the decoder
+    // chews through that buffer at non-real-time rates ('decoded=83/s'
+    // catch-up the user observed) and the queue fills before the
+    // wall-clock-driven consumer can drain it. 256 KB at ~3 Mbit/s
+    // is ~0.7 s of stream — plenty for the second audio packet (AAC
+    // packets arrive every ~23 ms) but small enough that the catch-up
+    // settles in a couple of frames.
     AVDictionary *opts = nullptr;
-    av_dict_set(&opts, "probesize",       "1048576", 0); // 1 MB
-    av_dict_set(&opts, "analyzeduration", "2000000", 0); // 2 s
+    av_dict_set(&opts, "probesize",       "262144",  0); // 256 KB
+    av_dict_set(&opts, "analyzeduration", "1000000", 0); // 1 s
     // Note: deliberately NOT setting "fflags: nobuffer" here — without
     // FFmpeg's internal packet buffer, av_read_frame returns whatever the
     // socket has *right now*, which on a bursty TCP stream means several

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -233,12 +233,19 @@ bool VideoCaptureRemote::captureFrame(Frame &frame)
 bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
 {
     std::lock_guard<std::mutex> lock(m_frameMutex);
-    // Pop the oldest queued frame and remember it as the "last consumed"
-    // so subsequent reads with an empty queue still return something
-    // sensible (the previous frame) instead of false — keeping the main
-    // loop's render path hot avoids the dummy/black flash that single-
-    // slot semantics produced under bursty decode timing.
-    if (!m_frameQueue.empty())
+    // PTS-anchored release: the decoder tagged each queued frame with the
+    // wall-clock time it should appear on screen (see decodeLoop). Pop
+    // any frames whose target time has been reached, keeping the most
+    // recent one as "currently displayed". Frames still in the future
+    // stay in the queue so the next poll picks them up at the right
+    // moment. This replaces the "always pop the front" behaviour that
+    // showed every queued frame as fast as the main loop polled —
+    // producing the bursty / irregular hold times the user noticed as
+    // "perdemos frame rate" judder on a 60Hz display fed a ~40 fps
+    // stream.
+    const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                  std::chrono::steady_clock::now().time_since_epoch()).count();
+    while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs)
     {
         m_lastConsumed = std::move(m_frameQueue.front());
         m_frameQueue.pop_front();
@@ -357,7 +364,50 @@ void VideoCaptureRemote::decodeLoop()
             uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(dstH - 1) * static_cast<size_t>(dstW) * 3 };
             int dstStrides[1]     = { -(dstW * 3) };
             sws_scale(m_swsCtx, frame->data, frame->linesize, 0, srcH, dstSlices, dstStrides);
+
+            // Capture the frame's PTS in stream timebase units BEFORE
+            // unref'ing. Used together with the per-stream anchor below
+            // to compute when this frame should appear on screen.
+            const int64_t framePtsTicks = (frame->pts != AV_NOPTS_VALUE) ? frame->pts : 0;
             av_frame_unref(frame);
+
+            // Establish the wall-clock anchor on the first decoded frame.
+            // From here on, every frame's target display time is computed
+            // off this anchor — so the consumer can hold each frame on
+            // screen for its exact stream-defined duration, rather than
+            // showing whatever-is-in-the-queue at every 16 ms poll, which
+            // produces visibly irregular hold times when the network /
+            // decoder delivers frames in bursts.
+            const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch()).count();
+            int64_t targetWallUs = nowWallUs;
+            if (!m_streamAnchored)
+            {
+                m_streamAnchored = true;
+                m_streamStartWallUs = nowWallUs;
+                m_firstPtsTicks     = framePtsTicks;
+                if (m_formatCtx && m_videoStreamIdx >= 0)
+                {
+                    const AVRational tb = m_formatCtx->streams[m_videoStreamIdx]->time_base;
+                    m_streamTimebaseSecs = av_q2d(tb);
+                }
+                if (m_streamTimebaseSecs <= 0.0) m_streamTimebaseSecs = 1.0 / 90000.0;
+            }
+            else
+            {
+                const int64_t deltaTicks = framePtsTicks - m_firstPtsTicks;
+                const int64_t deltaUs    = static_cast<int64_t>(static_cast<double>(deltaTicks) * m_streamTimebaseSecs * 1e6);
+                targetWallUs = m_streamStartWallUs + deltaUs;
+                // If we've fallen far behind (deltaUs in the past), snap
+                // the anchor forward so we don't accumulate latency
+                // forever when the stream pauses and resumes.
+                if (targetWallUs + 500'000 < nowWallUs)
+                {
+                    m_streamStartWallUs = nowWallUs;
+                    m_firstPtsTicks     = framePtsTicks;
+                    targetWallUs        = nowWallUs;
+                }
+            }
 
             // Push the new frame onto the bounded queue. Drop the oldest
             // if we've already buffered kMaxQueued — keeps latency bounded
@@ -369,8 +419,9 @@ void VideoCaptureRemote::decodeLoop()
                 std::lock_guard<std::mutex> lock(m_frameMutex);
                 QueuedFrame qf;
                 qf.rgb.assign(rgbBuf.begin(), rgbBuf.end());
-                qf.width  = static_cast<uint32_t>(dstW);
-                qf.height = static_cast<uint32_t>(dstH);
+                qf.width        = static_cast<uint32_t>(dstW);
+                qf.height       = static_cast<uint32_t>(dstH);
+                qf.targetWallUs = targetWallUs;
                 if (m_frameQueue.size() >= kMaxQueued)
                 {
                     m_frameQueue.pop_front();

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -163,8 +163,8 @@ void VideoCaptureRemote::close()
     m_url.clear();
     {
         std::lock_guard<std::mutex> lock(m_frameMutex);
-        m_latestRGB.clear();
-        m_latestW = m_latestH = 0;
+        m_frameQueue.clear();
+        m_lastConsumed = QueuedFrame{};
         m_hasFrame.store(false);
     }
 }
@@ -228,14 +228,24 @@ bool VideoCaptureRemote::captureFrame(Frame &frame)
 bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
 {
     std::lock_guard<std::mutex> lock(m_frameMutex);
-    if (!m_hasFrame.load() || m_latestRGB.empty())
+    // Pop the oldest queued frame and remember it as the "last consumed"
+    // so subsequent reads with an empty queue still return something
+    // sensible (the previous frame) instead of false — keeping the main
+    // loop's render path hot avoids the dummy/black flash that single-
+    // slot semantics produced under bursty decode timing.
+    if (!m_frameQueue.empty())
+    {
+        m_lastConsumed = std::move(m_frameQueue.front());
+        m_frameQueue.pop_front();
+    }
+    if (m_lastConsumed.rgb.empty())
     {
         return false;
     }
-    frame.data   = m_latestRGB.data();
-    frame.size   = m_latestRGB.size();
-    frame.width  = m_latestW;
-    frame.height = m_latestH;
+    frame.data   = m_lastConsumed.rgb.data();
+    frame.size   = m_lastConsumed.rgb.size();
+    frame.width  = m_lastConsumed.width;
+    frame.height = m_lastConsumed.height;
     frame.format = 0; // RGB24 — FrameProcessor's non-YUYV path
     return true;
 }
@@ -343,16 +353,22 @@ void VideoCaptureRemote::decodeLoop()
             sws_scale(m_swsCtx, frame->data, frame->linesize, 0, srcH, dstSlices, dstStrides);
             av_frame_unref(frame);
 
-            // Publish the new frame at its post-rescale dims.
+            // Push the new frame onto the bounded queue. Drop the oldest
+            // if we've already buffered kMaxQueued — keeps latency bounded
+            // while absorbing the TCP / decoder bursts that would
+            // otherwise show up as visible stuttering with a single-slot
+            // buffer.
             {
                 std::lock_guard<std::mutex> lock(m_frameMutex);
-                if (m_latestRGB.size() != rgbBuf.size())
+                QueuedFrame qf;
+                qf.rgb.assign(rgbBuf.begin(), rgbBuf.end());
+                qf.width  = static_cast<uint32_t>(dstW);
+                qf.height = static_cast<uint32_t>(dstH);
+                if (m_frameQueue.size() >= kMaxQueued)
                 {
-                    m_latestRGB.resize(rgbBuf.size());
+                    m_frameQueue.pop_front();
                 }
-                std::memcpy(m_latestRGB.data(), rgbBuf.data(), rgbBuf.size());
-                m_latestW = static_cast<uint32_t>(dstW);
-                m_latestH = static_cast<uint32_t>(dstH);
+                m_frameQueue.push_back(std::move(qf));
             }
             m_width  = static_cast<uint32_t>(dstW);
             m_height = static_cast<uint32_t>(dstH);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -531,10 +531,22 @@ void VideoCaptureRemote::decodeLoop()
                 const int64_t deltaTicks = framePtsTicks - m_firstPtsTicks;
                 const int64_t deltaUs    = static_cast<int64_t>(static_cast<double>(deltaTicks) * m_streamTimebaseSecs * 1e6);
                 targetWallUs = m_streamStartWallUs + deltaUs;
-                // If we've fallen far behind (deltaUs in the past), snap
-                // the anchor forward so we don't accumulate latency
-                // forever when the stream pauses and resumes.
-                if (targetWallUs + 500'000 < nowWallUs)
+                // Watchdog in both directions:
+                //  - >500 ms in the past: the stream paused / network
+                //    blipped, our queue would otherwise sit on stale
+                //    frames forever. Snap anchor forward.
+                //  - >500 ms in the future: the first-frame PTS we
+                //    used to anchor was bogus (commonly the very
+                //    first decoded packet arrives with AV_NOPTS_VALUE
+                //    and we substituted 0, so the second frame's real
+                //    PTS suddenly puts targets a full second ahead of
+                //    wall clock). That symptom was the user-reported
+                //    "primeiro frame translúcido sobre tudo": linear
+                //    mode held a ~95 %-F1 / 5 %-F2 blend on screen for
+                //    the whole 1 s catch-up window. Re-anchor on this
+                //    frame so we don't keep ghosting F1 forever.
+                if (targetWallUs + 500'000 < nowWallUs ||
+                    targetWallUs > nowWallUs + 500'000)
                 {
                     m_streamStartWallUs = nowWallUs;
                     m_firstPtsTicks     = framePtsTicks;

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -100,12 +100,18 @@ bool VideoCaptureRemote::initDecoder()
     // initDecoder pass starts with permission to block in I/O.
     m_decodeAborted.store(false);
 
-    // Hint that we want low-latency probing. Without these flags FFmpeg may
-    // buffer up several seconds of input before deciding what stream params
-    // it has.
+    // Probing budget: needs to be large enough for ffmpeg to see at
+    // least one packet of EACH expected stream so audio gets
+    // detected alongside video. The original 32 KB / 500 ms values
+    // were tuned for low-latency video-only probing, but they undercut
+    // the audio stream — at 256 kbit/s AAC the first audio packet can
+    // take ~30 ms-100 ms to arrive after the first video packet on a
+    // bursty TCP feed, and the demuxer can chew through 32 KB of
+    // video before that audio packet shows up. Raised to numbers
+    // closer to ffprobe's defaults so audio is consistently found.
     AVDictionary *opts = nullptr;
-    av_dict_set(&opts, "probesize",    "32768",        0); // bytes
-    av_dict_set(&opts, "analyzeduration", "500000",    0); // microseconds (0.5s)
+    av_dict_set(&opts, "probesize",       "1048576", 0); // 1 MB
+    av_dict_set(&opts, "analyzeduration", "2000000", 0); // 2 s
     // Note: deliberately NOT setting "fflags: nobuffer" here — without
     // FFmpeg's internal packet buffer, av_read_frame returns whatever the
     // socket has *right now*, which on a bursty TCP stream means several

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -190,15 +190,12 @@ bool VideoCaptureRemote::initDecoder()
     // client plays video only. This keeps the audio path additive —
     // a failure here doesn't break the rest of the remote viewer.
     m_audioStreamIdx = -1;
-    LOG_INFO("VideoCaptureRemote: scanning " + std::to_string(m_formatCtx->nb_streams) + " stream(s) for audio");
     for (unsigned int i = 0; i < m_formatCtx->nb_streams; ++i)
     {
-        const AVMediaType t = m_formatCtx->streams[i]->codecpar->codec_type;
-        LOG_INFO("VideoCaptureRemote:   stream " + std::to_string(i) + " type=" + std::to_string(static_cast<int>(t)) +
-                 " codec_id=" + std::to_string(m_formatCtx->streams[i]->codecpar->codec_id));
-        if (t == AVMEDIA_TYPE_AUDIO && m_audioStreamIdx < 0)
+        if (m_formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
         {
             m_audioStreamIdx = static_cast<int>(i);
+            break;
         }
     }
     if (m_audioStreamIdx < 0)
@@ -216,11 +213,9 @@ bool VideoCaptureRemote::initDecoder()
         if (aCodec)
         {
             m_audioCodecCtx = avcodec_alloc_context3(aCodec);
-            const bool gotCtx = m_audioCodecCtx != nullptr;
+            const bool gotCtx    = m_audioCodecCtx != nullptr;
             const bool gotParams = gotCtx && avcodec_parameters_to_context(m_audioCodecCtx, aPar) >= 0;
-            const int openRet = gotParams ? avcodec_open2(m_audioCodecCtx, aCodec, nullptr) : -1;
-            LOG_INFO("VideoCaptureRemote: audio codec setup — ctx=" + std::to_string(gotCtx) +
-                     " params=" + std::to_string(gotParams) + " openRet=" + std::to_string(openRet));
+            const int  openRet   = gotParams ? avcodec_open2(m_audioCodecCtx, aCodec, nullptr) : -1;
             if (gotCtx && gotParams && openRet >= 0)
             {
                 // Open the system sink at the decoder's native format
@@ -891,10 +886,10 @@ void VideoCaptureRemote::decodeLoop()
             if (m_statStart.time_since_epoch().count() == 0) m_statStart = nowTs;
             if (std::chrono::duration_cast<std::chrono::seconds>(nowTs - m_statStart).count() >= 1)
             {
-                LOG_INFO("VideoCaptureRemote: decoded=" + std::to_string(m_statProduced) +
-                         "/s consumed=" + std::to_string(m_statConsumed) +
-                         "/s drops=" + std::to_string(m_statDropped) +
-                         " queueDepth=" + std::to_string(m_frameQueue.size()));
+                LOG_DEBUG("VideoCaptureRemote: decoded=" + std::to_string(m_statProduced) +
+                          "/s consumed=" + std::to_string(m_statConsumed) +
+                          "/s drops=" + std::to_string(m_statDropped) +
+                          " queueDepth=" + std::to_string(m_frameQueue.size()));
                 m_statProduced = m_statConsumed = m_statDropped = 0;
                 m_statStart = nowTs;
             }

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -233,19 +233,24 @@ bool VideoCaptureRemote::captureFrame(Frame &frame)
 bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
 {
     std::lock_guard<std::mutex> lock(m_frameMutex);
-    // PTS-anchored release: the decoder tagged each queued frame with the
-    // wall-clock time it should appear on screen (see decodeLoop). Pop
-    // any frames whose target time has been reached, keeping the most
-    // recent one as "currently displayed". Frames still in the future
-    // stay in the queue so the next poll picks them up at the right
-    // moment. This replaces the "always pop the front" behaviour that
-    // showed every queued frame as fast as the main loop polled —
-    // producing the bursty / irregular hold times the user noticed as
-    // "perdemos frame rate" judder on a 60Hz display fed a ~40 fps
-    // stream.
+    // PTS-anchored release with a half-frame leniency window. The decoder
+    // tagged each queued frame with the wall-clock time it should appear
+    // on screen; we pop frames whose target has been reached, keeping the
+    // most recent one as "currently displayed". The half-frame window
+    // (kReleaseLeadUs) is the fix for "60 fps stream on a 60 Hz display
+    // doesn't feel like 60 fps": with a strict at-or-after PTS gate, a
+    // frame whose PTS jittered 1-2 ms later than the next display refresh
+    // missed that refresh and ended up shown for two cycles instead of
+    // one — invisible 3:2 pulldown judder. Allowing release up to ~8 ms
+    // before the target lets each frame land on the nearest refresh
+    // boundary instead of strictly the next one after PTS. The user
+    // worked around this by streaming at 120 fps, where every poll had
+    // a fresh frame whether or not the gate was strict; with this fix
+    // 60 fps streaming should feel as smooth as 120 fps used to.
+    constexpr int64_t kReleaseLeadUs = 8333; // half a 60 Hz frame
     const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                   std::chrono::steady_clock::now().time_since_epoch()).count();
-    while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs)
+    while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs + kReleaseLeadUs)
     {
         m_lastConsumed = std::move(m_frameQueue.front());
         m_frameQueue.pop_front();

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -285,6 +285,38 @@ void VideoCaptureRemote::decodeLoop()
 
     while (m_decodeRunning.load())
     {
+        // Reconnect path: when the previous av_read_frame tore the
+        // connection down (server stop / network blip) we land here
+        // with m_formatCtx == nullptr. Try to (re)open the input,
+        // back off on failure, keep trying until the application
+        // asks us to stop.
+        if (!m_formatCtx)
+        {
+            cleanupDecoder(); // belt-and-braces: drop any half-init state
+            if (!initDecoder())
+            {
+                LOG_WARN("VideoCaptureRemote: reconnect to " + m_url + " failed, retrying in 2 s");
+                cleanupDecoder();
+                for (int i = 0; i < 20 && m_decodeRunning.load(); ++i)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+                continue;
+            }
+            // Fresh stream: reset the PTS anchor and clear any stale
+            // frames that were sitting in the queue from before the
+            // disconnect. Otherwise the new stream's PTS=0 frame would
+            // be timed against the old anchor and either play in the
+            // past or sit far in the future.
+            m_streamAnchored = false;
+            {
+                std::lock_guard<std::mutex> lock(m_frameMutex);
+                m_frameQueue.clear();
+            }
+            rgbW = 0; rgbH = 0; rgbBuf.clear();
+            LOG_INFO("VideoCaptureRemote: reconnected to " + m_url);
+        }
+
         int rc = av_read_frame(m_formatCtx, packet);
         if (rc < 0)
         {
@@ -295,8 +327,12 @@ void VideoCaptureRemote::decodeLoop()
             }
             char errBuf[128] = {0};
             av_strerror(rc, errBuf, sizeof(errBuf));
-            LOG_WARN("VideoCaptureRemote::decodeLoop — av_read_frame: " + std::string(errBuf));
-            break; // Connection lost / EOF — exit loop.
+            LOG_WARN("VideoCaptureRemote::decodeLoop — av_read_frame: " + std::string(errBuf) +
+                     " — tearing down and waiting to reconnect");
+            // Tear down so the top of the outer loop reopens. Don't
+            // exit the thread — server is allowed to come back.
+            cleanupDecoder();
+            continue;
         }
 
         if (packet->stream_index != m_videoStreamIdx)

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -66,7 +66,12 @@ bool VideoCaptureRemote::initDecoder()
     AVDictionary *opts = nullptr;
     av_dict_set(&opts, "probesize",    "32768",        0); // bytes
     av_dict_set(&opts, "analyzeduration", "500000",    0); // microseconds (0.5s)
-    av_dict_set(&opts, "fflags",       "nobuffer",     0);
+    // Note: deliberately NOT setting "fflags: nobuffer" here — without
+    // FFmpeg's internal packet buffer, av_read_frame returns whatever the
+    // socket has *right now*, which on a bursty TCP stream means several
+    // packets arrive together and then a quiet period. Letting FFmpeg
+    // buffer ~2-3 packets internally smooths consumption without
+    // meaningfully hurting the live-stream latency floor.
     av_dict_set(&opts, "timeout",      "5000000",      0); // 5s read timeout (microseconds)
 
     int rc = avformat_open_input(&m_formatCtx, rawUrl.c_str(), nullptr, &opts);
@@ -237,6 +242,7 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
     {
         m_lastConsumed = std::move(m_frameQueue.front());
         m_frameQueue.pop_front();
+        ++m_statConsumed;
     }
     if (m_lastConsumed.rgb.empty())
     {
@@ -358,6 +364,7 @@ void VideoCaptureRemote::decodeLoop()
             // while absorbing the TCP / decoder bursts that would
             // otherwise show up as visible stuttering with a single-slot
             // buffer.
+            bool droppedOldest = false;
             {
                 std::lock_guard<std::mutex> lock(m_frameMutex);
                 QueuedFrame qf;
@@ -367,12 +374,29 @@ void VideoCaptureRemote::decodeLoop()
                 if (m_frameQueue.size() >= kMaxQueued)
                 {
                     m_frameQueue.pop_front();
+                    droppedOldest = true;
                 }
                 m_frameQueue.push_back(std::move(qf));
             }
             m_width  = static_cast<uint32_t>(dstW);
             m_height = static_cast<uint32_t>(dstH);
             m_hasFrame.store(true);
+
+            // Periodic decode stats so we can spot rate mismatches in the
+            // log — produce/drop counts over the last second.
+            ++m_statProduced;
+            if (droppedOldest) ++m_statDropped;
+            auto nowTs = std::chrono::steady_clock::now();
+            if (m_statStart.time_since_epoch().count() == 0) m_statStart = nowTs;
+            if (std::chrono::duration_cast<std::chrono::seconds>(nowTs - m_statStart).count() >= 1)
+            {
+                LOG_INFO("VideoCaptureRemote: decoded=" + std::to_string(m_statProduced) +
+                         "/s consumed=" + std::to_string(m_statConsumed) +
+                         "/s drops=" + std::to_string(m_statDropped) +
+                         " queueDepth=" + std::to_string(m_frameQueue.size()));
+                m_statProduced = m_statConsumed = m_statDropped = 0;
+                m_statStart = nowTs;
+            }
         }
     }
 

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -60,6 +60,29 @@ bool VideoCaptureRemote::initDecoder()
     // FFmpeg networking init — idempotent, cheap to call.
     avformat_network_init();
 
+    // Allocate format context up-front so we can install the interrupt
+    // callback before avformat_open_input is called. Without the
+    // callback ffmpeg's blocking I/O sits in recv()/connect() until its
+    // 5 s timeout, ignoring our stopCapture()/close() — the decode loop
+    // ends up keeping the socket and the decode thread alive for up to
+    // 5 s after Disconnect, which is what produced 'decoded=60/s
+    // consumed=0/s drops=60' in the logs after the user hit Disconnect.
+    m_formatCtx = avformat_alloc_context();
+    if (!m_formatCtx)
+    {
+        LOG_ERROR("VideoCaptureRemote: avformat_alloc_context failed");
+        return false;
+    }
+    static_cast<AVFormatContext *>(m_formatCtx)->interrupt_callback.callback =
+        [](void *opaque) -> int {
+            auto *self = static_cast<VideoCaptureRemote *>(opaque);
+            // Returning non-zero asks ffmpeg to abort the current
+            // blocking I/O call with AVERROR_EXIT. We return 1 as
+            // soon as the decode thread has been asked to stop.
+            return self && !self->m_decodeRunning.load() ? 1 : 0;
+        };
+    static_cast<AVFormatContext *>(m_formatCtx)->interrupt_callback.opaque = this;
+
     // Hint that we want low-latency probing. Without these flags FFmpeg may
     // buffer up several seconds of input before deciding what stream params
     // it has.

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -77,11 +77,19 @@ bool VideoCaptureRemote::initDecoder()
         [](void *opaque) -> int {
             auto *self = static_cast<VideoCaptureRemote *>(opaque);
             // Returning non-zero asks ffmpeg to abort the current
-            // blocking I/O call with AVERROR_EXIT. We return 1 as
-            // soon as the decode thread has been asked to stop.
-            return self && !self->m_decodeRunning.load() ? 1 : 0;
+            // blocking I/O call with AVERROR_EXIT. Only abort when
+            // stopCapture()/close() has explicitly asked us to —
+            // checking m_decodeRunning instead would trip during the
+            // initial open() (worker thread hasn't started yet, so
+            // the flag is still false) and avformat_open_input would
+            // return Immediate exit right away.
+            return self && self->m_decodeAborted.load() ? 1 : 0;
         };
     static_cast<AVFormatContext *>(m_formatCtx)->interrupt_callback.opaque = this;
+
+    // Clear any stale abort flag from a previous teardown so this
+    // initDecoder pass starts with permission to block in I/O.
+    m_decodeAborted.store(false);
 
     // Hint that we want low-latency probing. Without these flags FFmpeg may
     // buffer up several seconds of input before deciding what stream params
@@ -229,6 +237,12 @@ bool VideoCaptureRemote::startCapture()
 
 void VideoCaptureRemote::stopCapture()
 {
+    // Always set the abort flag — open()'s avformat_open_input path
+    // also observes it through the interrupt callback. Setting it before
+    // the m_decodeRunning early-return below means a stopCapture() that
+    // arrives while open() is still blocking unwinds cleanly even if the
+    // worker thread itself hasn't started yet.
+    m_decodeAborted.store(true);
     if (!m_decodeRunning.load())
     {
         return;

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -315,8 +315,12 @@ void VideoCaptureRemote::decodeLoop()
                 rgbBuf.assign(static_cast<size_t>(w) * static_cast<size_t>(h) * 3, 0);
             }
 
-            uint8_t *dstSlices[1] = { rgbBuf.data() };
-            int dstStrides[1]     = { w * 3 };
+            // Write rows in reverse (bottom-up) so the resulting RGB buffer
+            // matches the orientation the rest of the capture pipeline
+            // expects from V4L2 / DirectShow sources — without this, the
+            // image renders upside-down on screen.
+            uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(h - 1) * static_cast<size_t>(w) * 3 };
+            int dstStrides[1]     = { -(w * 3) };
             sws_scale(m_swsCtx, frame->data, frame->linesize, 0, h, dstSlices, dstStrides);
             av_frame_unref(frame);
 

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -258,21 +258,21 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
         return false;
     }
 
-    // Output buffer pointer & size — default to the cached frame; the
-    // interpolation path below replaces it with m_blendBuffer when
-    // there's a 'next' frame to interpolate toward. Frame.data is a
-    // non-const uint8_t* in the IVideoCapture contract; cast away
-    // const here because the downstream FrameProcessor never mutates
-    // these bytes — it just uploads them to a texture.
+    // Default: hand out the cached frame as-is. The Linear / Nearest
+    // branches below may override with a blended or temporally-closer
+    // frame. Frame.data is non-const uint8_t* in the IVideoCapture
+    // contract; cast away const where we point at a queued frame's
+    // buffer because the downstream FrameProcessor only reads.
     uint8_t *outData = m_lastConsumed.rgb.data();
     size_t outSize   = m_lastConsumed.rgb.size();
 
-    if (!m_frameQueue.empty())
+    const InterpolationMode mode = m_interpolationMode.load();
+    if (mode != InterpolationMode::Off && !m_frameQueue.empty())
     {
         const QueuedFrame &next = m_frameQueue.front();
-        // Both endpoints must have matching dims for a meaningful blend.
-        // The shader pipeline / texture upload would reject a size
-        // mismatch anyway, so just skip interpolation across a resize.
+        // Both endpoints must have matching dims for a meaningful blend
+        // / comparison. Skip interpolation across a resize so the
+        // texture upload path doesn't see a half-resized frame.
         if (next.width == m_lastConsumed.width &&
             next.height == m_lastConsumed.height &&
             next.rgb.size() == m_lastConsumed.rgb.size() &&
@@ -282,36 +282,48 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
             int64_t pos = nowWallUs - m_lastConsumed.targetWallUs;
             if (pos < 0) pos = 0;
             if (pos > span) pos = span;
-            // 0..256 fixed-point weight for the *next* frame; (256 - tFp)
-            // weights the previous frame. Tighter than float math and
-            // autovectorises cleanly to AVX2 byte-blend on x86_64.
-            const int tFp     = static_cast<int>((pos * 256) / span);
-            const int oneMinus = 256 - tFp;
 
-            if (tFp > 0 && tFp < 256)
+            if (mode == InterpolationMode::Linear)
             {
-                if (m_blendBuffer.size() != m_lastConsumed.rgb.size())
+                // 0..256 fixed-point weight for the *next* frame; the
+                // previous frame gets (256 - tFp). Autovectorises to
+                // AVX2 byte-blend on x86_64.
+                const int tFp     = static_cast<int>((pos * 256) / span);
+                const int oneMinus = 256 - tFp;
+                if (tFp > 0 && tFp < 256)
                 {
-                    m_blendBuffer.assign(m_lastConsumed.rgb.size(), 0);
+                    if (m_blendBuffer.size() != m_lastConsumed.rgb.size())
+                    {
+                        m_blendBuffer.assign(m_lastConsumed.rgb.size(), 0);
+                    }
+                    const uint8_t *a = m_lastConsumed.rgb.data();
+                    const uint8_t *b = next.rgb.data();
+                    uint8_t *o       = m_blendBuffer.data();
+                    const size_t n   = m_blendBuffer.size();
+                    for (size_t i = 0; i < n; ++i)
+                    {
+                        o[i] = static_cast<uint8_t>((a[i] * oneMinus + b[i] * tFp) >> 8);
+                    }
+                    outData = m_blendBuffer.data();
+                    outSize = m_blendBuffer.size();
                 }
-                const uint8_t *a = m_lastConsumed.rgb.data();
-                const uint8_t *b = next.rgb.data();
-                uint8_t *o       = m_blendBuffer.data();
-                const size_t n   = m_blendBuffer.size();
-                for (size_t i = 0; i < n; ++i)
+                else if (tFp >= 256)
                 {
-                    o[i] = static_cast<uint8_t>((a[i] * oneMinus + b[i] * tFp) >> 8);
+                    outData = const_cast<uint8_t *>(next.rgb.data());
+                    outSize = next.rgb.size();
                 }
-                outData = m_blendBuffer.data();
-                outSize = m_blendBuffer.size();
+                // tFp == 0 → stays on m_lastConsumed.
             }
-            else if (tFp >= 256)
+            else // InterpolationMode::Nearest
             {
-                // Exactly at next frame's target — show next directly.
-                outData = const_cast<uint8_t *>(next.rgb.data());
-                outSize = next.rgb.size();
+                // Pick whichever target is closer to now in time.
+                if (pos * 2 >= span)
+                {
+                    outData = const_cast<uint8_t *>(next.rgb.data());
+                    outSize = next.rgb.size();
+                }
+                // Otherwise stays on m_lastConsumed.
             }
-            // tFp == 0 → still on m_lastConsumed, default path.
         }
     }
 

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -1,14 +1,23 @@
 #include "VideoCaptureRemote.h"
 #include "../utils/Logger.h"
+#include "../audio/IAudioPlayback.h"
+#ifdef __linux__
+#include "../audio/AudioPlaybackPulse.h"
+#elif defined(_WIN32)
+#include "../audio/AudioPlaybackWASAPI.h"
+#endif
 
 extern "C"
 {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
 #include <libswscale/swscale.h>
+#include <libswresample/swresample.h>
 }
 
+#include "../utils/FFmpegCompat.h"
 #include <chrono>
 #include <cstring>
 
@@ -168,6 +177,89 @@ bool VideoCaptureRemote::initDecoder()
     LOG_INFO("VideoCaptureRemote: decoder ready — " + std::to_string(m_width) + "x" + std::to_string(m_height) +
              " codec=" + std::string(codec->name));
 
+    // Audio decoder + playback. The /raw stream always carries audio
+    // (see HTTPTSStreamer::pushAudio) so we expect to find an audio
+    // stream alongside the video; if not, we silently skip and the
+    // client plays video only. This keeps the audio path additive —
+    // a failure here doesn't break the rest of the remote viewer.
+    m_audioStreamIdx = -1;
+    for (unsigned int i = 0; i < m_formatCtx->nb_streams; ++i)
+    {
+        if (m_formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+        {
+            m_audioStreamIdx = static_cast<int>(i);
+            break;
+        }
+    }
+    if (m_audioStreamIdx >= 0)
+    {
+        AVCodecParameters *aPar = m_formatCtx->streams[m_audioStreamIdx]->codecpar;
+        const AVCodec *aCodec = avcodec_find_decoder(aPar->codec_id);
+        if (aCodec)
+        {
+            m_audioCodecCtx = avcodec_alloc_context3(aCodec);
+            if (m_audioCodecCtx &&
+                avcodec_parameters_to_context(m_audioCodecCtx, aPar) >= 0 &&
+                avcodec_open2(m_audioCodecCtx, aCodec, nullptr) >= 0)
+            {
+                // Open the system sink at the decoder's native format
+                // (e.g. AAC stereo 44.1 kHz). Shared-mode WASAPI /
+                // PulseAudio both auto-resample to whatever the device
+                // is configured for.
+#ifdef __linux__
+                m_audioPlayback = std::make_unique<AudioPlaybackPulse>();
+#elif defined(_WIN32)
+                m_audioPlayback = std::make_unique<AudioPlaybackWASAPI>();
+#endif
+                const uint32_t rate     = static_cast<uint32_t>(m_audioCodecCtx->sample_rate);
+                // Channel count compat: AVCodecContext.channels was
+                // deprecated in FFmpeg 5.1 in favour of ch_layout.nb_channels.
+                // Use whichever the build exposes.
+#if defined(FF_API_OLD_CHANNEL_LAYOUT) || LIBAVCODEC_VERSION_MAJOR < 60
+                const uint32_t channels = static_cast<uint32_t>(m_audioCodecCtx->channels);
+#else
+                const uint32_t channels = static_cast<uint32_t>(m_audioCodecCtx->ch_layout.nb_channels);
+#endif
+                if (!m_audioPlayback || !m_audioPlayback->open(rate, channels))
+                {
+                    LOG_WARN("VideoCaptureRemote: audio playback open failed — continuing video-only");
+                    m_audioPlayback.reset();
+                }
+                else
+                {
+                    // Resampler: decoder may emit planar floats / s16,
+                    // but the sink wants packed float32. swr_convert
+                    // handles both layout and sample-format conversions
+                    // transparently per audio frame.
+                    m_swrCtx = swr_alloc();
+                    FFmpegCompat::setSwrChannelLayout(m_swrCtx, "in_chlayout",  static_cast<int>(channels));
+                    FFmpegCompat::setSwrChannelLayout(m_swrCtx, "out_chlayout", static_cast<int>(channels));
+                    av_opt_set_int(m_swrCtx, "in_sample_rate",     m_audioCodecCtx->sample_rate, 0);
+                    av_opt_set_int(m_swrCtx, "out_sample_rate",    rate,                          0);
+                    av_opt_set_sample_fmt(m_swrCtx, "in_sample_fmt",  m_audioCodecCtx->sample_fmt, 0);
+                    av_opt_set_sample_fmt(m_swrCtx, "out_sample_fmt", AV_SAMPLE_FMT_FLT,          0);
+                    if (swr_init(m_swrCtx) < 0)
+                    {
+                        LOG_WARN("VideoCaptureRemote: swr_init failed — disabling audio");
+                        swr_free(&m_swrCtx);
+                        m_audioPlayback.reset();
+                    }
+                    else
+                    {
+                        LOG_INFO("VideoCaptureRemote: audio ready — " + std::to_string(rate) +
+                                 " Hz x " + std::to_string(channels) + " ch, codec=" +
+                                 std::string(aCodec->name));
+                    }
+                }
+            }
+            else
+            {
+                LOG_WARN("VideoCaptureRemote: audio codec open failed");
+                if (m_audioCodecCtx) avcodec_free_context(&m_audioCodecCtx);
+            }
+        }
+    }
+
     return true;
 }
 
@@ -189,6 +281,27 @@ void VideoCaptureRemote::cleanupDecoder()
         m_formatCtx = nullptr;
     }
     m_videoStreamIdx = -1;
+
+    // Audio side: same teardown order as video. Close the sink first
+    // so the playback thread (WASAPI) exits before we free the codec
+    // state it might still be reading PTS from.
+    if (m_audioPlayback)
+    {
+        m_audioPlayback->close();
+        m_audioPlayback.reset();
+    }
+    if (m_swrCtx)
+    {
+        swr_free(&m_swrCtx);
+        m_swrCtx = nullptr;
+    }
+    if (m_audioCodecCtx)
+    {
+        avcodec_free_context(&m_audioCodecCtx);
+        m_audioCodecCtx = nullptr;
+    }
+    m_audioStreamIdx = -1;
+    m_audioScratch.clear();
 }
 
 void VideoCaptureRemote::close()
@@ -277,6 +390,11 @@ void VideoCaptureRemote::setInterpolationMode(InterpolationMode mode)
         m_blendBuffer.clear();
     }
     m_streamAnchored.store(false);
+    m_firstPtsUs.store(0);
+    // Flush stale audio so a mode-switch doesn't leak samples from
+    // the previous timing window into the new one (would briefly
+    // glitch the clock until the buffer drained).
+    if (m_audioPlayback) m_audioPlayback->flush();
 }
 
 void VideoCaptureRemote::setTargetResolution(uint32_t width, uint32_t height)
@@ -307,8 +425,31 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
     // any non-integer stream:refresh ratio, and lets the server
     // transmit at whatever rate it wants without the client needing
     // a "magic" matched fps.
-    const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
-                                  std::chrono::steady_clock::now().time_since_epoch()).count();
+    // A/V sync — audio is the master clock when the remote stream
+    // carries audio (the typical case). Audio is significantly more
+    // sensitive to timing glitches than video; locking the video
+    // gate to the audio output keeps lip-sync correct even when the
+    // wall clock drifts relative to the audio device clock (which it
+    // will, over minutes-long sessions). Without audio we fall back
+    // to wall-clock + anchor.
+    int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch()).count();
+    if (m_audioPlayback && m_audioPlayback->isOpen() && m_streamAnchored.load())
+    {
+        const int64_t audioPtsAbsUs = m_audioPlayback->getClockUs();
+        if (audioPtsAbsUs > 0)
+        {
+            // audioPtsAbsUs is in the same coordinate the video frame
+            // PTS uses (microseconds, stream-origin-relative to 0).
+            // Each video frame's targetWallUs was computed as
+            //   m_streamStartWallUs + (frame_pts_us - m_firstPtsUs).
+            // The audio-equivalent 'now' in wall-clock units is then
+            //   m_streamStartWallUs + (audio_pts_us - m_firstPtsUs).
+            const int64_t audioRelUs = audioPtsAbsUs - m_firstPtsUs.load();
+            nowWallUs = m_streamStartWallUs + audioRelUs;
+        }
+    }
+
     while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs)
     {
         m_lastConsumed = std::move(m_frameQueue.front());
@@ -443,6 +584,8 @@ void VideoCaptureRemote::decodeLoop()
             // be timed against the old anchor and either play in the
             // past or sit far in the future.
             m_streamAnchored.store(false);
+            m_firstPtsUs.store(0);
+            if (m_audioPlayback) m_audioPlayback->flush();
             {
                 std::lock_guard<std::mutex> lock(m_frameMutex);
                 m_frameQueue.clear();
@@ -466,6 +609,59 @@ void VideoCaptureRemote::decodeLoop()
             // Tear down so the top of the outer loop reopens. Don't
             // exit the thread — server is allowed to come back.
             cleanupDecoder();
+            continue;
+        }
+
+        // Audio packets: decode, resample to packed float32, push to
+        // the playback sink. The sink's getClockUs() is the A/V master
+        // clock for the video gating below.
+        if (packet->stream_index == m_audioStreamIdx && m_audioCodecCtx && m_audioPlayback)
+        {
+            if (avcodec_send_packet(m_audioCodecCtx, packet) >= 0)
+            {
+                AVFrame *aFrame = av_frame_alloc();
+                while (aFrame && avcodec_receive_frame(m_audioCodecCtx, aFrame) >= 0)
+                {
+                    const int nbIn    = aFrame->nb_samples;
+                    const int outRate = m_audioCodecCtx->sample_rate;
+                    // Resampler may need extra output samples — ask
+                    // it how many it will emit for this frame.
+                    int64_t maxOut = swr_get_out_samples(m_swrCtx, nbIn);
+                    if (maxOut < nbIn) maxOut = nbIn;
+                    const int channels =
+#if defined(FF_API_OLD_CHANNEL_LAYOUT) || LIBAVCODEC_VERSION_MAJOR < 60
+                        m_audioCodecCtx->channels;
+#else
+                        m_audioCodecCtx->ch_layout.nb_channels;
+#endif
+                    const size_t neededFloats = static_cast<size_t>(maxOut) * static_cast<size_t>(channels);
+                    if (m_audioScratch.size() < neededFloats)
+                    {
+                        m_audioScratch.assign(neededFloats, 0.0f);
+                    }
+                    uint8_t *outPlanes[1] = { reinterpret_cast<uint8_t *>(m_audioScratch.data()) };
+                    const int produced = swr_convert(m_swrCtx, outPlanes, static_cast<int>(maxOut),
+                                                     const_cast<const uint8_t **>(aFrame->data), nbIn);
+                    if (produced > 0)
+                    {
+                        // Convert the frame's PTS (stream-tb units)
+                        // to stream-origin-relative microseconds the
+                        // same way the video path does it — see the
+                        // anchor logic below. We can reuse the anchor
+                        // because both streams share the same /raw
+                        // demuxer.
+                        const int64_t aPts = (aFrame->pts != AV_NOPTS_VALUE) ? aFrame->pts : 0;
+                        const AVRational tb = m_formatCtx->streams[m_audioStreamIdx]->time_base;
+                        const int64_t ptsUs = static_cast<int64_t>(static_cast<double>(aPts) * av_q2d(tb) * 1e6);
+                        m_audioPlayback->submit(m_audioScratch.data(),
+                                                static_cast<size_t>(produced),
+                                                ptsUs);
+                    }
+                    av_frame_unref(aFrame);
+                }
+                if (aFrame) av_frame_free(&aFrame);
+            }
+            av_packet_unref(packet);
             continue;
         }
 
@@ -562,31 +758,23 @@ void VideoCaptureRemote::decodeLoop()
                     m_streamTimebaseSecs = av_q2d(tb);
                 }
                 if (m_streamTimebaseSecs <= 0.0) m_streamTimebaseSecs = 1.0 / 90000.0;
+                // Also store firstPts in microseconds so the audio path
+                // can convert its own absolute PTS into the same
+                // stream-origin-relative coordinate system.
+                m_firstPtsUs.store(static_cast<int64_t>(static_cast<double>(framePtsTicks) * m_streamTimebaseSecs * 1e6));
             }
             else
             {
                 const int64_t deltaTicks = framePtsTicks - m_firstPtsTicks;
                 const int64_t deltaUs    = static_cast<int64_t>(static_cast<double>(deltaTicks) * m_streamTimebaseSecs * 1e6);
                 targetWallUs = m_streamStartWallUs + deltaUs;
-                // Watchdog in both directions:
-                //  - >500 ms in the past: the stream paused / network
-                //    blipped, our queue would otherwise sit on stale
-                //    frames forever. Snap anchor forward.
-                //  - >500 ms in the future: the first-frame PTS we
-                //    used to anchor was bogus (commonly the very
-                //    first decoded packet arrives with AV_NOPTS_VALUE
-                //    and we substituted 0, so the second frame's real
-                //    PTS suddenly puts targets a full second ahead of
-                //    wall clock). That symptom was the user-reported
-                //    "primeiro frame translúcido sobre tudo": linear
-                //    mode held a ~95 %-F1 / 5 %-F2 blend on screen for
-                //    the whole 1 s catch-up window. Re-anchor on this
-                //    frame so we don't keep ghosting F1 forever.
+                // Watchdog in both directions: see prior comment for why.
                 if (targetWallUs + 500'000 < nowWallUs ||
                     targetWallUs > nowWallUs + 500'000)
                 {
                     m_streamStartWallUs = nowWallUs;
                     m_firstPtsTicks     = framePtsTicks;
+                    m_firstPtsUs.store(static_cast<int64_t>(static_cast<double>(framePtsTicks) * m_streamTimebaseSecs * 1e6));
                     targetWallUs        = nowWallUs;
                 }
             }

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -233,24 +233,21 @@ bool VideoCaptureRemote::captureFrame(Frame &frame)
 bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
 {
     std::lock_guard<std::mutex> lock(m_frameMutex);
-    // PTS-anchored release with a half-frame leniency window. The decoder
-    // tagged each queued frame with the wall-clock time it should appear
-    // on screen; we pop frames whose target has been reached, keeping the
-    // most recent one as "currently displayed". The half-frame window
-    // (kReleaseLeadUs) is the fix for "60 fps stream on a 60 Hz display
-    // doesn't feel like 60 fps": with a strict at-or-after PTS gate, a
-    // frame whose PTS jittered 1-2 ms later than the next display refresh
-    // missed that refresh and ended up shown for two cycles instead of
-    // one — invisible 3:2 pulldown judder. Allowing release up to ~8 ms
-    // before the target lets each frame land on the nearest refresh
-    // boundary instead of strictly the next one after PTS. The user
-    // worked around this by streaming at 120 fps, where every poll had
-    // a fresh frame whether or not the gate was strict; with this fix
-    // 60 fps streaming should feel as smooth as 120 fps used to.
-    constexpr int64_t kReleaseLeadUs = 8333; // half a 60 Hz frame
+    // PTS-anchored release with per-refresh linear interpolation. The
+    // decoder tagged each queued frame with the wall-clock time at
+    // which it should appear on screen. We drain frames whose target
+    // has passed (current frame becomes m_lastConsumed), then LERP
+    // between m_lastConsumed and queue.front() based on how far the
+    // current wall clock is between the two — so each refresh of a
+    // 144 Hz panel showing a 60 fps stream gets a unique intermediate
+    // image instead of an alternating 2-or-3-refresh hold. That
+    // eliminates the 3:2 pulldown judder that's otherwise inherent to
+    // any non-integer stream:refresh ratio, and lets the server
+    // transmit at whatever rate it wants without the client needing
+    // a "magic" matched fps.
     const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                   std::chrono::steady_clock::now().time_since_epoch()).count();
-    while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs + kReleaseLeadUs)
+    while (!m_frameQueue.empty() && m_frameQueue.front().targetWallUs <= nowWallUs)
     {
         m_lastConsumed = std::move(m_frameQueue.front());
         m_frameQueue.pop_front();
@@ -260,8 +257,66 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
     {
         return false;
     }
-    frame.data   = m_lastConsumed.rgb.data();
-    frame.size   = m_lastConsumed.rgb.size();
+
+    // Output buffer pointer & size — default to the cached frame; the
+    // interpolation path below replaces it with m_blendBuffer when
+    // there's a 'next' frame to interpolate toward. Frame.data is a
+    // non-const uint8_t* in the IVideoCapture contract; cast away
+    // const here because the downstream FrameProcessor never mutates
+    // these bytes — it just uploads them to a texture.
+    uint8_t *outData = m_lastConsumed.rgb.data();
+    size_t outSize   = m_lastConsumed.rgb.size();
+
+    if (!m_frameQueue.empty())
+    {
+        const QueuedFrame &next = m_frameQueue.front();
+        // Both endpoints must have matching dims for a meaningful blend.
+        // The shader pipeline / texture upload would reject a size
+        // mismatch anyway, so just skip interpolation across a resize.
+        if (next.width == m_lastConsumed.width &&
+            next.height == m_lastConsumed.height &&
+            next.rgb.size() == m_lastConsumed.rgb.size() &&
+            next.targetWallUs > m_lastConsumed.targetWallUs)
+        {
+            const int64_t span = next.targetWallUs - m_lastConsumed.targetWallUs;
+            int64_t pos = nowWallUs - m_lastConsumed.targetWallUs;
+            if (pos < 0) pos = 0;
+            if (pos > span) pos = span;
+            // 0..256 fixed-point weight for the *next* frame; (256 - tFp)
+            // weights the previous frame. Tighter than float math and
+            // autovectorises cleanly to AVX2 byte-blend on x86_64.
+            const int tFp     = static_cast<int>((pos * 256) / span);
+            const int oneMinus = 256 - tFp;
+
+            if (tFp > 0 && tFp < 256)
+            {
+                if (m_blendBuffer.size() != m_lastConsumed.rgb.size())
+                {
+                    m_blendBuffer.assign(m_lastConsumed.rgb.size(), 0);
+                }
+                const uint8_t *a = m_lastConsumed.rgb.data();
+                const uint8_t *b = next.rgb.data();
+                uint8_t *o       = m_blendBuffer.data();
+                const size_t n   = m_blendBuffer.size();
+                for (size_t i = 0; i < n; ++i)
+                {
+                    o[i] = static_cast<uint8_t>((a[i] * oneMinus + b[i] * tFp) >> 8);
+                }
+                outData = m_blendBuffer.data();
+                outSize = m_blendBuffer.size();
+            }
+            else if (tFp >= 256)
+            {
+                // Exactly at next frame's target — show next directly.
+                outData = const_cast<uint8_t *>(next.rgb.data());
+                outSize = next.rgb.size();
+            }
+            // tFp == 0 → still on m_lastConsumed, default path.
+        }
+    }
+
+    frame.data   = outData;
+    frame.size   = outSize;
     frame.width  = m_lastConsumed.width;
     frame.height = m_lastConsumed.height;
     frame.format = 0; // RGB24 — FrameProcessor's non-YUYV path

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -465,8 +465,29 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
             //   m_streamStartWallUs + (frame_pts_us - m_firstPtsUs).
             // The audio-equivalent 'now' in wall-clock units is then
             //   m_streamStartWallUs + (audio_pts_us - m_firstPtsUs).
-            const int64_t audioRelUs = audioPtsAbsUs - m_firstPtsUs.load();
-            nowWallUs = m_streamStartWallUs + audioRelUs;
+            const int64_t audioRelUs    = audioPtsAbsUs - m_firstPtsUs.load();
+            const int64_t audioNowWall  = m_streamStartWallUs + audioRelUs;
+            // Sanity gate: only let audio drive the video clock if it's
+            // within ±500 ms of wall-clock. If the audio clock has run
+            // off (pa_simple_get_latency reports stale, the playback
+            // sink hasn't actually started accepting samples, etc.) we'd
+            // otherwise hold every video frame back forever and the
+            // queue fills (the user-observed
+            // 'decoded=60/s consumed=30/s drops=30/s queueDepth=20').
+            const int64_t drift = audioNowWall - nowWallUs;
+            if (drift > -500'000 && drift < 500'000)
+            {
+                nowWallUs = audioNowWall;
+            }
+            else
+            {
+                static int driftLogCount = 0;
+                if (driftLogCount++ < 5)
+                {
+                    LOG_WARN("VideoCaptureRemote: audio clock drift=" + std::to_string(drift) +
+                             "us — falling back to wall clock for A/V sync");
+                }
+            }
         }
     }
 

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -1,0 +1,343 @@
+#include "VideoCaptureRemote.h"
+#include "../utils/Logger.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libswscale/swscale.h>
+}
+
+#include <chrono>
+#include <cstring>
+
+VideoCaptureRemote::VideoCaptureRemote() = default;
+
+VideoCaptureRemote::~VideoCaptureRemote()
+{
+    close();
+}
+
+bool VideoCaptureRemote::open(const std::string &url)
+{
+    if (m_open.load())
+    {
+        LOG_WARN("VideoCaptureRemote::open — already open, closing previous connection first");
+        close();
+    }
+
+    if (url.empty())
+    {
+        LOG_ERROR("VideoCaptureRemote::open — empty URL");
+        return false;
+    }
+
+    m_url = url;
+
+    // Strip trailing slash from base URL so the appended /raw lands cleanly.
+    if (!m_url.empty() && m_url.back() == '/')
+    {
+        m_url.pop_back();
+    }
+
+    LOG_INFO("VideoCaptureRemote: connecting to remote base URL " + m_url);
+
+    if (!initDecoder())
+    {
+        cleanupDecoder();
+        return false;
+    }
+
+    m_open.store(true);
+    return true;
+}
+
+bool VideoCaptureRemote::initDecoder()
+{
+    const std::string rawUrl = m_url + "/raw";
+
+    // FFmpeg networking init — idempotent, cheap to call.
+    avformat_network_init();
+
+    // Hint that we want low-latency probing. Without these flags FFmpeg may
+    // buffer up several seconds of input before deciding what stream params
+    // it has.
+    AVDictionary *opts = nullptr;
+    av_dict_set(&opts, "probesize",    "32768",        0); // bytes
+    av_dict_set(&opts, "analyzeduration", "500000",    0); // microseconds (0.5s)
+    av_dict_set(&opts, "fflags",       "nobuffer",     0);
+    av_dict_set(&opts, "timeout",      "5000000",      0); // 5s read timeout (microseconds)
+
+    int rc = avformat_open_input(&m_formatCtx, rawUrl.c_str(), nullptr, &opts);
+    av_dict_free(&opts);
+    if (rc < 0)
+    {
+        char errBuf[256] = {0};
+        av_strerror(rc, errBuf, sizeof(errBuf));
+        LOG_ERROR("VideoCaptureRemote: avformat_open_input failed for " + rawUrl + ": " + errBuf);
+        return false;
+    }
+
+    if (avformat_find_stream_info(m_formatCtx, nullptr) < 0)
+    {
+        LOG_ERROR("VideoCaptureRemote: avformat_find_stream_info failed");
+        return false;
+    }
+
+    m_videoStreamIdx = -1;
+    for (unsigned int i = 0; i < m_formatCtx->nb_streams; ++i)
+    {
+        if (m_formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+        {
+            m_videoStreamIdx = static_cast<int>(i);
+            break;
+        }
+    }
+    if (m_videoStreamIdx < 0)
+    {
+        LOG_ERROR("VideoCaptureRemote: no video stream in remote feed");
+        return false;
+    }
+
+    AVCodecParameters *codecPar = m_formatCtx->streams[m_videoStreamIdx]->codecpar;
+    const AVCodec *codec = avcodec_find_decoder(codecPar->codec_id);
+    if (!codec)
+    {
+        LOG_ERROR("VideoCaptureRemote: no decoder for codec id " + std::to_string(codecPar->codec_id));
+        return false;
+    }
+
+    m_codecCtx = avcodec_alloc_context3(codec);
+    if (!m_codecCtx)
+    {
+        LOG_ERROR("VideoCaptureRemote: avcodec_alloc_context3 failed");
+        return false;
+    }
+    if (avcodec_parameters_to_context(m_codecCtx, codecPar) < 0)
+    {
+        LOG_ERROR("VideoCaptureRemote: avcodec_parameters_to_context failed");
+        return false;
+    }
+    if (avcodec_open2(m_codecCtx, codec, nullptr) < 0)
+    {
+        LOG_ERROR("VideoCaptureRemote: avcodec_open2 failed");
+        return false;
+    }
+
+    m_width  = static_cast<uint32_t>(m_codecCtx->width);
+    m_height = static_cast<uint32_t>(m_codecCtx->height);
+    m_pixelFormat = 0; // signals "RGB24" to FrameProcessor
+
+    LOG_INFO("VideoCaptureRemote: decoder ready — " + std::to_string(m_width) + "x" + std::to_string(m_height) +
+             " codec=" + std::string(codec->name));
+
+    return true;
+}
+
+void VideoCaptureRemote::cleanupDecoder()
+{
+    if (m_swsCtx)
+    {
+        sws_freeContext(m_swsCtx);
+        m_swsCtx = nullptr;
+    }
+    if (m_codecCtx)
+    {
+        avcodec_free_context(&m_codecCtx);
+        m_codecCtx = nullptr;
+    }
+    if (m_formatCtx)
+    {
+        avformat_close_input(&m_formatCtx);
+        m_formatCtx = nullptr;
+    }
+    m_videoStreamIdx = -1;
+}
+
+void VideoCaptureRemote::close()
+{
+    stopCapture();
+    cleanupDecoder();
+    m_open.store(false);
+    m_url.clear();
+    {
+        std::lock_guard<std::mutex> lock(m_frameMutex);
+        m_latestRGB.clear();
+        m_latestW = m_latestH = 0;
+        m_hasFrame.store(false);
+    }
+}
+
+bool VideoCaptureRemote::setFormat(uint32_t, uint32_t, uint32_t)
+{
+    // The remote server dictates the resolution. captureFrame returns frames
+    // at whatever size the decoder produces; the upstream FrameProcessor is
+    // already happy with dynamic frame sizes.
+    return true;
+}
+
+bool VideoCaptureRemote::setFramerate(uint32_t)
+{
+    // Same idea — server-controlled.
+    return true;
+}
+
+bool VideoCaptureRemote::startCapture()
+{
+    if (!m_open.load())
+    {
+        LOG_ERROR("VideoCaptureRemote::startCapture — not open");
+        return false;
+    }
+    if (m_decodeRunning.load())
+    {
+        return true;
+    }
+    m_decodeRunning.store(true);
+    m_decodeThread = std::thread(&VideoCaptureRemote::decodeLoop, this);
+    return true;
+}
+
+void VideoCaptureRemote::stopCapture()
+{
+    if (!m_decodeRunning.load())
+    {
+        return;
+    }
+    m_decodeRunning.store(false);
+    if (m_decodeThread.joinable())
+    {
+        m_decodeThread.join();
+    }
+}
+
+bool VideoCaptureRemote::captureFrame(Frame &frame)
+{
+    return captureLatestFrame(frame);
+}
+
+bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
+{
+    std::lock_guard<std::mutex> lock(m_frameMutex);
+    if (!m_hasFrame.load() || m_latestRGB.empty())
+    {
+        return false;
+    }
+    frame.data   = m_latestRGB.data();
+    frame.size   = m_latestRGB.size();
+    frame.width  = m_latestW;
+    frame.height = m_latestH;
+    frame.format = 0; // RGB24 — FrameProcessor's non-YUYV path
+    return true;
+}
+
+void VideoCaptureRemote::decodeLoop()
+{
+    AVPacket *packet = av_packet_alloc();
+    AVFrame  *frame  = av_frame_alloc();
+    AVFrame  *rgb    = av_frame_alloc();
+    if (!packet || !frame || !rgb)
+    {
+        LOG_ERROR("VideoCaptureRemote::decodeLoop — av_frame_alloc / av_packet_alloc failed");
+        if (packet) av_packet_free(&packet);
+        if (frame)  av_frame_free(&frame);
+        if (rgb)    av_frame_free(&rgb);
+        return;
+    }
+
+    // RGB scratch buffer attached to the rgb AVFrame; sized lazily once we
+    // see the first decoded frame, since the source dimensions may differ
+    // from m_codecCtx->width/height after a key-frame parameter set update.
+    int rgbW = 0, rgbH = 0;
+    std::vector<uint8_t> rgbBuf;
+
+    while (m_decodeRunning.load())
+    {
+        int rc = av_read_frame(m_formatCtx, packet);
+        if (rc < 0)
+        {
+            if (rc == AVERROR(EAGAIN))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                continue;
+            }
+            char errBuf[128] = {0};
+            av_strerror(rc, errBuf, sizeof(errBuf));
+            LOG_WARN("VideoCaptureRemote::decodeLoop — av_read_frame: " + std::string(errBuf));
+            break; // Connection lost / EOF — exit loop.
+        }
+
+        if (packet->stream_index != m_videoStreamIdx)
+        {
+            av_packet_unref(packet);
+            continue;
+        }
+
+        if (avcodec_send_packet(m_codecCtx, packet) < 0)
+        {
+            av_packet_unref(packet);
+            continue;
+        }
+        av_packet_unref(packet);
+
+        while (m_decodeRunning.load())
+        {
+            int r = avcodec_receive_frame(m_codecCtx, frame);
+            if (r == AVERROR(EAGAIN) || r == AVERROR_EOF) break;
+            if (r < 0)
+            {
+                LOG_WARN("VideoCaptureRemote::decodeLoop — avcodec_receive_frame failed");
+                break;
+            }
+
+            const int w = frame->width;
+            const int h = frame->height;
+            if (w <= 0 || h <= 0) { av_frame_unref(frame); continue; }
+
+            // (Re)build the sws context if dimensions or pixfmt changed.
+            const AVPixelFormat srcFmt = static_cast<AVPixelFormat>(frame->format);
+            m_swsCtx = sws_getCachedContext(m_swsCtx,
+                                            w, h, srcFmt,
+                                            w, h, AV_PIX_FMT_RGB24,
+                                            SWS_BILINEAR, nullptr, nullptr, nullptr);
+            if (!m_swsCtx)
+            {
+                LOG_ERROR("VideoCaptureRemote::decodeLoop — sws_getCachedContext failed");
+                av_frame_unref(frame);
+                continue;
+            }
+
+            if (w != rgbW || h != rgbH)
+            {
+                rgbW = w;
+                rgbH = h;
+                rgbBuf.assign(static_cast<size_t>(w) * static_cast<size_t>(h) * 3, 0);
+            }
+
+            uint8_t *dstSlices[1] = { rgbBuf.data() };
+            int dstStrides[1]     = { w * 3 };
+            sws_scale(m_swsCtx, frame->data, frame->linesize, 0, h, dstSlices, dstStrides);
+            av_frame_unref(frame);
+
+            // Publish the new frame.
+            {
+                std::lock_guard<std::mutex> lock(m_frameMutex);
+                if (m_latestRGB.size() != rgbBuf.size())
+                {
+                    m_latestRGB.resize(rgbBuf.size());
+                }
+                std::memcpy(m_latestRGB.data(), rgbBuf.data(), rgbBuf.size());
+                m_latestW = static_cast<uint32_t>(w);
+                m_latestH = static_cast<uint32_t>(h);
+            }
+            m_width  = static_cast<uint32_t>(w);
+            m_height = static_cast<uint32_t>(h);
+            m_hasFrame.store(true);
+        }
+    }
+
+    av_packet_free(&packet);
+    av_frame_free(&frame);
+    av_frame_free(&rgb);
+}

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -217,6 +217,31 @@ void VideoCaptureRemote::stopCapture()
     }
 }
 
+void VideoCaptureRemote::setInterpolationMode(InterpolationMode mode)
+{
+    if (m_interpolationMode.load() == mode) return;
+    m_interpolationMode.store(mode);
+
+    // Hot-switch hygiene: linear mode keeps a blend of the previous and
+    // next frame stuck on screen until the queue advances, so flipping
+    // back and forth between Linear / Nearest / Off while a stream is
+    // running leaves the previous mode's last frame as a static ghost
+    // ("o primeiro frame que chegou está estático na frente" — exactly
+    // that). Drop any queued frames and forget the last consumed one so
+    // the next captureLatestFrame call rebuilds state from scratch in
+    // the new mode. m_streamAnchored is reset too, so the decode thread
+    // re-establishes the wall-clock anchor on the next decoded frame —
+    // the previous mode's anchor may have drifted relative to where the
+    // new mode wants to start.
+    {
+        std::lock_guard<std::mutex> lock(m_frameMutex);
+        m_frameQueue.clear();
+        m_lastConsumed = QueuedFrame{};
+        m_blendBuffer.clear();
+    }
+    m_streamAnchored.store(false);
+}
+
 void VideoCaptureRemote::setTargetResolution(uint32_t width, uint32_t height)
 {
     // Atomic stores — picked up by the decode thread on the next frame.
@@ -380,7 +405,7 @@ void VideoCaptureRemote::decodeLoop()
             // disconnect. Otherwise the new stream's PTS=0 frame would
             // be timed against the old anchor and either play in the
             // past or sit far in the future.
-            m_streamAnchored = false;
+            m_streamAnchored.store(false);
             {
                 std::lock_guard<std::mutex> lock(m_frameMutex);
                 m_frameQueue.clear();
@@ -489,9 +514,9 @@ void VideoCaptureRemote::decodeLoop()
             const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                           std::chrono::steady_clock::now().time_since_epoch()).count();
             int64_t targetWallUs = nowWallUs;
-            if (!m_streamAnchored)
+            if (!m_streamAnchored.load())
             {
-                m_streamAnchored = true;
+                m_streamAnchored.store(true);
                 m_streamStartWallUs = nowWallUs;
                 m_firstPtsTicks     = framePtsTicks;
                 if (m_formatCtx && m_videoStreamIdx >= 0)

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -142,9 +142,24 @@ private:
     std::mutex             m_frameMutex;
     std::deque<QueuedFrame> m_frameQueue;
     // Last frame handed to the consumer — used to keep something on screen
-    // (rather than dummy black) when the queue is momentarily empty.
+    // (rather than dummy black) when the queue is momentarily empty, and
+    // as one of the two endpoints for the per-refresh interpolation
+    // (see m_blendBuffer below).
     QueuedFrame             m_lastConsumed;
     std::atomic<bool>       m_hasFrame{false};
+
+    // Per-refresh interpolation output buffer. The classic 3:2 pulldown
+    // problem (60 fps stream into a 144 Hz panel = 2.4 refreshes per
+    // frame → alternating 2/3-refresh hold times → visible judder) is
+    // a non-integer ratio issue that no choice of stream rate can fully
+    // solve at the client side. Instead, on every captureLatestFrame
+    // call we LERP between m_lastConsumed and the next queued frame
+    // using t = (now - prevTarget) / (nextTarget - prevTarget), so each
+    // refresh shows a unique intermediate image rather than a held
+    // duplicate. Indistinguishable from real motion at typical
+    // stream:refresh ratios; the dependency on the server transmitting
+    // at a "magic" matched rate goes away.
+    std::vector<uint8_t> m_blendBuffer;
 
     // PTS-anchored playback. On the first decoded frame we record the
     // current wall clock as the "stream zero" reference and the frame's

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -121,6 +121,14 @@ private:
 
     std::thread        m_decodeThread;
     std::atomic<bool>  m_decodeRunning{false};
+    // Set during stopCapture()/close() so the FFmpeg interrupt_callback
+    // can abort whichever blocking I/O the decode thread is parked in.
+    // Distinct from m_decodeRunning because m_decodeRunning is only
+    // true while the worker thread is alive; the callback fires from
+    // inside open()/avformat_open_input as well, and we don't want it
+    // tripping during the initial open just because the worker hasn't
+    // started yet.
+    std::atomic<bool>  m_decodeAborted{false};
 
     // Small bounded queue of decoded RGB frames. Decoder pushes to back;
     // consumer pops front. When the queue would exceed kMaxQueued the

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -61,9 +61,28 @@ public:
     bool startCapture() override;
     void stopCapture() override;
 
-    uint32_t getWidth() const override { return m_width; }
-    uint32_t getHeight() const override { return m_height; }
+    uint32_t getWidth() const override
+    {
+        const uint32_t tw = m_targetWidth.load();
+        return tw ? tw : m_width;
+    }
+    uint32_t getHeight() const override
+    {
+        const uint32_t th = m_targetHeight.load();
+        return th ? th : m_height;
+    }
     uint32_t getPixelFormat() const override { return m_pixelFormat; }
+
+    /**
+     * Resize the decoded frame to (width, height) before delivering it to
+     * the rest of the capture pipeline. Used by the remote-source path
+     * when the host's /meta reports a different source resolution than
+     * what the /raw stream is encoded at — the client wants the shader
+     * to run on the host's logical source dims, not the smaller
+     * transmission dims. Pass (0, 0) to disable rescaling and pass the
+     * decoded frames through at their native size.
+     */
+    void setTargetResolution(uint32_t width, uint32_t height);
 
 private:
     void decodeLoop();
@@ -76,6 +95,11 @@ private:
     uint32_t m_width = 0;
     uint32_t m_height = 0;
     uint32_t m_pixelFormat = 0; // 0 means "RGB24" for downstream FrameProcessor
+
+    // Optional rescale target. 0/0 means "pass through at stream resolution".
+    // Mutated from the application's main thread; read on the decode thread.
+    std::atomic<uint32_t> m_targetWidth{0};
+    std::atomic<uint32_t> m_targetHeight{0};
 
     AVFormatContext *m_formatCtx = nullptr;
     AVCodecContext  *m_codecCtx  = nullptr;

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -123,6 +123,10 @@ private:
         std::vector<uint8_t> rgb;
         uint32_t             width  = 0;
         uint32_t             height = 0;
+        // Wall-clock target time (steady_clock microseconds) at which this
+        // frame should become the on-screen frame. Computed in the decode
+        // loop from frame.pts and the stream anchor — see decodeLoop().
+        int64_t              targetWallUs = 0;
     };
     static constexpr size_t kMaxQueued = 5;
 
@@ -132,6 +136,20 @@ private:
     // (rather than dummy black) when the queue is momentarily empty.
     QueuedFrame             m_lastConsumed;
     std::atomic<bool>       m_hasFrame{false};
+
+    // PTS-anchored playback. On the first decoded frame we record the
+    // current wall clock as the "stream zero" reference and the frame's
+    // PTS as the stream PTS origin. Every subsequent frame's target wall
+    // time = m_streamStartWallUs + (pts - m_firstPtsTicks) * timebase.
+    // captureLatestFrame() then only releases a frame once its target
+    // time has been reached, holding the previously released frame on
+    // screen until then — eliminates the irregular 1/2-refresh-cycle
+    // judder we get when network/decoder bursts let us poll multiple
+    // new frames in quick succession.
+    bool    m_streamAnchored     = false;
+    int64_t m_streamStartWallUs  = 0;
+    int64_t m_firstPtsTicks      = 0;
+    double  m_streamTimebaseSecs = 0.0;
 
     // Rolling 1-second decode/consume counters — produces a periodic
     // LOG_INFO so rate mismatches and dropped-burst frames are visible

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -95,7 +95,7 @@ public:
         Nearest, // pick the temporally closer frame — clean image, 3:2 pulldown
         Off      // strict PTS gate, hold prev until next is due
     };
-    void setInterpolationMode(InterpolationMode mode) { m_interpolationMode.store(mode); }
+    void setInterpolationMode(InterpolationMode mode);
 
 private:
     void decodeLoop();
@@ -183,7 +183,7 @@ private:
     // screen until then — eliminates the irregular 1/2-refresh-cycle
     // judder we get when network/decoder bursts let us poll multiple
     // new frames in quick succession.
-    bool    m_streamAnchored     = false;
+    std::atomic<bool> m_streamAnchored{false};
     int64_t m_streamStartWallUs  = 0;
     int64_t m_firstPtsTicks      = 0;
     double  m_streamTimebaseSecs = 0.0;

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "IVideoCapture.h"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <cstdint>
+#include <string>
+
+// Forward-declare FFmpeg types so the FFmpeg headers stay out of this .h
+struct AVFormatContext;
+struct AVCodecContext;
+struct AVFrame;
+struct SwsContext;
+
+/**
+ * @brief Remote MPEG-TS source — consumes /raw from another RetroCapture
+ *        instance.
+ *
+ * Phase 3 of issue #47. open(url) takes the BASE URL of a remote server
+ * (e.g. "http://host:8080"); the implementation appends "/raw" by
+ * convention. Frames decoded from the stream are converted to RGB24 and
+ * delivered through the same IVideoCapture contract used by V4L2 / DS.
+ *
+ * Hardware-control surface (brightness/contrast/etc.) is a no-op: a
+ * remote stream isn't a piece of capture hardware and there's nothing to
+ * tweak from this side. The viewer-side shader pipeline lives in the
+ * usual ShaderEngine and is wired in Phase 4.
+ */
+class VideoCaptureRemote : public IVideoCapture
+{
+public:
+    VideoCaptureRemote();
+    ~VideoCaptureRemote() override;
+
+    // IVideoCapture
+    bool open(const std::string &url) override;
+    void close() override;
+    bool isOpen() const override { return m_open.load(); }
+
+    bool setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat = 0) override;
+    bool setFramerate(uint32_t fps) override;
+
+    bool captureFrame(Frame &frame) override;
+    bool captureLatestFrame(Frame &frame) override;
+
+    // Hardware controls — not applicable to a remote stream.
+    bool setControl(const std::string &, int32_t) override { return false; }
+    bool getControl(const std::string &, int32_t &) override { return false; }
+    bool getControlMin(const std::string &, int32_t &) override { return false; }
+    bool getControlMax(const std::string &, int32_t &) override { return false; }
+    bool getControlDefault(const std::string &, int32_t &) override { return false; }
+
+    std::vector<DeviceInfo> listDevices() override { return {}; }
+
+    void setDummyMode(bool) override {}
+    bool isDummyMode() const override { return false; }
+
+    bool startCapture() override;
+    void stopCapture() override;
+
+    uint32_t getWidth() const override { return m_width; }
+    uint32_t getHeight() const override { return m_height; }
+    uint32_t getPixelFormat() const override { return m_pixelFormat; }
+
+private:
+    void decodeLoop();
+    bool initDecoder();
+    void cleanupDecoder();
+
+    std::string m_url;        // base URL — "/raw" is appended internally
+    std::atomic<bool> m_open{false};
+
+    uint32_t m_width = 0;
+    uint32_t m_height = 0;
+    uint32_t m_pixelFormat = 0; // 0 means "RGB24" for downstream FrameProcessor
+
+    AVFormatContext *m_formatCtx = nullptr;
+    AVCodecContext  *m_codecCtx  = nullptr;
+    SwsContext      *m_swsCtx    = nullptr;
+    int              m_videoStreamIdx = -1;
+
+    std::thread        m_decodeThread;
+    std::atomic<bool>  m_decodeRunning{false};
+
+    // Latest decoded frame buffer. captureFrame / captureLatestFrame copy
+    // from here. Single-slot — newer frames overwrite older ones if the
+    // consumer hasn't pulled them yet (lossy by design; the encoder thread
+    // upstream will keep producing).
+    std::mutex            m_frameMutex;
+    std::vector<uint8_t>  m_latestRGB;
+    uint32_t              m_latestW = 0;
+    uint32_t              m_latestH = 0;
+    std::atomic<bool>     m_hasFrame{false};
+};

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -3,11 +3,12 @@
 #include "IVideoCapture.h"
 
 #include <atomic>
+#include <cstdint>
+#include <deque>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
-#include <cstdint>
-#include <string>
 
 // Forward-declare FFmpeg types so the FFmpeg headers stay out of this .h
 struct AVFormatContext;
@@ -109,13 +110,25 @@ private:
     std::thread        m_decodeThread;
     std::atomic<bool>  m_decodeRunning{false};
 
-    // Latest decoded frame buffer. captureFrame / captureLatestFrame copy
-    // from here. Single-slot — newer frames overwrite older ones if the
-    // consumer hasn't pulled them yet (lossy by design; the encoder thread
-    // upstream will keep producing).
-    std::mutex            m_frameMutex;
-    std::vector<uint8_t>  m_latestRGB;
-    uint32_t              m_latestW = 0;
-    uint32_t              m_latestH = 0;
-    std::atomic<bool>     m_hasFrame{false};
+    // Small bounded queue of decoded RGB frames. Decoder pushes to back;
+    // consumer pops front. When the queue would exceed kMaxQueued the
+    // oldest frame is dropped — bounds the latency at a few frames while
+    // absorbing TCP / decoder bursts that would otherwise overwrite mid-
+    // burst frames if we kept a single-slot buffer. Replaces the "single
+    // slot, newer overwrites older" design from the first cut of this
+    // class.
+    struct QueuedFrame
+    {
+        std::vector<uint8_t> rgb;
+        uint32_t             width  = 0;
+        uint32_t             height = 0;
+    };
+    static constexpr size_t kMaxQueued = 3;
+
+    std::mutex             m_frameMutex;
+    std::deque<QueuedFrame> m_frameQueue;
+    // Last frame handed to the consumer — used to keep something on screen
+    // (rather than dummy black) when the queue is momentarily empty.
+    QueuedFrame             m_lastConsumed;
+    std::atomic<bool>       m_hasFrame{false};
 };

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -128,7 +128,16 @@ private:
         // loop from frame.pts and the stream anchor — see decodeLoop().
         int64_t              targetWallUs = 0;
     };
-    static constexpr size_t kMaxQueued = 5;
+    // Bigger buffer absorbs the bursty arrival pattern produced by the
+    // server's variable-rate encoder + TCP buffering. PTS-anchored
+    // release means frames sit in the queue waiting for their target
+    // display moment, so bursts that arrive faster than the stream's
+    // average rate stack up briefly before draining. 5 was tight enough
+    // that bursts overflowed regularly (user observed drops=1-7/s in
+    // the decode loop telemetry); 20 gives ~500 ms of headroom at 40
+    // fps which is plenty for ordinary network jitter and still under
+    // the latency budget for distributed shader preview.
+    static constexpr size_t kMaxQueued = 20;
 
     std::mutex             m_frameMutex;
     std::deque<QueuedFrame> m_frameQueue;

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -3,6 +3,7 @@
 #include "IVideoCapture.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <deque>
 #include <mutex>
@@ -123,7 +124,7 @@ private:
         uint32_t             width  = 0;
         uint32_t             height = 0;
     };
-    static constexpr size_t kMaxQueued = 3;
+    static constexpr size_t kMaxQueued = 5;
 
     std::mutex             m_frameMutex;
     std::deque<QueuedFrame> m_frameQueue;
@@ -131,4 +132,12 @@ private:
     // (rather than dummy black) when the queue is momentarily empty.
     QueuedFrame             m_lastConsumed;
     std::atomic<bool>       m_hasFrame{false};
+
+    // Rolling 1-second decode/consume counters — produces a periodic
+    // LOG_INFO so rate mismatches and dropped-burst frames are visible
+    // in the log. Reset every second.
+    uint32_t m_statProduced = 0;
+    uint32_t m_statConsumed = 0;
+    uint32_t m_statDropped  = 0;
+    std::chrono::steady_clock::time_point m_statStart;
 };

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstdint>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -16,6 +17,8 @@ struct AVFormatContext;
 struct AVCodecContext;
 struct AVFrame;
 struct SwsContext;
+struct SwrContext;
+class  IAudioPlayback;
 
 /**
  * @brief Remote MPEG-TS source — consumes /raw from another RetroCapture
@@ -119,6 +122,19 @@ private:
     SwsContext      *m_swsCtx    = nullptr;
     int              m_videoStreamIdx = -1;
 
+    // Remote-stream audio path. Activated when the /raw demuxer
+    // exposes an audio stream — we decode it alongside video in the
+    // same decodeLoop and submit the float-PCM samples to the
+    // platform playback sink. The sink's getClockUs() becomes the
+    // A/V master clock for the captureLatestFrame() blend gate.
+    AVCodecContext  *m_audioCodecCtx = nullptr;
+    SwrContext      *m_swrCtx        = nullptr;
+    int              m_audioStreamIdx = -1;
+    std::unique_ptr<IAudioPlayback> m_audioPlayback;
+    // Reusable scratch so we don't reallocate per audio frame. Sized
+    // by the resampler's max-output estimate.
+    std::vector<float> m_audioScratch;
+
     std::thread        m_decodeThread;
     std::atomic<bool>  m_decodeRunning{false};
     // Set during stopCapture()/close() so the FFmpeg interrupt_callback
@@ -194,6 +210,13 @@ private:
     std::atomic<bool> m_streamAnchored{false};
     int64_t m_streamStartWallUs  = 0;
     int64_t m_firstPtsTicks      = 0;
+    // PTS of the first video frame in microseconds. Lets the audio
+    // path (which has its own stream timebase) translate its absolute
+    // PTS into the same stream-origin-relative coordinate the video
+    // queue uses. Both audio and video share the same MPEG-TS clock,
+    // so subtracting this gives 'microseconds since the first frame
+    // of the stream'.
+    std::atomic<int64_t> m_firstPtsUs{0};
     double  m_streamTimebaseSecs = 0.0;
 
     // Rolling 1-second decode/consume counters — produces a periodic

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -86,6 +86,17 @@ public:
      */
     void setTargetResolution(uint32_t width, uint32_t height);
 
+    // Per-refresh interpolation strategy when filling display refreshes
+    // between two consecutive stream frames. See captureLatestFrame for
+    // the per-mode semantics.
+    enum class InterpolationMode
+    {
+        Linear,  // LERP prev/next — smooth motion, slight ghosting
+        Nearest, // pick the temporally closer frame — clean image, 3:2 pulldown
+        Off      // strict PTS gate, hold prev until next is due
+    };
+    void setInterpolationMode(InterpolationMode mode) { m_interpolationMode.store(mode); }
+
 private:
     void decodeLoop();
     bool initDecoder();
@@ -147,6 +158,8 @@ private:
     // (see m_blendBuffer below).
     QueuedFrame             m_lastConsumed;
     std::atomic<bool>       m_hasFrame{false};
+
+    std::atomic<InterpolationMode> m_interpolationMode{InterpolationMode::Linear};
 
     // Per-refresh interpolation output buffer. The classic 3:2 pulldown
     // problem (60 fps stream into a 144 Hz panel = 2.4 refreshes per

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3745,13 +3745,27 @@ void Application::run()
                                     memcpy(dstPtr, srcPtr, readRowSizeUnpadded);
                                 }
 
-                                if (m_streamManager && m_streamManager->isActive())
+                                // Same target-FPS throttle as the FBO-complete push path
+                                // below — keeps the encoder fed at the configured streaming
+                                // rate regardless of how fast the main loop iterates (no
+                                // vsync, high-refresh-rate display, free-run).
                                 {
-                                    m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
-                                }
-                                if (m_recordingManager && m_recordingManager->isRecording())
-                                {
-                                    m_recordingManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                    const int64_t pboTargetFps = (m_ui && m_ui->getStreamingFps() > 0) ? m_ui->getStreamingFps() : 60;
+                                    const int64_t pboMinIntervalUs = 1000000LL / pboTargetFps;
+                                    const int64_t pboNowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                                                std::chrono::steady_clock::now().time_since_epoch()).count();
+                                    if (pboNowUs - m_lastStreamPushUs >= pboMinIntervalUs)
+                                    {
+                                        m_lastStreamPushUs = pboNowUs;
+                                        if (m_streamManager && m_streamManager->isActive())
+                                        {
+                                            m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        }
+                                        if (m_recordingManager && m_recordingManager->isRecording())
+                                        {
+                                            m_recordingManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        }
+                                    }
                                 }
                             }
                             else
@@ -4021,8 +4035,23 @@ void Application::run()
 
                                 // Share frame data between streaming and recording.
                                 // Pula push se o PBO async ainda não tem dados do frame anterior.
-                                if (frameDataReady && m_streamManager && m_streamManager->isActive())
+                                //
+                                // Throttle pushes to the configured streaming FPS — when the
+                                // main loop runs faster than the target frame rate (no vsync,
+                                // 240Hz display, free-run), pushing every iteration produces
+                                // hundreds of frames per second arriving at the encoder with
+                                // near-identical timestamps. That causes PTS retrocession,
+                                // overflow drops in the synchronizer and the visible
+                                // "back-and-forth" jitter the client sees.
+                                const int64_t s_targetFps = (m_ui && m_ui->getStreamingFps() > 0) ? m_ui->getStreamingFps() : 60;
+                                const int64_t s_minIntervalUs = 1000000LL / s_targetFps;
+                                const int64_t s_nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                                            std::chrono::steady_clock::now().time_since_epoch()).count();
+                                const bool s_pushAllowed = (s_nowUs - m_lastStreamPushUs >= s_minIntervalUs);
+
+                                if (s_pushAllowed && frameDataReady && m_streamManager && m_streamManager->isActive())
                                 {
+                                    m_lastStreamPushUs = s_nowUs;
                                     const bool useSource = streamWantsSource && sourceFrameReady;
                                     static int streamPushLogCount = 0;
                                     if (streamPushLogCount++ < 3 && m_ui)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4049,6 +4049,23 @@ void Application::run()
                                                             std::chrono::steady_clock::now().time_since_epoch()).count();
                                 const bool s_pushAllowed = (s_nowUs - m_lastStreamPushUs >= s_minIntervalUs);
 
+                                // 1s diagnostic so we can confirm the throttle is actually firing.
+                                static int64_t s_lastTickUs = 0;
+                                static uint32_t s_pushCount = 0;
+                                static uint32_t s_skipCount = 0;
+                                if (s_pushAllowed) ++s_pushCount;
+                                else ++s_skipCount;
+                                if (s_lastTickUs == 0) s_lastTickUs = s_nowUs;
+                                if (s_nowUs - s_lastTickUs >= 1000000LL)
+                                {
+                                    LOG_INFO("push throttle (FBO): targetFps=" + std::to_string(s_targetFps) +
+                                             " minIntervalUs=" + std::to_string(s_minIntervalUs) +
+                                             " pushes=" + std::to_string(s_pushCount) +
+                                             "/s skips=" + std::to_string(s_skipCount) + "/s");
+                                    s_pushCount = s_skipCount = 0;
+                                    s_lastTickUs = s_nowUs;
+                                }
+
                                 if (s_pushAllowed && frameDataReady && m_streamManager && m_streamManager->isActive())
                                 {
                                     m_lastStreamPushUs = s_nowUs;

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5,6 +5,7 @@
 #include "../capture/VideoCaptureFactory.h"
 #include "../capture/VideoCaptureRemote.h"
 #include "../streaming/RemoteMetaSync.h"
+#include "../encoding/MediaEncoder.h"
 #ifdef PLATFORM_LINUX
 #include "../v4l2/V4L2ControlMapper.h"
 #endif
@@ -1107,6 +1108,7 @@ bool Application::initUI()
     m_streamingVideoCodec = m_ui->getStreamingVideoCodec();
     m_streamingAudioCodec = m_ui->getStreamingAudioCodec();
     m_streamingH264Preset = m_ui->getStreamingH264Preset();
+    m_streamingHardwareEncoder = m_ui->getStreamingHardwareEncoder();
     m_streamingH265Preset = m_ui->getStreamingH265Preset();
     m_streamingH265Profile = m_ui->getStreamingH265Profile();
     m_streamingH265Level = m_ui->getStreamingH265Level();
@@ -1506,6 +1508,19 @@ bool Application::initUI()
                                         {
         m_streamingVP9Speed = speed;
         // If streaming is active, restart to apply new speed
+        if (m_streamingEnabled && m_streamManager) {
+            m_streamManager->stop();
+            m_streamManager->cleanup();
+            m_streamManager.reset();
+            initStreaming();
+        } });
+
+    m_ui->setOnStreamingHardwareEncoderChanged([this](int v)
+                                               {
+        m_streamingHardwareEncoder = v;
+        // Encoder backend is set at codec-init time inside MediaEncoder;
+        // a live stream needs a restart for the new selection to take
+        // effect (just like a preset / bitrate change does).
         if (m_streamingEnabled && m_streamManager) {
             m_streamManager->stop();
             m_streamManager->cleanup();
@@ -2544,6 +2559,7 @@ bool Application::initStreaming()
     if (m_streamingVideoCodec == "h264")
     {
         tsStreamer->setH264Preset(m_streamingH264Preset);
+        tsStreamer->setHardwareEncoder(static_cast<MediaEncoder::HardwareEncoder>(m_streamingHardwareEncoder));
     }
     // Configure H.265 preset, profile and level (if applicable)
     else if (m_streamingVideoCodec == "h265" || m_streamingVideoCodec == "hevc")
@@ -4981,6 +4997,7 @@ void Application::createPresetFromCurrentState(const std::string &name, const st
         data.streamingH265Level = m_streamingH265Level;
         data.streamingVP8Speed = m_streamingVP8Speed;
         data.streamingVP9Speed = m_streamingVP9Speed;
+        data.streamingHardwareEncoder = m_streamingHardwareEncoder;
     }
 
     // Collect V4L2 controls (if applicable)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4304,30 +4304,25 @@ void Application::run()
                 m_window->swapBuffers();
             }
 
-            // Render pacing for the valid-frame branch. The else-branch
-            // below has the same block; both paths need it because the
-            // outer if/else is "frame ready vs not" and most iterations
-            // hit the valid-frame branch — without pacing here the main
-            // loop free-runs at display refresh (the 1000+ fps reading
-            // the user saw in MangoHud right after /raw client connect).
+            // Pacing policy:
+            //  - Remote source: vsync (enabled in setOnSourceTypeChanged
+            //    when entering Remote) drives the loop at the panel's
+            //    display refresh rate. Adding a stream-fps software
+            //    pacing on top capped the loop at 60 Hz even on a
+            //    144 Hz panel, which is what made 60 fps streams look
+            //    choppy ("3:2 pulldown" 2-3 refresh pattern) compared
+            //    to 120 fps: the user couldn't use the extra refreshes
+            //    the panel had on offer because we were sleeping
+            //    through them. Free-running with vsync gives the
+            //    cleanest possible cadence at whatever stream:refresh
+            //    ratio the user picked.
+            //  - Local source streaming: keep the existing software
+            //    pace at the configured streaming FPS so we don't
+            //    burn GPU + glReadPixels for frames the encoder will
+            //    just throttle.
             if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
             {
-                const uint32_t fps = m_remoteSourceFps > 0 ? m_remoteSourceFps : 60;
-                const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
-                                          std::chrono::steady_clock::now().time_since_epoch()).count();
-                const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(fps);
-                if (m_lastFrameSwapUs == 0) m_lastFrameSwapUs = nowUs;
-                const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
-                if (elapsedUs < targetIntervalUs)
-                {
-                    const int64_t sleepUs = targetIntervalUs - elapsedUs;
-#ifdef PLATFORM_LINUX
-                    usleep(static_cast<useconds_t>(sleepUs));
-#else
-                    Sleep(static_cast<DWORD>(sleepUs / 1000));
-#endif
-                }
-                m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
+                // No software pacing — vsync does the work.
             }
             else
             {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4217,6 +4217,55 @@ void Application::run()
             {
                 m_window->swapBuffers();
             }
+
+            // Render pacing for the valid-frame branch. The else-branch
+            // below has the same block; both paths need it because the
+            // outer if/else is "frame ready vs not" and most iterations
+            // hit the valid-frame branch — without pacing here the main
+            // loop free-runs at display refresh (the 1000+ fps reading
+            // the user saw in MangoHud right after /raw client connect).
+            if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
+            {
+                const uint32_t fps = m_remoteSourceFps > 0 ? m_remoteSourceFps : 60;
+                const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch()).count();
+                const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(fps);
+                if (m_lastFrameSwapUs == 0) m_lastFrameSwapUs = nowUs;
+                const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
+                if (elapsedUs < targetIntervalUs)
+                {
+                    const int64_t sleepUs = targetIntervalUs - elapsedUs;
+#ifdef PLATFORM_LINUX
+                    usleep(static_cast<useconds_t>(sleepUs));
+#else
+                    Sleep(static_cast<DWORD>(sleepUs / 1000));
+#endif
+                }
+                m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
+            }
+            else
+            {
+                bool streamingActive = (m_streamManager && m_streamManager->isActive());
+                if (streamingActive && m_ui)
+                {
+                    const uint32_t targetFps = m_ui->getStreamingFps() > 0 ? m_ui->getStreamingFps() : 60;
+                    const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                              std::chrono::steady_clock::now().time_since_epoch()).count();
+                    const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(targetFps);
+                    if (m_lastFrameSwapUs == 0) m_lastFrameSwapUs = nowUs;
+                    const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
+                    if (elapsedUs < targetIntervalUs)
+                    {
+                        const int64_t sleepUs = targetIntervalUs - elapsedUs;
+#ifdef PLATFORM_LINUX
+                        usleep(static_cast<useconds_t>(sleepUs));
+#else
+                        Sleep(static_cast<DWORD>(sleepUs / 1000));
+#endif
+                    }
+                    m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
+                }
+            }
         }
         else
         {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4,6 +4,7 @@
 #include "../capture/IVideoCapture.h"
 #include "../capture/VideoCaptureFactory.h"
 #include "../capture/VideoCaptureRemote.h"
+#include "../streaming/RemoteMetaSync.h"
 #ifdef PLATFORM_LINUX
 #include "../v4l2/V4L2ControlMapper.h"
 #endif
@@ -547,6 +548,30 @@ bool Application::initCapture()
         LOG_INFO("Capture initialized: " +
                  std::to_string(m_capture->getWidth()) + "x" +
                  std::to_string(m_capture->getHeight()));
+    }
+
+    // Phase 4 of #47: when source is Remote, also poll the host's /meta to
+    // mirror the active shader + parameters locally. Snapshot deltas are
+    // staged on m_pendingRemote* and consumed on the GL thread inside the
+    // main loop (see applyPendingRemoteMeta()).
+    if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote && !m_devicePath.empty())
+    {
+        m_remoteMetaSync = std::make_unique<RemoteMetaSync>();
+        m_remoteMetaSync->start(m_devicePath,
+            [this](const RemoteMetaSync::Snapshot &snap)
+            {
+                std::lock_guard<std::mutex> lock(m_pendingRemoteMutex);
+                m_pendingRemotePreset          = snap.preset;
+                m_pendingRemotePresetHash      = snap.presetHash;
+                m_pendingRemotePipelineEnabled = snap.pipelineEnabled;
+                m_pendingRemoteParams.clear();
+                m_pendingRemoteParams.reserve(snap.parameters.size());
+                for (const auto &p : snap.parameters)
+                {
+                    m_pendingRemoteParams.emplace_back(p.name, p.value);
+                }
+                m_hasPendingRemoteMeta.store(true);
+            });
     }
 
     return true;
@@ -2692,7 +2717,11 @@ void Application::run()
             LOG_WARN("Window is invalid - exiting main loop");
             break;
         }
-        
+
+        // Phase 4 of #47: drain pending remote /meta deltas onto this
+        // thread before any GL work. Cheap when nothing pending.
+        applyPendingRemoteMeta();
+
         m_window->pollEvents();
         
         // Check again after polling events (window may have been invalidated)
@@ -4663,6 +4692,73 @@ std::string Application::resolveShaderPath(const std::string &shaderPath) const
     fs::path fullPath = shaderBasePath / shaderPath;
 
     return fullPath.string();
+}
+
+void Application::applyPendingRemoteMeta()
+{
+    if (!m_hasPendingRemoteMeta.load()) return;
+
+    // Snapshot the pending values out from under the polling thread.
+    std::string preset;
+    std::string presetHash;
+    bool pipelineEnabled = true;
+    std::vector<std::pair<std::string, float>> params;
+    {
+        std::lock_guard<std::mutex> lock(m_pendingRemoteMutex);
+        preset           = std::move(m_pendingRemotePreset);
+        presetHash       = std::move(m_pendingRemotePresetHash);
+        pipelineEnabled  = m_pendingRemotePipelineEnabled;
+        params           = std::move(m_pendingRemoteParams);
+        m_hasPendingRemoteMeta.store(false);
+    }
+
+    if (!m_shaderEngine || !m_ui)
+    {
+        return;
+    }
+
+    // Phase 4 minimum: resolve preset by name in the local shader library.
+    // If the preset isn't there, log and keep whatever shader the client
+    // already has — Phase 4b will fetch the bundle from /meta/shader-bundle
+    // and cache it locally for these cases.
+    bool reloaded = false;
+    if (!preset.empty() && presetHash != m_appliedRemotePresetHash)
+    {
+        const std::string fullPath = resolveShaderPath(preset);
+        if (!fullPath.empty())
+        {
+            LOG_INFO("RemoteMetaSync: applying host preset '" + preset + "' (hash " + presetHash + ")");
+            if (m_shaderEngine->loadPreset(fullPath))
+            {
+                m_ui->setCurrentShader(preset);
+                m_appliedRemotePresetHash = presetHash;
+                reloaded = true;
+            }
+            else
+            {
+                LOG_WARN("RemoteMetaSync: failed to load preset locally — bundle fetch is a Phase 4b TODO");
+            }
+        }
+    }
+
+    // Master pipeline toggle: mirror the host's "Apply shader pipeline".
+    m_ui->setShaderPipelineEnabled(pipelineEnabled);
+
+    // Parameter overrides apply on top of whatever preset is now active.
+    // After a preset reload, the engine's parameters are at their preset
+    // defaults; layering the host's overrides on top reproduces the look.
+    if (!params.empty())
+    {
+        for (const auto &kv : params)
+        {
+            m_shaderEngine->setShaderParameter(kv.first, kv.second);
+        }
+        if (reloaded)
+        {
+            LOG_INFO("RemoteMetaSync: applied " + std::to_string(params.size()) +
+                     " parameter override(s)");
+        }
+    }
 }
 
 // Recording methods

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2380,8 +2380,15 @@ bool Application::initUI()
                 LOG_WARN("Failed to connect to remote host " + devicePath);
                 if (m_ui)
                 {
-                    m_ui->setCaptureInfo(0, 0, 0, "Remote (disconnected)");
+                    m_ui->setCaptureInfo(0, 0, 0, "Remote (failed)");
+                    // Clear the current device so the connection window
+                    // stops reporting 'connected'. Done via direct
+                    // assignment because setCurrentDevice("") would
+                    // re-enter this callback and we're still inside its
+                    // processingDeviceChange guard.
+                    m_ui->setCurrentDeviceSilent("");
                 }
+                m_devicePath.clear();
             }
 
             processingDeviceChange = false;

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1109,6 +1109,10 @@ bool Application::initUI()
     m_streamingAudioCodec = m_ui->getStreamingAudioCodec();
     m_streamingH264Preset = m_ui->getStreamingH264Preset();
     m_streamingHardwareEncoder = m_ui->getStreamingHardwareEncoder();
+    m_streamingNvencPreset = m_ui->getStreamingNvencPreset();
+    m_streamingVaapiRcMode = m_ui->getStreamingVaapiRcMode();
+    m_streamingQsvPreset   = m_ui->getStreamingQsvPreset();
+    m_streamingAmfQuality  = m_ui->getStreamingAmfQuality();
     m_streamingH265Preset = m_ui->getStreamingH265Preset();
     m_streamingH265Profile = m_ui->getStreamingH265Profile();
     m_streamingH265Level = m_ui->getStreamingH265Level();
@@ -1527,6 +1531,30 @@ bool Application::initUI()
             m_streamManager.reset();
             initStreaming();
         } });
+
+    // Per-backend preset/quality strings — same restart-on-change
+    // policy as above, since these all end up in opts that are passed
+    // to avcodec_open2 at MediaEncoder::initializeHardwareVideoCodec.
+    auto restartIfStreaming = [this] {
+        if (m_streamingEnabled && m_streamManager) {
+            m_streamManager->stop();
+            m_streamManager->cleanup();
+            m_streamManager.reset();
+            initStreaming();
+        }
+    };
+    m_ui->setOnStreamingNvencPresetChanged([this, restartIfStreaming](const std::string &v) {
+        m_streamingNvencPreset = v; restartIfStreaming();
+    });
+    m_ui->setOnStreamingVaapiRcModeChanged([this, restartIfStreaming](const std::string &v) {
+        m_streamingVaapiRcMode = v; restartIfStreaming();
+    });
+    m_ui->setOnStreamingQsvPresetChanged([this, restartIfStreaming](const std::string &v) {
+        m_streamingQsvPreset = v; restartIfStreaming();
+    });
+    m_ui->setOnStreamingAmfQualityChanged([this, restartIfStreaming](const std::string &v) {
+        m_streamingAmfQuality = v; restartIfStreaming();
+    });
 
     // Callbacks for buffer settings
     m_ui->setOnStreamingMaxVideoBufferSizeChanged([this](size_t size)
@@ -2559,7 +2587,21 @@ bool Application::initStreaming()
     if (m_streamingVideoCodec == "h264")
     {
         tsStreamer->setH264Preset(m_streamingH264Preset);
-        tsStreamer->setHardwareEncoder(static_cast<MediaEncoder::HardwareEncoder>(m_streamingHardwareEncoder));
+        auto hw = static_cast<MediaEncoder::HardwareEncoder>(m_streamingHardwareEncoder);
+        tsStreamer->setHardwareEncoder(hw);
+        // Pick the backend-specific preset string. For Auto we let
+        // MediaEncoder hardcode its default (empty string) since the
+        // actual backend isn't resolved until codec-open time.
+        std::string backendPreset;
+        switch (hw)
+        {
+            case MediaEncoder::HardwareEncoder::NVENC: backendPreset = m_streamingNvencPreset; break;
+            case MediaEncoder::HardwareEncoder::VAAPI: backendPreset = m_streamingVaapiRcMode; break;
+            case MediaEncoder::HardwareEncoder::QSV:   backendPreset = m_streamingQsvPreset;   break;
+            case MediaEncoder::HardwareEncoder::AMF:   backendPreset = m_streamingAmfQuality;  break;
+            default: backendPreset.clear(); break;
+        }
+        tsStreamer->setHardwareEncoderPreset(backendPreset);
     }
     // Configure H.265 preset, profile and level (if applicable)
     else if (m_streamingVideoCodec == "h265" || m_streamingVideoCodec == "hevc")

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -20,6 +20,7 @@
 #endif
 #include "../shader/ShaderEngine.h"
 #include "../ui/UIManager.h"
+#include "../ui/UIRemoteConnection.h"
 #include "../ui/UICapturePresets.h"
 #include "../ui/UIRecordings.h"
 #include "../renderer/glad_loader.h"
@@ -3196,6 +3197,13 @@ void Application::run()
         if (m_ui)
         {
             m_ui->beginFrame();
+            // Keep the Remote connection window's capture pointer current.
+            // Cheap pointer swap each iteration; UIRemoteConnection only
+            // dereferences it inside its own render() guarded by m_visible.
+            if (auto *win = m_ui->getRemoteConnectionWindow())
+            {
+                win->setCapture(m_capture.get());
+            }
         }
 
         // Try to capture and process the latest frame (discarding old frames)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -606,6 +606,11 @@ bool Application::initCapture()
                 }
                 m_pendingRemoteSourceWidth  = snap.sourceWidth;
                 m_pendingRemoteSourceHeight = snap.sourceHeight;
+                // Plain assignment — uint32_t is atomic on every platform
+                // we target, and a momentarily stale read in the main
+                // loop is harmless (just one extra render iteration at
+                // most).
+                if (snap.sourceFps > 0) m_remoteSourceFps = snap.sourceFps;
                 m_hasPendingRemoteMeta.store(true);
             });
     }
@@ -2232,6 +2237,9 @@ bool Application::initUI()
                         {
                             m_pendingRemoteParams.emplace_back(p.name, p.value);
                         }
+                        m_pendingRemoteSourceWidth  = snap.sourceWidth;
+                        m_pendingRemoteSourceHeight = snap.sourceHeight;
+                        if (snap.sourceFps > 0) m_remoteSourceFps = snap.sourceFps;
                         m_hasPendingRemoteMeta.store(true);
                     });
             }
@@ -4248,12 +4256,74 @@ void Application::run()
                 m_window->swapBuffers();
             }
 
-// Do a small sleep to not consume 100% CPU
+            // Remote-source render pacing: when this client is consuming a
+            // remote /raw stream, there's no point iterating faster than
+            // the host's source FPS. Without this cap an idle 144 / 240 /
+            // 360 Hz display will spin the main loop at hundreds of fps,
+            // re-rendering the same decoded frame and re-running
+            // applyPendingRemoteMeta — wastes GPU and produces the
+            // 500-fps reading the user spotted in MangoHud. Sleep until
+            // the next host-frame deadline.
+            if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote && m_remoteSourceFps > 0)
+            {
+                const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch()).count();
+                const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(m_remoteSourceFps);
+                if (m_lastFrameSwapUs == 0)
+                {
+                    m_lastFrameSwapUs = nowUs;
+                }
+                const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
+                if (elapsedUs < targetIntervalUs)
+                {
+                    const int64_t sleepUs = targetIntervalUs - elapsedUs;
 #ifdef PLATFORM_LINUX
-            usleep(1000); // 1ms
+                    usleep(static_cast<useconds_t>(sleepUs));
 #else
-            Sleep(1); // 1ms sleep
+                    Sleep(static_cast<DWORD>(sleepUs / 1000));
 #endif
+                }
+                m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
+            }
+            else
+            {
+                // Local-source path (V4L2 / DS / None / no remote source
+                // info yet). When streaming is active, pace the main loop
+                // to match the configured streaming FPS so we don't burn
+                // GPU + glReadPixels work re-rendering a frame the encoder
+                // throttle will discard anyway. When streaming is idle,
+                // fall back to the existing 1 ms sleep so the local
+                // preview stays responsive on whatever refresh rate the
+                // display happens to run at.
+                bool streamingActive = (m_streamManager && m_streamManager->isActive());
+                if (streamingActive && m_ui)
+                {
+                    const uint32_t targetFps = m_ui->getStreamingFps() > 0 ? m_ui->getStreamingFps() : 60;
+                    const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                              std::chrono::steady_clock::now().time_since_epoch()).count();
+                    const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(targetFps);
+                    if (m_lastFrameSwapUs == 0) m_lastFrameSwapUs = nowUs;
+                    const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
+                    if (elapsedUs < targetIntervalUs)
+                    {
+                        const int64_t sleepUs = targetIntervalUs - elapsedUs;
+#ifdef PLATFORM_LINUX
+                        usleep(static_cast<useconds_t>(sleepUs));
+#else
+                        Sleep(static_cast<DWORD>(sleepUs / 1000));
+#endif
+                    }
+                    m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
+                }
+                else
+                {
+#ifdef PLATFORM_LINUX
+                    usleep(1000);
+#else
+                    Sleep(1);
+#endif
+                }
+            }
         }
     }
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -393,6 +393,23 @@ bool Application::initCapture()
     if (!m_capture->open(m_devicePath))
     {
         LOG_WARN("Failed to open capture device: " + (m_devicePath.empty() ? "(none)" : m_devicePath));
+
+        // Phase 5b/#47: Remote source has no "dummy fallback" — a remote
+        // stream is either reachable or not. Falling back to dummy here is
+        // what made a failed `--source remote` look like a silent green
+        // screen. Leave m_capture closed and surface the state via the UI;
+        // the user can re-enter a URL and click Connect, which fires the
+        // OnDeviceChanged handler and retries.
+        if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
+        {
+            LOG_INFO("Remote source could not connect. Enter a base URL in the Source tab and click Connect.");
+            if (m_ui)
+            {
+                m_ui->setCaptureInfo(0, 0, 0, "Remote (not connected)");
+            }
+            return true; // Not a fatal initialization error.
+        }
+
         LOG_INFO("Activating dummy mode: generating black frames at specified resolution.");
 #ifdef __linux__
         LOG_INFO("Select a device in the V4L2 tab to use real capture.");
@@ -2088,6 +2105,33 @@ bool Application::initUI()
                                          }
                                      }
 #endif
+
+                                     // Phase 5b/#47: switching INTO Remote — close the
+                                     // current capture (V4L2/DS/None) and stand up an
+                                     // empty VideoCaptureRemote that waits for the
+                                     // user to type a URL + click Connect.
+                                     if (sourceType == UIManager::SourceType::Remote)
+                                     {
+                                         LOG_INFO("Remote source selected — close any active capture, await Connect");
+                                         if (m_remoteMetaSync)
+                                         {
+                                             m_remoteMetaSync->stop();
+                                             m_remoteMetaSync.reset();
+                                         }
+                                         if (m_capture)
+                                         {
+                                             m_capture->stopCapture();
+                                             m_capture->close();
+                                         }
+                                         m_capture = std::make_unique<VideoCaptureRemote>();
+                                         m_devicePath.clear();
+                                         if (m_ui)
+                                         {
+                                             m_ui->setCaptureInfo(0, 0, 0, "Remote (not connected)");
+                                             m_ui->setCurrentDevice("");
+                                             m_ui->setCaptureControls(nullptr);
+                                         }
+                                     }
                                  });
 
     m_ui->setOnDeviceChanged([this](const std::string &devicePath)
@@ -2098,7 +2142,77 @@ bool Application::initUI()
             return;
         }
         processingDeviceChange = true;
-        
+
+        // Phase 5b/#47: when the active source is Remote, this callback
+        // carries the remote BASE URL — not a V4L2 / DirectShow device
+        // path. Spin up (or replace) the VideoCaptureRemote and
+        // RemoteMetaSync to point at the new host. Empty URL == disconnect.
+        if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
+        {
+            LOG_INFO("Remote URL change: " + (devicePath.empty() ? "(disconnect)" : devicePath));
+
+            // Tear down any existing remote pipeline (capture + meta-sync).
+            if (m_remoteMetaSync)
+            {
+                m_remoteMetaSync->stop();
+                m_remoteMetaSync.reset();
+            }
+            if (m_capture)
+            {
+                m_capture->stopCapture();
+                m_capture->close();
+            }
+
+            m_devicePath = devicePath;
+
+            if (devicePath.empty())
+            {
+                processingDeviceChange = false;
+                return;
+            }
+
+            // Recreate the capture as Remote (the existing instance might be
+            // V4L2/DS if the user just flipped source type).
+            m_capture = std::make_unique<VideoCaptureRemote>();
+            if (m_capture->open(devicePath))
+            {
+                m_capture->startCapture();
+                if (m_ui)
+                {
+                    m_ui->setCaptureInfo(m_capture->getWidth(), m_capture->getHeight(),
+                                         m_captureFps, devicePath);
+                }
+                // Re-start the /meta poller against the new host.
+                m_remoteMetaSync = std::make_unique<RemoteMetaSync>();
+                m_remoteMetaSync->start(devicePath,
+                    [this](const RemoteMetaSync::Snapshot &snap)
+                    {
+                        std::lock_guard<std::mutex> lock(m_pendingRemoteMutex);
+                        m_pendingRemotePreset          = snap.preset;
+                        m_pendingRemotePresetHash      = snap.presetHash;
+                        m_pendingRemotePipelineEnabled = snap.pipelineEnabled;
+                        m_pendingRemoteParams.clear();
+                        m_pendingRemoteParams.reserve(snap.parameters.size());
+                        for (const auto &p : snap.parameters)
+                        {
+                            m_pendingRemoteParams.emplace_back(p.name, p.value);
+                        }
+                        m_hasPendingRemoteMeta.store(true);
+                    });
+            }
+            else
+            {
+                LOG_WARN("Failed to connect to remote host " + devicePath);
+                if (m_ui)
+                {
+                    m_ui->setCaptureInfo(0, 0, 0, "Remote (disconnected)");
+                }
+            }
+
+            processingDeviceChange = false;
+            return;
+        }
+
         // If devicePath is empty, it means "None" - activate dummy mode
         if (devicePath.empty())
         {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3,6 +3,7 @@
 #include "../utils/Paths.h"
 #include "../capture/IVideoCapture.h"
 #include "../capture/VideoCaptureFactory.h"
+#include "../capture/VideoCaptureRemote.h"
 #ifdef PLATFORM_LINUX
 #include "../v4l2/V4L2ControlMapper.h"
 #endif
@@ -339,7 +340,19 @@ bool Application::initRenderer()
 bool Application::initCapture()
 {
     LOG_INFO("Creating VideoCapture...");
-    m_capture = VideoCaptureFactory::create();
+
+    // Phase 3 of #47: if the UIManager already has the source type set to
+    // Remote (CLI selected --source remote), build the remote capture
+    // instead of the platform-default V4L2 / DirectShow factory.
+    if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
+    {
+        LOG_INFO("Source is remote — creating VideoCaptureRemote");
+        m_capture = std::make_unique<VideoCaptureRemote>();
+    }
+    else
+    {
+        m_capture = VideoCaptureFactory::create();
+    }
     if (!m_capture)
     {
         LOG_ERROR("Failed to create VideoCapture for this platform");

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4339,24 +4339,38 @@ void Application::run()
             }
 
             // Pacing policy:
-            //  - Remote source: vsync (enabled in setOnSourceTypeChanged
-            //    when entering Remote) drives the loop at the panel's
-            //    display refresh rate. Adding a stream-fps software
-            //    pacing on top capped the loop at 60 Hz even on a
-            //    144 Hz panel, which is what made 60 fps streams look
-            //    choppy ("3:2 pulldown" 2-3 refresh pattern) compared
-            //    to 120 fps: the user couldn't use the extra refreshes
-            //    the panel had on offer because we were sleeping
-            //    through them. Free-running with vsync gives the
-            //    cleanest possible cadence at whatever stream:refresh
-            //    ratio the user picked.
+            //  - Remote source: vsync drives the loop at the panel's
+            //    display refresh rate. Vsync is toggled on focus —
+            //    when the window is backgrounded a lot of compositors
+            //    park vsync at 0 Hz, so swapBuffers would block forever
+            //    and the main loop would stop draining the frame queue
+            //    (the user-observed "consumed=0 drops=60/s queueDepth=20"
+            //    stall). When unfocused we disable vsync and add a
+            //    small sleep to avoid burning CPU on hidden refreshes.
             //  - Local source streaming: keep the existing software
             //    pace at the configured streaming FPS so we don't
             //    burn GPU + glReadPixels for frames the encoder will
             //    just throttle.
             if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
             {
-                // No software pacing — vsync does the work.
+                const bool focused = m_window && m_window->isFocused();
+                if (m_window && focused != m_remoteWindowFocused)
+                {
+                    m_window->setVsync(focused);
+                    m_remoteWindowFocused = focused;
+                }
+                if (!focused)
+                {
+                    // Hidden / backgrounded — sleep a frame's worth so
+                    // captureLatestFrame still drains the queue at a
+                    // reasonable rate without spinning the CPU.
+#ifdef PLATFORM_LINUX
+                    usleep(16000);
+#else
+                    Sleep(16);
+#endif
+                }
+                // When focused, vsync does the pacing.
             }
             else
             {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4521,31 +4521,14 @@ void Application::run()
                 }
                 const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
 
-                // 1 s telemetry — confirms the pacing actually runs in the
-                // remote-source code path. Removable after verifying.
-                static int64_t s_lastPaceTickUs = 0;
-                static uint32_t s_paceIters = 0;
-                static uint32_t s_paceSleeps = 0;
-                ++s_paceIters;
-                if (s_lastPaceTickUs == 0) s_lastPaceTickUs = nowUs;
                 if (elapsedUs < targetIntervalUs)
                 {
                     const int64_t sleepUs = targetIntervalUs - elapsedUs;
-                    ++s_paceSleeps;
 #ifdef PLATFORM_LINUX
                     usleep(static_cast<useconds_t>(sleepUs));
 #else
                     Sleep(static_cast<DWORD>(sleepUs / 1000));
 #endif
-                }
-                if (nowUs - s_lastPaceTickUs >= 1000000LL)
-                {
-                    LOG_INFO("remote render pace: fps=" + std::to_string(fps) +
-                             " iters=" + std::to_string(s_paceIters) +
-                             "/s sleeps=" + std::to_string(s_paceSleeps) +
-                             "/s sourceFpsFromMeta=" + std::to_string(m_remoteSourceFps));
-                    s_paceIters = s_paceSleeps = 0;
-                    s_lastPaceTickUs = nowUs;
                 }
 
                 m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1399,14 +1399,39 @@ bool Application::initUI()
             initStreaming();
         } });
 
-    m_ui->setOnStreamingWidthChanged([this](uint32_t width)
-                                     { m_streamingWidth = width; });
+    // Resolution / FPS changes need the same restart-if-streaming policy
+    // as bitrate/preset — initStreaming() bakes width/height/fps into the
+    // MediaEncoder + MediaMuxer at construction time, so just storing the
+    // new value on the field has no effect on a live stream.
+    m_ui->setOnStreamingWidthChanged([this](uint32_t width) {
+        m_streamingWidth = width;
+        if (m_streamingEnabled && m_streamManager) {
+            m_streamManager->stop();
+            m_streamManager->cleanup();
+            m_streamManager.reset();
+            initStreaming();
+        }
+    });
 
-    m_ui->setOnStreamingHeightChanged([this](uint32_t height)
-                                      { m_streamingHeight = height; });
+    m_ui->setOnStreamingHeightChanged([this](uint32_t height) {
+        m_streamingHeight = height;
+        if (m_streamingEnabled && m_streamManager) {
+            m_streamManager->stop();
+            m_streamManager->cleanup();
+            m_streamManager.reset();
+            initStreaming();
+        }
+    });
 
-    m_ui->setOnStreamingFpsChanged([this](uint32_t fps)
-                                   { m_streamingFps = fps; });
+    m_ui->setOnStreamingFpsChanged([this](uint32_t fps) {
+        m_streamingFps = fps;
+        if (m_streamingEnabled && m_streamManager) {
+            m_streamManager->stop();
+            m_streamManager->cleanup();
+            m_streamManager.reset();
+            initStreaming();
+        }
+    });
 
     m_ui->setOnStreamingBitrateChanged([this](uint32_t bitrate)
                                        {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -164,6 +164,15 @@ bool Application::init()
         m_shaderEngine->setViewport(currentWidth, currentHeight);
     }
 
+    // Apply the source-type-appropriate vsync mode on startup so a user
+    // who saved Remote as their source gets the display-refresh-aligned
+    // playback path immediately instead of only after the next source
+    // change. setOnSourceTypeChanged handles all subsequent transitions.
+    if (m_window && m_ui)
+    {
+        m_window->setVsync(m_ui->getSourceType() == UIManager::SourceType::Remote);
+    }
+
     LOG_INFO("Application initialized successfully");
     return true;
 }
@@ -2031,6 +2040,26 @@ bool Application::initUI()
     m_ui->setOnSourceTypeChanged([this](UIManager::SourceType sourceType)
                                  {
                                      LOG_INFO("Source type changed via UI");
+
+                                     // Remote-source playback wants vsync ON so frame
+                                     // changes land on display refresh boundaries — this
+                                     // is what eliminated the 'stuttering at 60 fps but
+                                     // smooth at 120 fps' artefact: without vsync our
+                                     // ~60 Hz pacing drifts relative to the panel's own
+                                     // 60 Hz refresh, dropping the occasional frame across
+                                     // a refresh boundary. With vsync the loop's effective
+                                     // rate IS the panel's rate, and the strict PTS gate
+                                     // hands the queue's current head out at exactly the
+                                     // next refresh.
+                                     //
+                                     // Local capture keeps vsync OFF — capture/encoder
+                                     // threads can't tolerate the main loop stalling when
+                                     // the window is minimized (compositors sometimes
+                                     // park vsync at 0 Hz for backgrounded windows).
+                                     if (m_window)
+                                     {
+                                         m_window->setVsync(sourceType == UIManager::SourceType::Remote);
+                                     }
 
                                      if (sourceType == UIManager::SourceType::None)
                                      {

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -358,7 +358,12 @@ bool Application::initCapture()
     if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
     {
         LOG_INFO("Source is remote — creating VideoCaptureRemote");
-        m_capture = std::make_unique<VideoCaptureRemote>();
+        auto remote = std::make_unique<VideoCaptureRemote>();
+        VideoCaptureRemote::InterpolationMode imode = VideoCaptureRemote::InterpolationMode::Linear;
+        if (m_remoteInterpolation == "nearest") imode = VideoCaptureRemote::InterpolationMode::Nearest;
+        else if (m_remoteInterpolation == "off") imode = VideoCaptureRemote::InterpolationMode::Off;
+        remote->setInterpolationMode(imode);
+        m_capture = std::move(remote);
     }
     else
     {
@@ -1122,6 +1127,7 @@ bool Application::initUI()
     m_streamingVaapiRcMode = m_ui->getStreamingVaapiRcMode();
     m_streamingQsvPreset   = m_ui->getStreamingQsvPreset();
     m_streamingAmfQuality  = m_ui->getStreamingAmfQuality();
+    m_remoteInterpolation  = m_ui->getRemoteInterpolation();
     m_streamingH265Preset = m_ui->getStreamingH265Preset();
     m_streamingH265Profile = m_ui->getStreamingH265Profile();
     m_streamingH265Level = m_ui->getStreamingH265Level();
@@ -1588,6 +1594,20 @@ bool Application::initUI()
     });
     m_ui->setOnStreamingAmfQualityChanged([this, restartIfStreaming](const std::string &v) {
         m_streamingAmfQuality = v; restartIfStreaming();
+    });
+
+    // Remote interpolation mode — applied immediately to the active
+    // VideoCaptureRemote (if any). No streaming restart required since
+    // it's a client-side display decision.
+    m_ui->setOnRemoteInterpolationChanged([this](const std::string &v) {
+        m_remoteInterpolation = v;
+        if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
+        {
+            VideoCaptureRemote::InterpolationMode mode = VideoCaptureRemote::InterpolationMode::Linear;
+            if (v == "nearest") mode = VideoCaptureRemote::InterpolationMode::Nearest;
+            else if (v == "off") mode = VideoCaptureRemote::InterpolationMode::Off;
+            remote->setInterpolationMode(mode);
+        }
     });
 
     // Callbacks for buffer settings
@@ -2244,7 +2264,14 @@ bool Application::initUI()
                                              m_capture->stopCapture();
                                              m_capture->close();
                                          }
-                                         m_capture = std::make_unique<VideoCaptureRemote>();
+                                         {
+                                             auto remote = std::make_unique<VideoCaptureRemote>();
+                                             VideoCaptureRemote::InterpolationMode imode = VideoCaptureRemote::InterpolationMode::Linear;
+                                             if (m_remoteInterpolation == "nearest") imode = VideoCaptureRemote::InterpolationMode::Nearest;
+                                             else if (m_remoteInterpolation == "off") imode = VideoCaptureRemote::InterpolationMode::Off;
+                                             remote->setInterpolationMode(imode);
+                                             m_capture = std::move(remote);
+                                         }
                                          m_devicePath.clear();
                                          if (m_ui)
                                          {
@@ -2294,7 +2321,14 @@ bool Application::initUI()
 
             // Recreate the capture as Remote (the existing instance might be
             // V4L2/DS if the user just flipped source type).
-            m_capture = std::make_unique<VideoCaptureRemote>();
+            {
+                auto remote = std::make_unique<VideoCaptureRemote>();
+                VideoCaptureRemote::InterpolationMode imode = VideoCaptureRemote::InterpolationMode::Linear;
+                if (m_remoteInterpolation == "nearest") imode = VideoCaptureRemote::InterpolationMode::Nearest;
+                else if (m_remoteInterpolation == "off") imode = VideoCaptureRemote::InterpolationMode::Off;
+                remote->setInterpolationMode(imode);
+                m_capture = std::move(remote);
+            }
             if (m_capture->open(devicePath))
             {
                 m_capture->startCapture();

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -565,6 +565,23 @@ bool Application::initCapture()
         LOG_INFO("Capture initialized: " +
                  std::to_string(m_capture->getWidth()) + "x" +
                  std::to_string(m_capture->getHeight()));
+
+        // Sync m_captureWidth / m_captureHeight with what the device
+        // actually produces. For V4L2 / DS this is usually a no-op (we
+        // already asked for those dims via setFormat); for Remote the
+        // server picks the dimensions, and without this sync the render
+        // pipeline keeps using the local config defaults — leaving the
+        // image filling only a fraction of the window.
+        const uint32_t actualW = m_capture->getWidth();
+        const uint32_t actualH = m_capture->getHeight();
+        if (actualW > 0 && actualH > 0 && (actualW != m_captureWidth || actualH != m_captureHeight))
+        {
+            LOG_INFO("Adjusting capture dims to actual " +
+                     std::to_string(actualW) + "x" + std::to_string(actualH) +
+                     " (was " + std::to_string(m_captureWidth) + "x" + std::to_string(m_captureHeight) + ")");
+            m_captureWidth  = actualW;
+            m_captureHeight = actualH;
+        }
     }
 
     // Phase 4 of #47: when source is Remote, also poll the host's /meta to
@@ -2177,6 +2194,22 @@ bool Application::initUI()
             if (m_capture->open(devicePath))
             {
                 m_capture->startCapture();
+
+                // Pull the actual stream dimensions from the freshly-opened
+                // decoder and sync the application's idea of capture size.
+                // Without this the rest of the render pipeline keeps using
+                // m_captureWidth / m_captureHeight from the local config
+                // (1920x1080 by default), producing the "image fills only
+                // half the window" symptom when the host streams smaller.
+                const uint32_t actualW = m_capture->getWidth();
+                const uint32_t actualH = m_capture->getHeight();
+                if (actualW > 0 && actualH > 0)
+                {
+                    m_captureWidth  = actualW;
+                    m_captureHeight = actualH;
+                    LOG_INFO("Remote stream dims: " + std::to_string(actualW) + "x" + std::to_string(actualH));
+                }
+
                 if (m_ui)
                 {
                     m_ui->setCaptureInfo(m_capture->getWidth(), m_capture->getHeight(),

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -622,6 +622,19 @@ bool Application::initCapture()
                 }
                 m_pendingRemoteSourceWidth  = snap.sourceWidth;
                 m_pendingRemoteSourceHeight = snap.sourceHeight;
+                // Image-tab values: seed only once per connection — see
+                // applyPendingRemoteMeta for the gate. Stash the values
+                // from this snapshot; if it's the first one we'll apply
+                // them on the GL thread, otherwise the apply gate skips.
+                if (!m_remoteImageSeeded)
+                {
+                    m_pendingRemoteImageBrightness     = snap.imageBrightness;
+                    m_pendingRemoteImageContrast       = snap.imageContrast;
+                    m_pendingRemoteImageMaintainAspect = snap.imageMaintainAspect;
+                    m_pendingRemoteImageOutputWidth    = snap.imageOutputWidth;
+                    m_pendingRemoteImageOutputHeight   = snap.imageOutputHeight;
+                    m_hasPendingRemoteImageSeed        = true;
+                }
                 // Plain assignment — uint32_t is atomic on every platform
                 // we target, and a momentarily stale read in the main
                 // loop is harmless (just one extra render iteration at
@@ -2337,6 +2350,10 @@ bool Application::initUI()
                 {
                     m_ui->setCaptureInfo(0, 0, 0, "");
                 }
+                // Re-arm the Image seed for the next connection — each
+                // session gets one seed from /meta, after which the user
+                // owns the values locally.
+                m_remoteImageSeeded = false;
                 processingDeviceChange = false;
                 return;
             }
@@ -2392,6 +2409,16 @@ bool Application::initUI()
                         }
                         m_pendingRemoteSourceWidth  = snap.sourceWidth;
                         m_pendingRemoteSourceHeight = snap.sourceHeight;
+                        // Image-tab seed — first snapshot per connection only.
+                        if (!m_remoteImageSeeded)
+                        {
+                            m_pendingRemoteImageBrightness     = snap.imageBrightness;
+                            m_pendingRemoteImageContrast       = snap.imageContrast;
+                            m_pendingRemoteImageMaintainAspect = snap.imageMaintainAspect;
+                            m_pendingRemoteImageOutputWidth    = snap.imageOutputWidth;
+                            m_pendingRemoteImageOutputHeight   = snap.imageOutputHeight;
+                            m_hasPendingRemoteImageSeed        = true;
+                        }
                         if (snap.sourceFps > 0) m_remoteSourceFps = snap.sourceFps;
                         m_hasPendingRemoteMeta.store(true);
                     });
@@ -5208,6 +5235,10 @@ void Application::applyPendingRemoteMeta()
     bool pipelineEnabled = true;
     std::vector<std::pair<std::string, float>> params;
     uint32_t sourceW = 0, sourceH = 0;
+    bool seedImage = false;
+    float imgBrightness = 1.0f, imgContrast = 1.0f;
+    bool imgMaintainAspect = true;
+    uint32_t imgOutW = 0, imgOutH = 0;
     {
         std::lock_guard<std::mutex> lock(m_pendingRemoteMutex);
         preset           = std::move(m_pendingRemotePreset);
@@ -5216,7 +5247,36 @@ void Application::applyPendingRemoteMeta()
         params           = std::move(m_pendingRemoteParams);
         sourceW          = m_pendingRemoteSourceWidth;
         sourceH          = m_pendingRemoteSourceHeight;
+        if (m_hasPendingRemoteImageSeed)
+        {
+            seedImage         = true;
+            imgBrightness     = m_pendingRemoteImageBrightness;
+            imgContrast       = m_pendingRemoteImageContrast;
+            imgMaintainAspect = m_pendingRemoteImageMaintainAspect;
+            imgOutW           = m_pendingRemoteImageOutputWidth;
+            imgOutH           = m_pendingRemoteImageOutputHeight;
+            m_hasPendingRemoteImageSeed = false;
+        }
         m_hasPendingRemoteMeta.store(false);
+    }
+
+    // Seed the local Image tab from the host on the very first snapshot
+    // per connection. m_remoteImageSeeded flips true here and gates the
+    // callback so subsequent snapshots leave these values alone — the
+    // user is free to tweak the local Image controls after the initial
+    // sync.
+    if (seedImage && m_ui)
+    {
+        m_ui->setBrightness(imgBrightness);
+        m_ui->setContrast(imgContrast);
+        m_ui->setMaintainAspect(imgMaintainAspect);
+        m_ui->setOutputResolution(imgOutW, imgOutH);
+        m_remoteImageSeeded = true;
+        LOG_INFO("RemoteMetaSync: seeded local Image from host — brightness=" +
+                 std::to_string(imgBrightness) + " contrast=" +
+                 std::to_string(imgContrast) + " maintainAspect=" +
+                 std::to_string(imgMaintainAspect) + " output=" +
+                 std::to_string(imgOutW) + "x" + std::to_string(imgOutH));
     }
 
     // Tell the remote capture to rescale to the host's source dims (if the

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -604,6 +604,8 @@ bool Application::initCapture()
                 {
                     m_pendingRemoteParams.emplace_back(p.name, p.value);
                 }
+                m_pendingRemoteSourceWidth  = snap.sourceWidth;
+                m_pendingRemoteSourceHeight = snap.sourceHeight;
                 m_hasPendingRemoteMeta.store(true);
             });
     }
@@ -4850,13 +4852,35 @@ void Application::applyPendingRemoteMeta()
     std::string presetHash;
     bool pipelineEnabled = true;
     std::vector<std::pair<std::string, float>> params;
+    uint32_t sourceW = 0, sourceH = 0;
     {
         std::lock_guard<std::mutex> lock(m_pendingRemoteMutex);
         preset           = std::move(m_pendingRemotePreset);
         presetHash       = std::move(m_pendingRemotePresetHash);
         pipelineEnabled  = m_pendingRemotePipelineEnabled;
         params           = std::move(m_pendingRemoteParams);
+        sourceW          = m_pendingRemoteSourceWidth;
+        sourceH          = m_pendingRemoteSourceHeight;
         m_hasPendingRemoteMeta.store(false);
+    }
+
+    // Tell the remote capture to rescale to the host's source dims (if the
+    // stream is encoded at a different size) and sync our render-size view
+    // so downstream FBO / viewport calculations use the right values.
+    if (sourceW > 0 && sourceH > 0)
+    {
+        if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
+        {
+            remote->setTargetResolution(sourceW, sourceH);
+        }
+        if (sourceW != m_captureWidth || sourceH != m_captureHeight)
+        {
+            LOG_INFO("Remote source dims from /meta: " +
+                     std::to_string(sourceW) + "x" + std::to_string(sourceH) +
+                     " (was " + std::to_string(m_captureWidth) + "x" + std::to_string(m_captureHeight) + ")");
+            m_captureWidth  = sourceW;
+            m_captureHeight = sourceH;
+        }
     }
 
     if (!m_shaderEngine || !m_ui)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3782,8 +3782,12 @@ void Application::run()
                                                                !m_ui->getStreamingApplyShader();
                                 const bool recordWantsSource = m_ui && m_recordingManager && m_recordingManager->isRecording() &&
                                                                !m_ui->getRecordingApplyShader();
+                                // Phase 2 of #47: /raw is by-contract pre-shader, so any connected
+                                // /raw client also triggers the source-frame capture below.
+                                const bool rawWantsSource = m_streamManager && m_streamManager->isActive() &&
+                                                            m_streamManager->hasRawClients();
                                 const bool needSourceCapture = masterOn && shaderActive &&
-                                                               (streamWantsSource || recordWantsSource);
+                                                               (streamWantsSource || recordWantsSource || rawWantsSource);
 
                                 bool sourceFrameReady = false;
                                 uint32_t sourceFrameW = 0, sourceFrameH = 0;
@@ -3845,6 +3849,15 @@ void Application::run()
                                     else
                                     {
                                         m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                    }
+
+                                    // Phase 2 of #47: also feed the /raw output (pre-shader, always).
+                                    // hasRawClients() gates this so the encoder idles when nothing
+                                    // is listening — the CPU cost only shows up when a remote
+                                    // client is actually consuming the raw feed.
+                                    if (sourceFrameReady && m_streamManager->hasRawClients())
+                                    {
+                                        m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
                                     }
                                 }
                                 if (frameDataReady && m_recordingManager && m_recordingManager->isRecording())

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2300,6 +2300,20 @@ bool Application::initUI()
         {
             LOG_INFO("Remote URL change: " + (devicePath.empty() ? "(disconnect)" : devicePath));
 
+            // Disconnect path optimisation: drop the on-screen frame
+            // BEFORE waiting on the decode thread's join. The texture
+            // upload happens on the main thread, so by the time we get
+            // here we own m_frameProcessor and can wipe it immediately;
+            // otherwise the user sees the last received frame frozen on
+            // screen for the full ~50-100 ms it can take stopCapture to
+            // unwind the interrupted I/O. Combined with the new
+            // 'Disconnecting...' status the window shows, the perceived
+            // freeze on Disconnect goes away.
+            if (devicePath.empty() && m_frameProcessor)
+            {
+                m_frameProcessor->deleteTexture();
+            }
+
             // Tear down any existing remote pipeline (capture + meta-sync).
             if (m_remoteMetaSync)
             {
@@ -2316,6 +2330,13 @@ bool Application::initUI()
 
             if (devicePath.empty())
             {
+                // Mark the UI as cleanly disconnected so the connection
+                // window stops showing 'Stream: WxH' from the last
+                // session.
+                if (m_ui)
+                {
+                    m_ui->setCaptureInfo(0, 0, 0, "");
+                }
                 processingDeviceChange = false;
                 return;
             }

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3811,27 +3811,23 @@ void Application::run()
                                     memcpy(dstPtr, srcPtr, readRowSizeUnpadded);
                                 }
 
-                                // Same target-FPS throttle as the FBO-complete push path
-                                // below — keeps the encoder fed at the configured streaming
-                                // rate regardless of how fast the main loop iterates (no
-                                // vsync, high-refresh-rate display, free-run).
+                                // Push every frame produced by this iteration. The main
+                                // loop is already paced (see the render-pace blocks at the
+                                // end of the loop), so the per-iteration rate matches the
+                                // configured streaming FPS. The earlier dedicated push
+                                // throttle here was meant to protect against an uncapped
+                                // main loop on a high-refresh display, but with main-loop
+                                // pacing in place it just rejected legitimate frames whose
+                                // arrival jittered slightly below 1/fps (observed as
+                                // "push throttle skips=20-24/s" while the encoder sat
+                                // idle waiting for input).
+                                if (m_streamManager && m_streamManager->isActive())
                                 {
-                                    const int64_t pboTargetFps = (m_ui && m_ui->getStreamingFps() > 0) ? m_ui->getStreamingFps() : 60;
-                                    const int64_t pboMinIntervalUs = 1000000LL / pboTargetFps;
-                                    const int64_t pboNowUs = std::chrono::duration_cast<std::chrono::microseconds>(
-                                                                std::chrono::steady_clock::now().time_since_epoch()).count();
-                                    if (pboNowUs - m_lastStreamPushUs >= pboMinIntervalUs)
-                                    {
-                                        m_lastStreamPushUs = pboNowUs;
-                                        if (m_streamManager && m_streamManager->isActive())
-                                        {
-                                            m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
-                                        }
-                                        if (m_recordingManager && m_recordingManager->isRecording())
-                                        {
-                                            m_recordingManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
-                                        }
-                                    }
+                                    m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                }
+                                if (m_recordingManager && m_recordingManager->isRecording())
+                                {
+                                    m_recordingManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
                                 }
                             }
                             else
@@ -4101,40 +4097,18 @@ void Application::run()
 
                                 // Share frame data between streaming and recording.
                                 // Pula push se o PBO async ainda não tem dados do frame anterior.
-                                //
-                                // Throttle pushes to the configured streaming FPS — when the
-                                // main loop runs faster than the target frame rate (no vsync,
-                                // 240Hz display, free-run), pushing every iteration produces
-                                // hundreds of frames per second arriving at the encoder with
-                                // near-identical timestamps. That causes PTS retrocession,
-                                // overflow drops in the synchronizer and the visible
-                                // "back-and-forth" jitter the client sees.
-                                const int64_t s_targetFps = (m_ui && m_ui->getStreamingFps() > 0) ? m_ui->getStreamingFps() : 60;
-                                const int64_t s_minIntervalUs = 1000000LL / s_targetFps;
-                                const int64_t s_nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
-                                                            std::chrono::steady_clock::now().time_since_epoch()).count();
-                                const bool s_pushAllowed = (s_nowUs - m_lastStreamPushUs >= s_minIntervalUs);
-
-                                // 1s diagnostic so we can confirm the throttle is actually firing.
-                                static int64_t s_lastTickUs = 0;
-                                static uint32_t s_pushCount = 0;
-                                static uint32_t s_skipCount = 0;
-                                if (s_pushAllowed) ++s_pushCount;
-                                else ++s_skipCount;
-                                if (s_lastTickUs == 0) s_lastTickUs = s_nowUs;
-                                if (s_nowUs - s_lastTickUs >= 1000000LL)
+                                // Push every frame the FBO path produces. Main-loop pacing
+                                // (added in cd7b13a / 4b69c72) already caps the iteration rate
+                                // at the configured streaming FPS, so the per-frame interval
+                                // matches the target and there's no risk of overshooting the
+                                // way an uncapped 240 Hz refresh free-run did. An earlier
+                                // dedicated throttle here ended up rejecting ~30 % of
+                                // legitimate frames every second because per-iteration work
+                                // time jittered slightly below 1/fps — visible in the log as
+                                // "push throttle: pushes=37/s skips=24/s" while VAAPI sat idle
+                                // waiting for input.
+                                if (frameDataReady && m_streamManager && m_streamManager->isActive())
                                 {
-                                    LOG_INFO("push throttle (FBO): targetFps=" + std::to_string(s_targetFps) +
-                                             " minIntervalUs=" + std::to_string(s_minIntervalUs) +
-                                             " pushes=" + std::to_string(s_pushCount) +
-                                             "/s skips=" + std::to_string(s_skipCount) + "/s");
-                                    s_pushCount = s_skipCount = 0;
-                                    s_lastTickUs = s_nowUs;
-                                }
-
-                                if (s_pushAllowed && frameDataReady && m_streamManager && m_streamManager->isActive())
-                                {
-                                    m_lastStreamPushUs = s_nowUs;
                                     const bool useSource = streamWantsSource && sourceFrameReady;
                                     static int streamPushLogCount = 0;
                                     if (streamPushLogCount++ < 3 && m_ui)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4264,25 +4264,49 @@ void Application::run()
             // applyPendingRemoteMeta — wastes GPU and produces the
             // 500-fps reading the user spotted in MangoHud. Sleep until
             // the next host-frame deadline.
-            if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote && m_remoteSourceFps > 0)
+            //
+            // Fall back to 60 fps when /meta hasn't arrived yet or reports
+            // fps=0 — anything's better than the 1 ms-sleep free-run that
+            // produced the 500 fps reading we're trying to fix.
+            if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote)
             {
+                const uint32_t fps = m_remoteSourceFps > 0 ? m_remoteSourceFps : 60;
                 const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                           std::chrono::steady_clock::now().time_since_epoch()).count();
-                const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(m_remoteSourceFps);
+                const int64_t targetIntervalUs = 1000000LL / static_cast<int64_t>(fps);
                 if (m_lastFrameSwapUs == 0)
                 {
                     m_lastFrameSwapUs = nowUs;
                 }
                 const int64_t elapsedUs = nowUs - m_lastFrameSwapUs;
+
+                // 1 s telemetry — confirms the pacing actually runs in the
+                // remote-source code path. Removable after verifying.
+                static int64_t s_lastPaceTickUs = 0;
+                static uint32_t s_paceIters = 0;
+                static uint32_t s_paceSleeps = 0;
+                ++s_paceIters;
+                if (s_lastPaceTickUs == 0) s_lastPaceTickUs = nowUs;
                 if (elapsedUs < targetIntervalUs)
                 {
                     const int64_t sleepUs = targetIntervalUs - elapsedUs;
+                    ++s_paceSleeps;
 #ifdef PLATFORM_LINUX
                     usleep(static_cast<useconds_t>(sleepUs));
 #else
                     Sleep(static_cast<DWORD>(sleepUs / 1000));
 #endif
                 }
+                if (nowUs - s_lastPaceTickUs >= 1000000LL)
+                {
+                    LOG_INFO("remote render pace: fps=" + std::to_string(fps) +
+                             " iters=" + std::to_string(s_paceIters) +
+                             "/s sleeps=" + std::to_string(s_paceSleeps) +
+                             "/s sourceFpsFromMeta=" + std::to_string(m_remoteSourceFps));
+                    s_paceIters = s_paceSleeps = 0;
+                    s_lastPaceTickUs = nowUs;
+                }
+
                 m_lastFrameSwapUs = nowUs + std::max<int64_t>(0, targetIntervalUs - elapsedUs);
             }
             else

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -170,15 +170,6 @@ private:
     std::unique_ptr<PBOManager> m_pboManager; // PBO para leitura assíncrona de pixels
     std::unique_ptr<RecordingManager> m_recordingManager;
 
-    // Push-rate throttle for streaming/recording — the main loop can run
-    // faster than the configured stream FPS when vsync is off or the
-    // display refresh rate is higher than 60 Hz, which produces hundreds
-    // of pushes per second with near-identical timestamps. The encoder
-    // chokes (PTS retrocession, sync-zone overflow) and the client sees
-    // back-and-forth jitter. Track last push wall-clock time and skip
-    // pushes that come within (1 / targetFps) of the previous one.
-    int64_t m_lastStreamPushUs = 0;
-
     // Remote-source render pacing: when consuming a remote /raw stream the
     // client's main loop has no reason to iterate faster than the host's
     // source FPS. Without this cap an idle high-refresh display can

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -289,6 +289,7 @@ private:
     std::string m_streamingVaapiRcMode = "CBR";
     std::string m_streamingQsvPreset   = "veryfast";
     std::string m_streamingAmfQuality  = "speed";
+    std::string m_remoteInterpolation  = "linear";
 
     // Buffer configuration
     size_t m_streamingMaxVideoBufferSize = 10;     // Máximo de frames no buffer de vídeo (1-50)

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -170,6 +170,15 @@ private:
     std::unique_ptr<PBOManager> m_pboManager; // PBO para leitura assíncrona de pixels
     std::unique_ptr<RecordingManager> m_recordingManager;
 
+    // Push-rate throttle for streaming/recording — the main loop can run
+    // faster than the configured stream FPS when vsync is off or the
+    // display refresh rate is higher than 60 Hz, which produces hundreds
+    // of pushes per second with near-identical timestamps. The encoder
+    // chokes (PTS retrocession, sync-zone overflow) and the client sees
+    // back-and-forth jitter. Track last push wall-clock time and skip
+    // pushes that come within (1 / targetFps) of the previous one.
+    int64_t m_lastStreamPushUs = 0;
+
     // Phase 4 of #47: when source is Remote, this polls /meta and dispatches
     // shader/parameter deltas onto the main thread (see m_pendingRemote* below).
     std::unique_ptr<class RemoteMetaSync> m_remoteMetaSync;

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -293,6 +293,7 @@ private:
     std::string m_streamingH265Level = "auto";      // Level H.265: "auto", "1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"
     int m_streamingVP8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_streamingVP9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
+    int m_streamingHardwareEncoder = 0;             // 0 = Auto (MediaEncoder::HardwareEncoder enum value)
 
     // Buffer configuration
     size_t m_streamingMaxVideoBufferSize = 10;     // Máximo de frames no buffer de vídeo (1-50)

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -196,6 +196,17 @@ private:
     // source size, not the smaller transmission size.
     uint32_t                         m_pendingRemoteSourceWidth  = 0;
     uint32_t                         m_pendingRemoteSourceHeight = 0;
+    // Host's Image-tab values from /meta. Only applied on the FIRST
+    // snapshot after a connect — m_remoteImageSeeded gates the apply
+    // so subsequent snapshots don't stomp whatever the local user
+    // tweaked after the seed.
+    bool                             m_remoteImageSeeded = false;
+    float                            m_pendingRemoteImageBrightness     = 1.0f;
+    float                            m_pendingRemoteImageContrast       = 1.0f;
+    bool                             m_pendingRemoteImageMaintainAspect = true;
+    uint32_t                         m_pendingRemoteImageOutputWidth    = 0;
+    uint32_t                         m_pendingRemoteImageOutputHeight   = 0;
+    bool                             m_hasPendingRemoteImageSeed        = false;
 
     // Buffers reutilizáveis no caminho de captura — evita alocar ~6MB/frame a 1080p.
     // pushFrame() copia os dados, então é seguro reutilizar.

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -138,6 +138,11 @@ public:
     
     // Shader path resolution (centralized)
     std::string resolveShaderPath(const std::string& shaderPath) const;
+
+    // Phase 4 of #47: drains pending remote /meta snapshot onto the GL
+    // thread. Called once per main-loop iteration; cheap no-op when
+    // m_hasPendingRemoteMeta is false.
+    void applyPendingRemoteMeta();
     fs::path getShaderBasePath() const;
     
     // Thread-safe resolution change scheduling
@@ -164,6 +169,17 @@ private:
     std::unique_ptr<IAudioCapture> m_audioCapture;
     std::unique_ptr<PBOManager> m_pboManager; // PBO para leitura assíncrona de pixels
     std::unique_ptr<RecordingManager> m_recordingManager;
+
+    // Phase 4 of #47: when source is Remote, this polls /meta and dispatches
+    // shader/parameter deltas onto the main thread (see m_pendingRemote* below).
+    std::unique_ptr<class RemoteMetaSync> m_remoteMetaSync;
+    std::mutex                       m_pendingRemoteMutex;
+    std::atomic<bool>                m_hasPendingRemoteMeta{false};
+    std::string                      m_pendingRemotePreset;
+    std::string                      m_pendingRemotePresetHash;
+    std::string                      m_appliedRemotePresetHash;
+    bool                             m_pendingRemotePipelineEnabled = true;
+    std::vector<std::pair<std::string, float>> m_pendingRemoteParams;
 
     // Buffers reutilizáveis no caminho de captura — evita alocar ~6MB/frame a 1080p.
     // pushFrame() copia os dados, então é seguro reutilizar.

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -180,6 +180,11 @@ private:
     std::string                      m_appliedRemotePresetHash;
     bool                             m_pendingRemotePipelineEnabled = true;
     std::vector<std::pair<std::string, float>> m_pendingRemoteParams;
+    // Host's source resolution from /meta. The capture rescales /raw to
+    // these dims so the local shader sees frames at the host's logical
+    // source size, not the smaller transmission size.
+    uint32_t                         m_pendingRemoteSourceWidth  = 0;
+    uint32_t                         m_pendingRemoteSourceHeight = 0;
 
     // Buffers reutilizáveis no caminho de captura — evita alocar ~6MB/frame a 1080p.
     // pushFrame() copia os dados, então é seguro reutilizar.

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -290,6 +290,7 @@ private:
     std::string m_streamingQsvPreset   = "veryfast";
     std::string m_streamingAmfQuality  = "speed";
     std::string m_remoteInterpolation  = "linear";
+    bool        m_remoteWindowFocused  = true;  // tracks vsync toggle state in the Remote main-loop branch
 
     // Buffer configuration
     size_t m_streamingMaxVideoBufferSize = 10;     // Máximo de frames no buffer de vídeo (1-50)

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -179,6 +179,17 @@ private:
     // pushes that come within (1 / targetFps) of the previous one.
     int64_t m_lastStreamPushUs = 0;
 
+    // Remote-source render pacing: when consuming a remote /raw stream the
+    // client's main loop has no reason to iterate faster than the host's
+    // source FPS. Without this cap an idle high-refresh display can
+    // re-render the same decoded frame hundreds of times per source frame
+    // — wasted GPU and CPU, plus the ImGui frame counter ends up showing
+    // 500+ fps regardless of how slow the underlying source is.
+    // sourceFps comes from /meta; m_lastFrameSwapUs tracks the timestamp
+    // of the last completed main-loop iteration to compute the next sleep.
+    uint32_t m_remoteSourceFps = 0;
+    int64_t  m_lastFrameSwapUs = 0;
+
     // Phase 4 of #47: when source is Remote, this polls /meta and dispatches
     // shader/parameter deltas onto the main thread (see m_pendingRemote* below).
     std::unique_ptr<class RemoteMetaSync> m_remoteMetaSync;

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -294,6 +294,10 @@ private:
     int m_streamingVP8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_streamingVP9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
     int m_streamingHardwareEncoder = 0;             // 0 = Auto (MediaEncoder::HardwareEncoder enum value)
+    std::string m_streamingNvencPreset = "p4";
+    std::string m_streamingVaapiRcMode = "CBR";
+    std::string m_streamingQsvPreset   = "veryfast";
+    std::string m_streamingAmfQuality  = "speed";
 
     // Buffer configuration
     size_t m_streamingMaxVideoBufferSize = 10;     // Máximo de frames no buffer de vídeo (1-50)

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -142,7 +142,17 @@ bool MediaEncoder::initializeVideoCodec()
     codecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
     codecCtx->bit_rate = m_videoConfig.bitrate;
     codecCtx->thread_count = 0;
-    codecCtx->thread_type = FF_THREAD_SLICE;
+    // FF_THREAD_FRAME parallelises encoding across consecutive frames
+    // (each thread works on a different frame) instead of FF_THREAD_SLICE
+    // which divides one frame into parallel slices. On a multi-core CPU
+    // with libx264 at non-trivial presets the per-frame budget is the
+    // bottleneck — slice threading caps how much we can speed up a
+    // single frame, but frame threading lets us keep N frames in flight
+    // simultaneously and roughly multiply throughput by core count.
+    // Adds ~thread_count frames of latency (libx264 holds a few frames
+    // in its pipeline), acceptable for a /raw distribution stream where
+    // we already buffer ~500 ms on the client.
+    codecCtx->thread_type = FF_THREAD_FRAME;
 
     // Configurar global header baseado no uso (streaming vs arquivo)
     // Para gravação em arquivo: usar global header (extradata no header do container)

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -548,10 +548,13 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
     codecCtx->profile = FF_PROFILE_H264_MAIN;
 
     AVDictionary *opts = nullptr;
-    // Per-backend tuning. Defaults aim at low-latency live streaming.
+    // Per-backend tuning. hwPreset from the UI overrides the default
+    // when non-empty; meaning differs per backend (NVENC preset / VAAPI
+    // rc_mode / QSV preset / AMF quality).
+    const std::string &userPreset = m_videoConfig.hwPreset;
     if (backend == HardwareEncoder::NVENC)
     {
-        av_dict_set(&opts, "preset", "p4", 0);           // p1=fastest..p7=slowest
+        av_dict_set(&opts, "preset", userPreset.empty() ? "p4" : userPreset.c_str(), 0);
         av_dict_set(&opts, "tune",   "ll",  0);          // low-latency
         av_dict_set(&opts, "rc",     "cbr", 0);
         av_dict_set_int(&opts, "zerolatency", 1, 0);
@@ -559,20 +562,20 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
     }
     else if (backend == HardwareEncoder::VAAPI)
     {
-        av_dict_set(&opts, "rc_mode", "CBR", 0);
+        av_dict_set(&opts, "rc_mode", userPreset.empty() ? "CBR" : userPreset.c_str(), 0);
         // low_power=1 is unsupported on a chunk of AMD parts — let the
         // driver pick the entry path instead.
         av_dict_set_int(&opts, "idr_interval", static_cast<int>(m_videoConfig.fps * 2), 0);
     }
     else if (backend == HardwareEncoder::QSV)
     {
-        av_dict_set(&opts, "preset", "veryfast", 0);
+        av_dict_set(&opts, "preset", userPreset.empty() ? "veryfast" : userPreset.c_str(), 0);
         av_dict_set_int(&opts, "look_ahead", 0, 0);
     }
     else if (backend == HardwareEncoder::AMF)
     {
-        av_dict_set(&opts, "usage", "transcoding", 0);
-        av_dict_set(&opts, "quality", "speed",     0);
+        av_dict_set(&opts, "usage",   "transcoding", 0);
+        av_dict_set(&opts, "quality", userPreset.empty() ? "speed" : userPreset.c_str(), 0);
         av_dict_set(&opts, "rc",      "cbr",       0);
     }
 

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -539,20 +539,29 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
         codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
 
+    // H.264 profile: pin to Main. Every hardware encoder we target
+    // supports Main, but consumer AMD VAAPI builds frequently don't
+    // expose High encoding entrypoints ("No usable encoding entrypoint
+    // found for profile VAProfileH264High" is the user-visible
+    // signature). If even Main fails we let the outer dispatcher fall
+    // back to libx264.
+    codecCtx->profile = FF_PROFILE_H264_MAIN;
+
     AVDictionary *opts = nullptr;
     // Per-backend tuning. Defaults aim at low-latency live streaming.
     if (backend == HardwareEncoder::NVENC)
     {
-        av_dict_set(&opts, "preset", "p4", 0);           // medium-speed quality preset (p1=fastest..p7=slowest)
+        av_dict_set(&opts, "preset", "p4", 0);           // p1=fastest..p7=slowest
         av_dict_set(&opts, "tune",   "ll",  0);          // low-latency
         av_dict_set(&opts, "rc",     "cbr", 0);
         av_dict_set_int(&opts, "zerolatency", 1, 0);
-        av_dict_set_int(&opts, "bf",          0, 0);     // no B-frames in low-latency mode
+        av_dict_set_int(&opts, "bf",          0, 0);
     }
     else if (backend == HardwareEncoder::VAAPI)
     {
         av_dict_set(&opts, "rc_mode", "CBR", 0);
-        av_dict_set_int(&opts, "low_power", 1, 0);
+        // low_power=1 is unsupported on a chunk of AMD parts — let the
+        // driver pick the entry path instead.
         av_dict_set_int(&opts, "idr_interval", static_cast<int>(m_videoConfig.fps * 2), 0);
     }
     else if (backend == HardwareEncoder::QSV)
@@ -567,15 +576,16 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
         av_dict_set(&opts, "rc",      "cbr",       0);
     }
 
-    int ret = avcodec_open2(codecCtx, codec, &opts);
+    int openRet = avcodec_open2(codecCtx, codec, &opts);
     av_dict_free(&opts);
-    if (ret < 0)
+    if (openRet < 0)
     {
         char errBuf[256] = {0};
-        av_strerror(ret, errBuf, sizeof(errBuf));
+        av_strerror(openRet, errBuf, sizeof(errBuf));
         LOG_WARN(std::string("MediaEncoder: avcodec_open2 failed for ") + codecName + ": " + errBuf);
         return false;
     }
+    LOG_INFO(std::string("MediaEncoder: ") + codecName + " opened with profile Main");
 
     AVFrame *swFrame = av_frame_alloc();
     if (!swFrame)

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -300,44 +300,41 @@ bool MediaEncoder::initializeVideoCodec()
     // we already buffer ~500 ms on the client.
     codecCtx->thread_type = FF_THREAD_FRAME;
 
-    // Configurar global header baseado no uso (streaming vs arquivo).
-    // File recording: usa global header (extradata no header do container).
-    // Streaming MPEG-TS: NÃO usar global header — o demuxer no client
-    //   conecta no meio do stream e nunca recebe o extradata do container,
-    //   então VPS/SPS/PPS precisam estar inline no bitstream a cada
-    //   keyframe (libx264 'repeat-headers=1' / libx265 'repeat-headers=1').
-    //   HEVC sempre estava marcando GLOBAL_HEADER aqui mesmo em streaming,
-    //   o que produzia o sintoma observado: SPS truncado/lixado no client
-    //   ('Truncating likely oversized VPS 128575 > 4096', 'Invalid NAL
-    //   unit 35') e a imagem virava artefato.
+    // Global-header policy depends on use: file recording carries
+    // extradata in the container header, but a streaming MPEG-TS client
+    // connecting mid-stream never receives that extradata, so VPS/SPS/PPS
+    // must travel inline with each keyframe (libx264/libx265
+    // 'repeat-headers=1'). HEVC used to always set GLOBAL_HEADER here
+    // even for streaming, which produced the truncated VPS / 'Invalid
+    // NAL unit 35' artefacts observed on the client.
     if (m_forStreaming)
     {
-        // streaming: nenhum codec usa global header
+        // Streaming: no codec sets global header.
         if (codec->id == AV_CODEC_ID_VP8 || codec->id == AV_CODEC_ID_VP9)
         {
-            // VP8/VP9 em WebM precisam de extradata no container; mas o
-            // pipeline streaming nunca foi exposto pra VPx, então o
+            // VP8/VP9 in WebM need extradata in the container, but the
+            // streaming pipeline never exposes VPx, so the conservative
             // efeito prático é zero. Mantemos GLOBAL_HEADER por
-            // segurança até alguém realmente streamar VPx.
+            // default to GLOBAL_HEADER until someone actually streams VPx.
             codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         }
     }
     else
     {
-        // file recording: todos os codecs com global header
+        // File recording: every codec uses global header.
         codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
 
-    // Configurar opções específicas do codec
+    // Codec-specific options
     AVDictionary *opts = nullptr;
     if (codec->id == AV_CODEC_ID_H264)
     {
         av_dict_set(&opts, "preset", m_videoConfig.preset.c_str(), 0);
-        // tune=zerolatency mantido em ambos os modos: ele desliga
-        // lookahead/B-frames internos do x264. Em arquivo o lookahead
-        // só cobraria CPU/frame extra (lookahead default 40 frames =
-        // ~10% mais work), o que derruba encoders abaixo de realtime
-        // em presets >= fast. zerolatency mantém custo previsível.
+        // tune=zerolatency in both modes: it disables x264's internal
+        // lookahead / B-frames. For file recording the lookahead would
+        // only cost extra CPU per frame (default 40-frame lookahead =
+        // ~10% more work) and pushes encoders below realtime at
+        // preset >= fast. zerolatency keeps cost predictable.
         av_dict_set(&opts, "tune", "zerolatency", 0);
         av_dict_set(&opts, "profile", m_videoConfig.profile.c_str(), 0);
         int keyint = static_cast<int>(m_videoConfig.fps * 2);
@@ -348,7 +345,7 @@ bool MediaEncoder::initializeVideoCodec()
 
         if (m_forStreaming)
         {
-            // Streaming HTTP-TS: vbv apertado limita variação de bitrate.
+            // HTTP-TS streaming: tight vbv caps bitrate variation.
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
             av_dict_set_int(&opts, "repeat-headers", 1, 0);
         }

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -895,20 +895,21 @@ void MediaEncoder::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
 
     if (isVideo)
     {
-        if (pts != AV_NOPTS_VALUE_LOCAL)
-        {
-            if (m_lastVideoPTS >= 0 && pts <= m_lastVideoPTS)
-            {
-                pts = m_lastVideoPTS + 1;
-                uint64_t total = m_desyncFrameCount.fetch_add(1, std::memory_order_relaxed) + 1;
-                if (total == 1 || (total % 60) == 0)
-                {
-                    LOG_WARN("MediaEncoder: PTS retrocession on video frame (total: " +
-                             std::to_string(total) + ")");
-                }
-            }
-            m_lastVideoPTS = pts;
-        }
+        // PTS is in DISPLAY order — when libx264 emits B-frames (any
+        // preset slower than ultrafast/superfast can), a B-frame's PTS
+        // is legitimately smaller than the previous packet's PTS in
+        // decode order: the B-frame displays between an I-frame and a
+        // P-frame, but is emitted by the encoder AFTER the P-frame it
+        // references. Forcing PTS monotonic here was rewriting B-frame
+        // PTS values so they ended up displayed in the wrong order —
+        // that's exactly the back-and-forth ghost effect the user saw
+        // when picking a slower preset / higher bitrate.
+        //
+        // Only DTS needs to be strictly monotonic; libx264 already
+        // guarantees that, but we keep the check as defense in depth.
+        // Clamping DTS to PTS was equally wrong — for a B-frame
+        // DTS > PTS is the entire point (decoded after the future
+        // P-frame it depends on, displayed earlier than it).
         if (dts != AV_NOPTS_VALUE_LOCAL)
         {
             if (m_lastVideoDTS >= 0 && dts <= m_lastVideoDTS)
@@ -917,10 +918,10 @@ void MediaEncoder::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
             }
             m_lastVideoDTS = dts;
         }
-        if (pts != AV_NOPTS_VALUE_LOCAL && dts != AV_NOPTS_VALUE_LOCAL && dts > pts)
+        if (pts != AV_NOPTS_VALUE_LOCAL)
         {
-            dts = pts;
-            m_lastVideoDTS = dts;
+            // Tracked for telemetry only — no longer used to clamp.
+            m_lastVideoPTS = pts;
         }
     }
     else

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -29,8 +29,21 @@ const char *MediaEncoder::hardwareEncoderName(HardwareEncoder h)
     return "?";
 }
 
-const char *MediaEncoder::hardwareEncoderCodec(HardwareEncoder h)
+const char *MediaEncoder::hardwareEncoderCodec(HardwareEncoder h, bool isHEVC)
 {
+    if (isHEVC)
+    {
+        switch (h)
+        {
+            case HardwareEncoder::Auto:     return "";
+            case HardwareEncoder::Software: return "libx265";
+            case HardwareEncoder::NVENC:    return "hevc_nvenc";
+            case HardwareEncoder::VAAPI:    return "hevc_vaapi";
+            case HardwareEncoder::QSV:      return "hevc_qsv";
+            case HardwareEncoder::AMF:      return "hevc_amf";
+        }
+        return "";
+    }
     switch (h)
     {
         case HardwareEncoder::Auto:     return "";          // resolved at runtime
@@ -59,18 +72,21 @@ std::vector<MediaEncoder::HardwareEncoder> MediaEncoder::detectAvailableEncoders
         };
         for (HardwareEncoder candidate : candidates)
         {
-            const char *codecName = hardwareEncoderCodec(candidate);
-            if (!codecName || !*codecName) continue;
-            // avcodec_find_encoder_by_name only tells us the codec is
-            // compiled into ffmpeg, not that the host can actually use it
-            // — but it's a cheap first filter that excludes builds where
-            // the hw lib wasn't linked in (e.g. ffmpeg without nvenc).
-            // Real availability is confirmed when we try to open it at
-            // initialize() time and gracefully fall back on failure.
-            if (avcodec_find_encoder_by_name(codecName) != nullptr)
+            const char *h264Name = hardwareEncoderCodec(candidate, false);
+            const char *hevcName = hardwareEncoderCodec(candidate, true);
+            const bool hasH264 = h264Name && *h264Name && avcodec_find_encoder_by_name(h264Name) != nullptr;
+            const bool hasHEVC = hevcName && *hevcName && avcodec_find_encoder_by_name(hevcName) != nullptr;
+            // Probe both the H.264 and HEVC builds — a backend is
+            // reported as available if either codec is compiled in.
+            // (Typically both come from the same ffmpeg library, but
+            // some custom builds drop one.) Real availability is
+            // confirmed at codec-open time; on failure we fall back to
+            // software for that specific codec.
+            if (hasH264 || hasHEVC)
             {
                 cache.push_back(candidate);
-                LOG_INFO(std::string("MediaEncoder: hardware encoder available — ") + hardwareEncoderName(candidate));
+                LOG_INFO(std::string("MediaEncoder: hardware encoder available — ") + hardwareEncoderName(candidate) +
+                         " (h264=" + (hasH264 ? "yes" : "no") + ", hevc=" + (hasHEVC ? "yes" : "no") + ")");
             }
         }
     });
@@ -117,24 +133,30 @@ bool MediaEncoder::initialize(const VideoConfig &videoConfig, const AudioConfig 
 
 bool MediaEncoder::initializeVideoCodec()
 {
-    // Hardware encoder dispatcher. Only applies when the user requested
-    // h264 — the hardware backends in this project all encode H.264.
-    // For other codecs (h265/vp8/vp9) we keep the original software path.
-    if (m_videoConfig.codec == "h264" || m_videoConfig.codec == "libx264")
+    // Hardware encoder dispatcher. Applies to both H.264 and H.265 —
+    // the other codecs in this project (vp8/vp9) have no hardware
+    // equivalents we support, they keep the software-only path.
+    const bool wantHEVC = (m_videoConfig.codec == "h265" ||
+                           m_videoConfig.codec == "libx265" ||
+                           m_videoConfig.codec == "hevc");
+    const bool wantH264 = (m_videoConfig.codec == "h264" ||
+                           m_videoConfig.codec == "libx264");
+    if (wantH264 || wantHEVC)
     {
         HardwareEncoder selected = m_videoConfig.hardwareEncoder;
         if (selected == HardwareEncoder::Auto)
         {
             // Walk the same priority list detectAvailableEncoders uses,
-            // picking the first hardware backend that's compiled in. The
-            // actual open() may still fail (driver missing etc.) — we
-            // fall back to software in that case.
+            // picking the first hardware backend whose codec for the
+            // user-selected family is compiled in. open() may still
+            // fail (driver missing etc.) — we fall back to software in
+            // that case.
             for (HardwareEncoder candidate : { HardwareEncoder::NVENC,
                                                HardwareEncoder::VAAPI,
                                                HardwareEncoder::QSV,
                                                HardwareEncoder::AMF })
             {
-                if (avcodec_find_encoder_by_name(hardwareEncoderCodec(candidate)))
+                if (avcodec_find_encoder_by_name(hardwareEncoderCodec(candidate, wantHEVC)))
                 {
                     selected = candidate;
                     break;
@@ -152,7 +174,7 @@ bool MediaEncoder::initializeVideoCodec()
                 return true;
             }
             LOG_WARN(std::string("MediaEncoder: hardware backend ") + hardwareEncoderName(selected) +
-                     " failed to initialize, falling back to software libx264");
+                     " failed to initialize, falling back to software libx264/libx265");
             // Tear down anything the failed HW init may have allocated
             // so the software path below starts from a clean slate.
             if (m_videoCodecContext)
@@ -484,7 +506,10 @@ bool MediaEncoder::createHardwareContext(HardwareEncoder backend)
 
 bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
 {
-    const char *codecName = hardwareEncoderCodec(backend);
+    const bool wantHEVC = (m_videoConfig.codec == "h265" ||
+                           m_videoConfig.codec == "libx265" ||
+                           m_videoConfig.codec == "hevc");
+    const char *codecName = hardwareEncoderCodec(backend, wantHEVC);
     const AVCodec *codec = avcodec_find_encoder_by_name(codecName);
     if (!codec)
     {
@@ -539,13 +564,13 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
         codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
 
-    // H.264 profile: pin to Main. Every hardware encoder we target
-    // supports Main, but consumer AMD VAAPI builds frequently don't
-    // expose High encoding entrypoints ("No usable encoding entrypoint
-    // found for profile VAProfileH264High" is the user-visible
-    // signature). If even Main fails we let the outer dispatcher fall
-    // back to libx264.
-    codecCtx->profile = FF_PROFILE_H264_MAIN;
+    // Profile selection: pin to Main for both H.264 and HEVC. Every
+    // hardware encoder we target supports Main; consumer AMD VAAPI
+    // builds frequently lack High encoding entrypoints (the user-visible
+    // signature is "No usable encoding entrypoint found for profile
+    // VAProfileH264High"). If Main also fails we let the outer
+    // dispatcher fall back to the software encoder for that codec.
+    codecCtx->profile = wantHEVC ? FF_PROFILE_HEVC_MAIN : FF_PROFILE_H264_MAIN;
 
     AVDictionary *opts = nullptr;
     // Per-backend tuning. hwPreset from the UI overrides the default

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -300,17 +300,31 @@ bool MediaEncoder::initializeVideoCodec()
     // we already buffer ~500 ms on the client.
     codecCtx->thread_type = FF_THREAD_FRAME;
 
-    // Configurar global header baseado no uso (streaming vs arquivo)
-    // Para gravação em arquivo: usar global header (extradata no header do container)
-    // Para streaming: não usar global header, usar repeat-headers (extradata em cada keyframe)
-    if (codec->id == AV_CODEC_ID_HEVC || codec->id == AV_CODEC_ID_VP8 || codec->id == AV_CODEC_ID_VP9)
+    // Configurar global header baseado no uso (streaming vs arquivo).
+    // File recording: usa global header (extradata no header do container).
+    // Streaming MPEG-TS: NÃO usar global header — o demuxer no client
+    //   conecta no meio do stream e nunca recebe o extradata do container,
+    //   então VPS/SPS/PPS precisam estar inline no bitstream a cada
+    //   keyframe (libx264 'repeat-headers=1' / libx265 'repeat-headers=1').
+    //   HEVC sempre estava marcando GLOBAL_HEADER aqui mesmo em streaming,
+    //   o que produzia o sintoma observado: SPS truncado/lixado no client
+    //   ('Truncating likely oversized VPS 128575 > 4096', 'Invalid NAL
+    //   unit 35') e a imagem virava artefato.
+    if (m_forStreaming)
     {
-        codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        // streaming: nenhum codec usa global header
+        if (codec->id == AV_CODEC_ID_VP8 || codec->id == AV_CODEC_ID_VP9)
+        {
+            // VP8/VP9 em WebM precisam de extradata no container; mas o
+            // pipeline streaming nunca foi exposto pra VPx, então o
+            // efeito prático é zero. Mantemos GLOBAL_HEADER por
+            // segurança até alguém realmente streamar VPx.
+            codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        }
     }
-    else if (codec->id == AV_CODEC_ID_H264 && !m_forStreaming)
+    else
     {
-        // Para H.264 em gravação de arquivo, usar global header para simplificar
-        // FFmpeg vai lidar com extradata automaticamente
+        // file recording: todos os codecs com global header
         codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
 
@@ -362,6 +376,13 @@ bool MediaEncoder::initializeVideoCodec()
         if (m_forStreaming)
         {
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
+            // Inline VPS/SPS/PPS at every keyframe — libx265 equivalent
+            // of libx264's repeat-headers. Without this, a client that
+            // joins the MPEG-TS stream after the first keyframe never
+            // receives the parameter sets and reads NAL data as random
+            // bytes ('Invalid NAL unit 35', 'Truncating likely oversized
+            // VPS', 'PCM bit depth out of range').
+            av_dict_set(&opts, "x265-params", "repeat-headers=1:annexb=1", 0);
         }
         else
         {
@@ -584,6 +605,11 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
         av_dict_set(&opts, "rc",     "cbr", 0);
         av_dict_set_int(&opts, "zerolatency", 1, 0);
         av_dict_set_int(&opts, "bf",          0, 0);
+        // hevc_nvenc/h264_nvenc: emit VPS/SPS/PPS in front of every IDR
+        // so MPEG-TS clients that join mid-stream get the parameter
+        // sets without needing the muxer's extradata. Without this the
+        // client sees keyframes with no headers and decodes garbage.
+        av_dict_set_int(&opts, "forced-idr", 1, 0);
     }
     else if (backend == HardwareEncoder::VAAPI)
     {
@@ -591,17 +617,26 @@ bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
         // low_power=1 is unsupported on a chunk of AMD parts — let the
         // driver pick the entry path instead.
         av_dict_set_int(&opts, "idr_interval", static_cast<int>(m_videoConfig.fps * 2), 0);
+        // hevc_vaapi / h264_vaapi emit headers inline by default when
+        // every IDR is forced (vs. only first keyframe). No additional
+        // option needed beyond idr_interval; mid-stream join works.
     }
     else if (backend == HardwareEncoder::QSV)
     {
         av_dict_set(&opts, "preset", userPreset.empty() ? "veryfast" : userPreset.c_str(), 0);
         av_dict_set_int(&opts, "look_ahead", 0, 0);
+        // QSV's 'idr_interval' is in seconds and inserts inline headers
+        // at every IDR. 0 = once per GOP (default) is sufficient.
     }
     else if (backend == HardwareEncoder::AMF)
     {
         av_dict_set(&opts, "usage",   "transcoding", 0);
         av_dict_set(&opts, "quality", userPreset.empty() ? "speed" : userPreset.c_str(), 0);
         av_dict_set(&opts, "rc",      "cbr",       0);
+        // header_insertion_mode=idr → emit VPS/SPS/PPS at every IDR
+        // frame (default 'none' only emits once and leaves mid-stream
+        // joiners without parameter sets).
+        av_dict_set(&opts, "header_insertion_mode", "idr", 0);
     }
 
     int openRet = avcodec_open2(codecCtx, codec, &opts);

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -7,11 +7,75 @@ extern "C"
 #include <libavutil/imgutils.h>
 #include <libavutil/opt.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/hwcontext.h>
 #include <libswscale/swscale.h>
 #include <libswresample/swresample.h>
 }
 
 #include "../utils/FFmpegCompat.h"
+#include <mutex>
+
+const char *MediaEncoder::hardwareEncoderName(HardwareEncoder h)
+{
+    switch (h)
+    {
+        case HardwareEncoder::Auto:     return "Auto";
+        case HardwareEncoder::Software: return "Software (libx264)";
+        case HardwareEncoder::NVENC:    return "NVIDIA NVENC";
+        case HardwareEncoder::VAAPI:    return "VAAPI (Linux)";
+        case HardwareEncoder::QSV:      return "Intel Quick Sync";
+        case HardwareEncoder::AMF:      return "AMD AMF (Windows)";
+    }
+    return "?";
+}
+
+const char *MediaEncoder::hardwareEncoderCodec(HardwareEncoder h)
+{
+    switch (h)
+    {
+        case HardwareEncoder::Auto:     return "";          // resolved at runtime
+        case HardwareEncoder::Software: return "libx264";
+        case HardwareEncoder::NVENC:    return "h264_nvenc";
+        case HardwareEncoder::VAAPI:    return "h264_vaapi";
+        case HardwareEncoder::QSV:      return "h264_qsv";
+        case HardwareEncoder::AMF:      return "h264_amf";
+    }
+    return "";
+}
+
+std::vector<MediaEncoder::HardwareEncoder> MediaEncoder::detectAvailableEncoders()
+{
+    static std::vector<HardwareEncoder> cache;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        // Software always available (libx264 is a hard dependency of the build).
+        cache.push_back(HardwareEncoder::Software);
+
+        const HardwareEncoder candidates[] = {
+            HardwareEncoder::NVENC,
+            HardwareEncoder::VAAPI,
+            HardwareEncoder::QSV,
+            HardwareEncoder::AMF,
+        };
+        for (HardwareEncoder candidate : candidates)
+        {
+            const char *codecName = hardwareEncoderCodec(candidate);
+            if (!codecName || !*codecName) continue;
+            // avcodec_find_encoder_by_name only tells us the codec is
+            // compiled into ffmpeg, not that the host can actually use it
+            // — but it's a cheap first filter that excludes builds where
+            // the hw lib wasn't linked in (e.g. ffmpeg without nvenc).
+            // Real availability is confirmed when we try to open it at
+            // initialize() time and gracefully fall back on failure.
+            if (avcodec_find_encoder_by_name(codecName) != nullptr)
+            {
+                cache.push_back(candidate);
+                LOG_INFO(std::string("MediaEncoder: hardware encoder available — ") + hardwareEncoderName(candidate));
+            }
+        }
+    });
+    return cache;
+}
 
 MediaEncoder::MediaEncoder()
 {
@@ -53,6 +117,66 @@ bool MediaEncoder::initialize(const VideoConfig &videoConfig, const AudioConfig 
 
 bool MediaEncoder::initializeVideoCodec()
 {
+    // Hardware encoder dispatcher. Only applies when the user requested
+    // h264 — the hardware backends in this project all encode H.264.
+    // For other codecs (h265/vp8/vp9) we keep the original software path.
+    if (m_videoConfig.codec == "h264" || m_videoConfig.codec == "libx264")
+    {
+        HardwareEncoder selected = m_videoConfig.hardwareEncoder;
+        if (selected == HardwareEncoder::Auto)
+        {
+            // Walk the same priority list detectAvailableEncoders uses,
+            // picking the first hardware backend that's compiled in. The
+            // actual open() may still fail (driver missing etc.) — we
+            // fall back to software in that case.
+            for (HardwareEncoder candidate : { HardwareEncoder::NVENC,
+                                               HardwareEncoder::VAAPI,
+                                               HardwareEncoder::QSV,
+                                               HardwareEncoder::AMF })
+            {
+                if (avcodec_find_encoder_by_name(hardwareEncoderCodec(candidate)))
+                {
+                    selected = candidate;
+                    break;
+                }
+            }
+            if (selected == HardwareEncoder::Auto) selected = HardwareEncoder::Software;
+        }
+
+        if (selected != HardwareEncoder::Software)
+        {
+            if (initializeHardwareVideoCodec(selected))
+            {
+                m_activeHardwareEncoder = selected;
+                LOG_INFO(std::string("MediaEncoder: using hardware encoder — ") + hardwareEncoderName(selected));
+                return true;
+            }
+            LOG_WARN(std::string("MediaEncoder: hardware backend ") + hardwareEncoderName(selected) +
+                     " failed to initialize, falling back to software libx264");
+            // Tear down anything the failed HW init may have allocated
+            // so the software path below starts from a clean slate.
+            if (m_videoCodecContext)
+            {
+                AVCodecContext *cc = static_cast<AVCodecContext *>(m_videoCodecContext);
+                avcodec_free_context(&cc);
+                m_videoCodecContext = nullptr;
+            }
+            if (m_hwFramesCtx)
+            {
+                AVBufferRef *ref = static_cast<AVBufferRef *>(m_hwFramesCtx);
+                av_buffer_unref(&ref);
+                m_hwFramesCtx = nullptr;
+            }
+            if (m_hwDeviceCtx)
+            {
+                AVBufferRef *ref = static_cast<AVBufferRef *>(m_hwDeviceCtx);
+                av_buffer_unref(&ref);
+                m_hwDeviceCtx = nullptr;
+            }
+        }
+        m_activeHardwareEncoder = HardwareEncoder::Software;
+    }
+
     // Tentar encontrar codec por nome primeiro, depois por ID
     const AVCodec *codec = nullptr;
 
@@ -285,6 +409,214 @@ bool MediaEncoder::initializeVideoCodec()
     return true;
 }
 
+namespace
+{
+    AVHWDeviceType deviceTypeForBackend(MediaEncoder::HardwareEncoder b)
+    {
+        switch (b)
+        {
+            case MediaEncoder::HardwareEncoder::VAAPI: return AV_HWDEVICE_TYPE_VAAPI;
+            case MediaEncoder::HardwareEncoder::QSV:   return AV_HWDEVICE_TYPE_QSV;
+            case MediaEncoder::HardwareEncoder::AMF:   return AV_HWDEVICE_TYPE_D3D11VA;
+            default:                                   return AV_HWDEVICE_TYPE_NONE;
+        }
+    }
+
+    AVPixelFormat hwPixelFormatForBackend(MediaEncoder::HardwareEncoder b)
+    {
+        switch (b)
+        {
+            case MediaEncoder::HardwareEncoder::VAAPI: return AV_PIX_FMT_VAAPI;
+            case MediaEncoder::HardwareEncoder::QSV:   return AV_PIX_FMT_QSV;
+            case MediaEncoder::HardwareEncoder::AMF:   return AV_PIX_FMT_D3D11;
+            default:                                   return AV_PIX_FMT_NV12;
+        }
+    }
+}
+
+bool MediaEncoder::createHardwareContext(HardwareEncoder backend)
+{
+    // NVENC accepts software-allocated YUV420P frames directly; no need
+    // to spin up an AVHWFramesContext. The other backends (VAAPI, QSV,
+    // AMF/D3D11VA) require a HW device + HW frames context, with the
+    // codec receiving AVFrames whose .data lives in GPU memory.
+    if (backend == HardwareEncoder::NVENC) return true;
+
+    AVHWDeviceType type = deviceTypeForBackend(backend);
+    if (type == AV_HWDEVICE_TYPE_NONE) return false;
+
+    AVBufferRef *deviceCtx = nullptr;
+    int rc = av_hwdevice_ctx_create(&deviceCtx, type, nullptr, nullptr, 0);
+    if (rc < 0 || !deviceCtx)
+    {
+        char errBuf[128] = {0};
+        av_strerror(rc, errBuf, sizeof(errBuf));
+        LOG_WARN(std::string("MediaEncoder: av_hwdevice_ctx_create failed for ") +
+                 hardwareEncoderName(backend) + ": " + errBuf);
+        return false;
+    }
+    m_hwDeviceCtx = deviceCtx;
+
+    AVBufferRef *framesCtxRef = av_hwframe_ctx_alloc(deviceCtx);
+    if (!framesCtxRef)
+    {
+        LOG_WARN("MediaEncoder: av_hwframe_ctx_alloc failed");
+        return false;
+    }
+    AVHWFramesContext *framesCtx = reinterpret_cast<AVHWFramesContext *>(framesCtxRef->data);
+    framesCtx->format    = hwPixelFormatForBackend(backend);
+    framesCtx->sw_format = AV_PIX_FMT_NV12;
+    framesCtx->width     = m_videoConfig.width;
+    framesCtx->height    = m_videoConfig.height;
+    framesCtx->initial_pool_size = 8; // small pool — keep enough surfaces for the in-flight frame threads
+    rc = av_hwframe_ctx_init(framesCtxRef);
+    if (rc < 0)
+    {
+        char errBuf[128] = {0};
+        av_strerror(rc, errBuf, sizeof(errBuf));
+        LOG_WARN(std::string("MediaEncoder: av_hwframe_ctx_init failed: ") + errBuf);
+        av_buffer_unref(&framesCtxRef);
+        return false;
+    }
+    m_hwFramesCtx = framesCtxRef;
+    return true;
+}
+
+bool MediaEncoder::initializeHardwareVideoCodec(HardwareEncoder backend)
+{
+    const char *codecName = hardwareEncoderCodec(backend);
+    const AVCodec *codec = avcodec_find_encoder_by_name(codecName);
+    if (!codec)
+    {
+        LOG_WARN(std::string("MediaEncoder: codec ") + codecName + " not present in this ffmpeg build");
+        return false;
+    }
+
+    if (!createHardwareContext(backend))
+    {
+        return false;
+    }
+
+    AVCodecContext *codecCtx = avcodec_alloc_context3(codec);
+    if (!codecCtx)
+    {
+        LOG_ERROR("MediaEncoder: avcodec_alloc_context3 failed for hardware codec");
+        return false;
+    }
+    m_videoCodecContext = codecCtx;
+
+    codecCtx->codec_id   = codec->id;
+    codecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
+    codecCtx->width      = m_videoConfig.width;
+    codecCtx->height     = m_videoConfig.height;
+    codecCtx->time_base  = {1, 90000};
+    codecCtx->framerate  = {static_cast<int>(m_videoConfig.fps), 1};
+    codecCtx->gop_size   = static_cast<int>(m_videoConfig.fps * 2);
+    codecCtx->max_b_frames = 0;
+    codecCtx->bit_rate   = m_videoConfig.bitrate;
+    codecCtx->thread_count = 1; // hardware encoders manage their own parallelism
+
+    if (backend == HardwareEncoder::NVENC)
+    {
+        // NVENC accepts a regular software YUV420P input frame.
+        codecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
+    }
+    else
+    {
+        // VAAPI / QSV / AMF require their hardware-surface pixel format
+        // and a populated hw_frames_ctx.
+        codecCtx->pix_fmt = hwPixelFormatForBackend(backend);
+        codecCtx->hw_frames_ctx = av_buffer_ref(static_cast<AVBufferRef *>(m_hwFramesCtx));
+        if (!codecCtx->hw_frames_ctx)
+        {
+            LOG_ERROR("MediaEncoder: failed to attach hw_frames_ctx to codec");
+            return false;
+        }
+    }
+
+    if (m_forStreaming == false || codec->id == AV_CODEC_ID_HEVC)
+    {
+        codecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    }
+
+    AVDictionary *opts = nullptr;
+    // Per-backend tuning. Defaults aim at low-latency live streaming.
+    if (backend == HardwareEncoder::NVENC)
+    {
+        av_dict_set(&opts, "preset", "p4", 0);           // medium-speed quality preset (p1=fastest..p7=slowest)
+        av_dict_set(&opts, "tune",   "ll",  0);          // low-latency
+        av_dict_set(&opts, "rc",     "cbr", 0);
+        av_dict_set_int(&opts, "zerolatency", 1, 0);
+        av_dict_set_int(&opts, "bf",          0, 0);     // no B-frames in low-latency mode
+    }
+    else if (backend == HardwareEncoder::VAAPI)
+    {
+        av_dict_set(&opts, "rc_mode", "CBR", 0);
+        av_dict_set_int(&opts, "low_power", 1, 0);
+        av_dict_set_int(&opts, "idr_interval", static_cast<int>(m_videoConfig.fps * 2), 0);
+    }
+    else if (backend == HardwareEncoder::QSV)
+    {
+        av_dict_set(&opts, "preset", "veryfast", 0);
+        av_dict_set_int(&opts, "look_ahead", 0, 0);
+    }
+    else if (backend == HardwareEncoder::AMF)
+    {
+        av_dict_set(&opts, "usage", "transcoding", 0);
+        av_dict_set(&opts, "quality", "speed",     0);
+        av_dict_set(&opts, "rc",      "cbr",       0);
+    }
+
+    int ret = avcodec_open2(codecCtx, codec, &opts);
+    av_dict_free(&opts);
+    if (ret < 0)
+    {
+        char errBuf[256] = {0};
+        av_strerror(ret, errBuf, sizeof(errBuf));
+        LOG_WARN(std::string("MediaEncoder: avcodec_open2 failed for ") + codecName + ": " + errBuf);
+        return false;
+    }
+
+    AVFrame *swFrame = av_frame_alloc();
+    if (!swFrame)
+    {
+        LOG_ERROR("MediaEncoder: failed to allocate software AVFrame");
+        return false;
+    }
+    // The software-side frame we fill with NV12/YUV420P pixel data — for
+    // NVENC this is the frame we feed directly; for VAAPI/QSV/AMF it
+    // becomes the upload source via av_hwframe_transfer_data.
+    swFrame->format = (backend == HardwareEncoder::NVENC) ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_NV12;
+    swFrame->width  = m_videoConfig.width;
+    swFrame->height = m_videoConfig.height;
+    if (av_frame_get_buffer(swFrame, 0) < 0)
+    {
+        LOG_ERROR("MediaEncoder: failed to allocate sw frame buffer");
+        av_frame_free(&swFrame);
+        return false;
+    }
+    m_videoFrame = swFrame;
+
+    if (backend != HardwareEncoder::NVENC)
+    {
+        AVFrame *hwFrame = av_frame_alloc();
+        if (!hwFrame)
+        {
+            LOG_ERROR("MediaEncoder: failed to allocate hw AVFrame");
+            return false;
+        }
+        if (av_hwframe_get_buffer(static_cast<AVBufferRef *>(m_hwFramesCtx), hwFrame, 0) < 0)
+        {
+            LOG_ERROR("MediaEncoder: av_hwframe_get_buffer failed");
+            av_frame_free(&hwFrame);
+            return false;
+        }
+        m_hwVideoFrame = hwFrame;
+    }
+
+    return true;
+}
+
 bool MediaEncoder::initializeAudioCodec()
 {
     const AVCodec *codec = nullptr;
@@ -486,9 +818,21 @@ bool MediaEncoder::convertRGBToYUV(const uint8_t *rgbData, uint32_t width, uint3
         }
     }
 
+    // Hardware backends that need NV12 (VAAPI/QSV/AMF upload via NV12
+    // surfaces) set frame->format = NV12; software / NVENC keep YUV420P.
+    // We honour whatever the frame asks for so the same code path covers
+    // both — the sws context is rebuilt if any of source dims / dest dims
+    // / dest format changes.
+    AVPixelFormat dstFormat = static_cast<AVPixelFormat>(frame->format);
+    if (dstFormat != AV_PIX_FMT_YUV420P && dstFormat != AV_PIX_FMT_NV12)
+    {
+        dstFormat = AV_PIX_FMT_YUV420P;
+    }
+
     SwsContext *swsCtx = static_cast<SwsContext *>(m_swsContext);
     if (!swsCtx || m_swsSrcWidth != width || m_swsSrcHeight != height ||
-        m_swsDstWidth != dstWidth || m_swsDstHeight != dstHeight)
+        m_swsDstWidth != dstWidth || m_swsDstHeight != dstHeight ||
+        static_cast<int>(m_swsDstFormat) != static_cast<int>(dstFormat))
     {
         if (swsCtx)
         {
@@ -497,7 +841,7 @@ bool MediaEncoder::convertRGBToYUV(const uint8_t *rgbData, uint32_t width, uint3
 
         swsCtx = sws_getContext(
             width, height, AV_PIX_FMT_RGB24,
-            dstWidth, dstHeight, AV_PIX_FMT_YUV420P,
+            dstWidth, dstHeight, dstFormat,
             SWS_BILINEAR, nullptr, nullptr, nullptr);
 
         if (!swsCtx)
@@ -511,6 +855,7 @@ bool MediaEncoder::convertRGBToYUV(const uint8_t *rgbData, uint32_t width, uint3
         m_swsSrcHeight = height;
         m_swsDstWidth = dstWidth;
         m_swsDstHeight = dstHeight;
+        m_swsDstFormat = static_cast<int>(dstFormat);
     }
 
     if (av_frame_make_writable(frame) < 0)
@@ -1022,13 +1367,37 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
     }
     m_videoFrameCount++;
 
-    int ret = avcodec_send_frame(codecCtx, videoFrame);
+    // HW backends that hold pixel data in a GPU surface (VAAPI / QSV /
+    // AMF / D3D11) need the software-side NV12 frame uploaded to a
+    // hardware surface before the codec can consume it. NVENC and the
+    // software path skip this and feed the sw frame directly.
+    AVFrame *frameToSend = videoFrame;
+    if (m_hwVideoFrame &&
+        m_activeHardwareEncoder != HardwareEncoder::Software &&
+        m_activeHardwareEncoder != HardwareEncoder::NVENC)
+    {
+        AVFrame *hwFrame = static_cast<AVFrame *>(m_hwVideoFrame);
+        int rc = av_hwframe_transfer_data(hwFrame, videoFrame, 0);
+        if (rc < 0)
+        {
+            char errBuf[128] = {0};
+            av_strerror(rc, errBuf, sizeof(errBuf));
+            LOG_ERROR(std::string("MediaEncoder: av_hwframe_transfer_data failed: ") + errBuf);
+            return false;
+        }
+        hwFrame->pts        = videoFrame->pts;
+        hwFrame->pict_type  = videoFrame->pict_type;
+        FFmpegCompat::setKeyFrame(hwFrame, forceKeyframe);
+        frameToSend = hwFrame;
+    }
+
+    int ret = avcodec_send_frame(codecCtx, frameToSend);
     if (ret < 0)
     {
         if (ret == AVERROR(EAGAIN))
         {
             receiveVideoPackets(packets, captureTimestampUs);
-            ret = avcodec_send_frame(codecCtx, videoFrame);
+            ret = avcodec_send_frame(codecCtx, frameToSend);
         }
         if (ret < 0 && ret != AVERROR(EAGAIN))
         {
@@ -1036,6 +1405,9 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
             return false;
         }
     }
+    // Suppress -Wunused for the conditional re-send variable when the HW
+    // path is inactive.
+    (void)frameToSend;
 
     return receiveVideoPackets(packets, captureTimestampUs);
 }

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -895,21 +895,21 @@ void MediaEncoder::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
 
     if (isVideo)
     {
-        // PTS is in DISPLAY order — when libx264 emits B-frames (any
-        // preset slower than ultrafast/superfast can), a B-frame's PTS
-        // is legitimately smaller than the previous packet's PTS in
-        // decode order: the B-frame displays between an I-frame and a
-        // P-frame, but is emitted by the encoder AFTER the P-frame it
-        // references. Forcing PTS monotonic here was rewriting B-frame
-        // PTS values so they ended up displayed in the wrong order —
-        // that's exactly the back-and-forth ghost effect the user saw
-        // when picking a slower preset / higher bitrate.
+        // PTS is in DISPLAY order, DTS is in DECODE order. We do NOT
+        // force PTS monotonic across packets — that was breaking
+        // B-frame display order in slower presets (visible ghost
+        // effect). PTS values pass through.
         //
-        // Only DTS needs to be strictly monotonic; libx264 already
-        // guarantees that, but we keep the check as defense in depth.
-        // Clamping DTS to PTS was equally wrong — for a B-frame
-        // DTS > PTS is the entire point (decoded after the future
-        // P-frame it depends on, displayed earlier than it).
+        // DTS still needs to be strictly monotonic, both for muxer
+        // sanity and because libavcodec occasionally emits packets
+        // with duplicate / regressing DTS (observed under medium
+        // preset + higher bitrate). When we bump DTS forward to
+        // maintain monotonicity we may push it above the packet's
+        // PTS — but MPEG-TS requires PTS >= DTS for every packet
+        // ("pts < dts in stream 0" error). When that happens we
+        // pull PTS up to match the bumped DTS so the invariant
+        // holds. Display order is preserved relative to other
+        // packets because DTS monotonicity is preserved.
         if (dts != AV_NOPTS_VALUE_LOCAL)
         {
             if (m_lastVideoDTS >= 0 && dts <= m_lastVideoDTS)
@@ -918,9 +918,12 @@ void MediaEncoder::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
             }
             m_lastVideoDTS = dts;
         }
+        if (pts != AV_NOPTS_VALUE_LOCAL && dts != AV_NOPTS_VALUE_LOCAL && pts < dts)
+        {
+            pts = dts;
+        }
         if (pts != AV_NOPTS_VALUE_LOCAL)
         {
-            // Tracked for telemetry only — no longer used to clamp.
             m_lastVideoPTS = pts;
         }
     }

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -17,6 +17,28 @@
 class MediaEncoder
 {
 public:
+    // Hardware encoder backend selection. Auto picks the best available
+    // at runtime (hardware > software); Software forces libx264. The
+    // specific hardware backends are matched against what ffmpeg can
+    // actually open on this host — detectAvailableEncoders() returns the
+    // ones that opened cleanly at startup.
+    enum class HardwareEncoder
+    {
+        Auto,      // detect — prefer hardware if available
+        Software,  // libx264
+        NVENC,     // h264_nvenc — NVIDIA dedicated encoder block
+        VAAPI,     // h264_vaapi — Linux Intel/AMD via libva
+        QSV,       // h264_qsv  — Intel Quick Sync Video
+        AMF        // h264_amf  — AMD on Windows (Advanced Media Framework)
+    };
+
+    static const char *hardwareEncoderName(HardwareEncoder h);   // display label
+    static const char *hardwareEncoderCodec(HardwareEncoder h);  // ffmpeg codec name
+    // Returns the subset of HardwareEncoder values whose ffmpeg codec
+    // can actually be opened on this machine. Always includes Software.
+    // First call may probe; subsequent calls return cached results.
+    static std::vector<HardwareEncoder> detectAvailableEncoders();
+
     // Configuração de vídeo
     struct VideoConfig
     {
@@ -31,6 +53,7 @@ public:
         std::string h265Level = "auto";   // Para H.265
         int vp8Speed = 12;                // 0-16
         int vp9Speed = 6;                 // 0-9
+        HardwareEncoder hardwareEncoder = HardwareEncoder::Auto;
     };
 
     // Configuração de áudio
@@ -128,14 +151,24 @@ private:
     // FFmpeg conversion contexts
     void *m_swsContext = nullptr; // SwsContext* (RGB to YUV)
     void *m_swrContext = nullptr; // SwrContext* (int16 to float planar)
-    void *m_videoFrame = nullptr; // AVFrame* (para encoding de vídeo)
+    void *m_videoFrame = nullptr; // AVFrame* (para encoding de vídeo — software pixel buffer)
+    void *m_hwVideoFrame = nullptr; // AVFrame* (hw surface destination, when using a HW encoder)
     void *m_audioFrame = nullptr; // AVFrame* (para encoding de áudio)
+
+    // Hardware encoder runtime state. Empty when running software libx264.
+    void *m_hwDeviceCtx = nullptr; // AVBufferRef* (AV_HWDEVICE_TYPE_*)
+    void *m_hwFramesCtx = nullptr; // AVBufferRef* (AVHWFramesContext)
+    HardwareEncoder m_activeHardwareEncoder = HardwareEncoder::Software;
+    // Helpers used by initializeVideoCodec when a HW backend is selected.
+    bool initializeHardwareVideoCodec(HardwareEncoder backend);
+    bool createHardwareContext(HardwareEncoder backend);
 
     // Cache para dimensões do SwsContext
     uint32_t m_swsSrcWidth = 0;
     uint32_t m_swsSrcHeight = 0;
     uint32_t m_swsDstWidth = 0;
     uint32_t m_swsDstHeight = 0;
+    int m_swsDstFormat = 0; // AVPixelFormat — invalidate sws ctx when destination format changes too
 
     // Timestamps de referência (primeiro frame/chunk) - apenas para referência
     int64_t m_firstVideoTimestampUs = 0;

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -54,6 +54,14 @@ public:
         int vp8Speed = 12;                // 0-16
         int vp9Speed = 6;                 // 0-9
         HardwareEncoder hardwareEncoder = HardwareEncoder::Auto;
+        // Free-form quality / preset value whose interpretation depends
+        // on the active hardware backend:
+        //   NVENC: "p1".."p7"
+        //   VAAPI: "CBR" / "VBR" / "CQP"
+        //   QSV:   "veryfast".."veryslow"
+        //   AMF:   "speed" / "balanced" / "quality"
+        // Empty string falls back to the backend's hardcoded default.
+        std::string hwPreset;
     };
 
     // Configuração de áudio

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -33,10 +33,15 @@ public:
     };
 
     static const char *hardwareEncoderName(HardwareEncoder h);   // display label
-    static const char *hardwareEncoderCodec(HardwareEncoder h);  // ffmpeg codec name
+    // Returns the ffmpeg codec name for the given backend, choosing
+    // h264_* or hevc_* based on `isHEVC`. The other codecs in the
+    // project (vp8/vp9) don't have hardware equivalents we support.
+    static const char *hardwareEncoderCodec(HardwareEncoder h, bool isHEVC = false);
     // Returns the subset of HardwareEncoder values whose ffmpeg codec
     // can actually be opened on this machine. Always includes Software.
-    // First call may probe; subsequent calls return cached results.
+    // Probes both the H.264 and HEVC builds — a backend is reported as
+    // available if either codec is compiled in. First call may probe;
+    // subsequent calls return cached results.
     static std::vector<HardwareEncoder> detectAvailableEncoders();
 
     // Configuração de vídeo

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -770,20 +770,13 @@ void MediaMuxer::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
 
     if (isVideo)
     {
-        // PTS is in DISPLAY order, DTS is in DECODE order. With
-        // B-frames (any preset slower than ultrafast/superfast can
-        // emit them), PTS values legitimately go non-monotonically in
-        // the encode/decode order: a B-frame is emitted after the
-        // P-frame it references but displayed before it. Forcing PTS
-        // monotonic here rewrote B-frame PTS values, so the client
-        // ended up displaying frames in the wrong order — the visible
-        // ghost / back-and-forth effect the user saw when picking a
-        // slower preset.
-        //
-        // We still enforce strict DTS monotonicity (libavcodec already
-        // guarantees this, but defence in depth is cheap), and we no
-        // longer clamp DTS to PTS — DTS > PTS is the defining property
-        // of a B-frame.
+        // PTS is in DISPLAY order; we do NOT force it monotonic here
+        // (would mangle B-frame display order). DTS still must be
+        // strictly monotonic for the muxer to accept packets in MPEG-TS.
+        // When the monotonic bump pushes DTS past the packet's PTS we
+        // pull PTS up to match: MPEG-TS rejects "pts < dts in stream"
+        // with Invalid argument and we lose the packet entirely, which
+        // is worse than a one-tick PTS shift.
         if (dts != AV_NOPTS_VALUE_LOCAL)
         {
             if (m_lastVideoDTS >= 0 && dts <= m_lastVideoDTS)
@@ -791,6 +784,10 @@ void MediaMuxer::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
                 dts = m_lastVideoDTS + 1;
             }
             m_lastVideoDTS = dts;
+        }
+        if (pts != AV_NOPTS_VALUE_LOCAL && dts != AV_NOPTS_VALUE_LOCAL && pts < dts)
+        {
+            pts = dts;
         }
         if (pts != AV_NOPTS_VALUE_LOCAL)
         {
@@ -802,7 +799,6 @@ void MediaMuxer::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
                          ", last: " + std::to_string(m_lastVideoPTS) +
                          ", delta: " + std::to_string(pts - m_lastVideoPTS));
             }
-            // Tracked for telemetry only — no longer used to clamp.
             m_lastVideoPTS = pts;
         }
     }

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -685,11 +685,11 @@ bool MediaMuxer::muxPacket(const MediaEncoder::EncodedPacket &packet)
         }
     }
 
-    if (pkt->pts != AV_NOPTS_VALUE && pkt->dts > pkt->pts)
-    {
-        pkt->dts = pkt->pts;
-    }
-
+    // DTS > PTS is the defining property of a B-frame (decoded after
+    // the future P-frame it depends on, displayed earlier than it).
+    // We used to clamp DTS to PTS here, which broke B-frame ordering
+    // for any preset slower than ultrafast — fix removed alongside
+    // the matching clamp in ensureMonotonicPTS.
     ensureMonotonicPTS(pkt->pts, pkt->dts, packet.isVideo);
 
     {
@@ -770,50 +770,40 @@ void MediaMuxer::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
 
     if (isVideo)
     {
+        // PTS is in DISPLAY order, DTS is in DECODE order. With
+        // B-frames (any preset slower than ultrafast/superfast can
+        // emit them), PTS values legitimately go non-monotonically in
+        // the encode/decode order: a B-frame is emitted after the
+        // P-frame it references but displayed before it. Forcing PTS
+        // monotonic here rewrote B-frame PTS values, so the client
+        // ended up displaying frames in the wrong order — the visible
+        // ghost / back-and-forth effect the user saw when picking a
+        // slower preset.
+        //
+        // We still enforce strict DTS monotonicity (libavcodec already
+        // guarantees this, but defence in depth is cheap), and we no
+        // longer clamp DTS to PTS — DTS > PTS is the defining property
+        // of a B-frame.
+        if (dts != AV_NOPTS_VALUE_LOCAL)
+        {
+            if (m_lastVideoDTS >= 0 && dts <= m_lastVideoDTS)
+            {
+                dts = m_lastVideoDTS + 1;
+            }
+            m_lastVideoDTS = dts;
+        }
         if (pts != AV_NOPTS_VALUE_LOCAL)
         {
-            // CRITICAL: Only prevent retrocession (PTS going backwards)
-            // Don't force minimum increment - use PTS as calculated for correct speed
-            // This ensures video speed matches reality based on timestamps
-            if (m_lastVideoPTS >= 0 && pts <= m_lastVideoPTS)
-            {
-                // Log when we prevent retrocession
-                static int retroLogCounter = 0;
-                if (retroLogCounter++ < 5)
-                {
-                    LOG_WARN("MediaMuxer: Preventing PTS retrocession - last: " + std::to_string(m_lastVideoPTS) +
-                             ", calculated: " + std::to_string(pts) + ", adjusted to: " + std::to_string(m_lastVideoPTS + 1));
-                }
-                // PTS would go backwards - just increment by 1 to prevent retrocession
-                // But don't force a large increment that would slow down the video
-                pts = m_lastVideoPTS + 1;
-            }
-            // Otherwise, use PTS as-is for correct speed
-
-            // Log PTS progression occasionally
             static int muxLogCounter = 0;
             muxLogCounter++;
             if (muxLogCounter == 1 || muxLogCounter % 300 == 0)
             {
                 LOG_INFO("MediaMuxer: Video PTS - current: " + std::to_string(pts) +
                          ", last: " + std::to_string(m_lastVideoPTS) +
-                         ", increment: " + std::to_string(pts - m_lastVideoPTS));
+                         ", delta: " + std::to_string(pts - m_lastVideoPTS));
             }
-
+            // Tracked for telemetry only — no longer used to clamp.
             m_lastVideoPTS = pts;
-        }
-        if (dts != AV_NOPTS_VALUE_LOCAL)
-        {
-            if (m_lastVideoDTS >= 0 && dts < m_lastVideoDTS)
-            {
-                dts = m_lastVideoDTS + 1;
-            }
-            m_lastVideoDTS = dts;
-        }
-        if (pts != AV_NOPTS_VALUE_LOCAL && dts != AV_NOPTS_VALUE_LOCAL && dts > pts)
-        {
-            dts = pts;
-            m_lastVideoDTS = dts;
         }
     }
     else

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -468,12 +468,33 @@ bool MediaMuxer::initializeStreams(void *videoCodecContext, void *audioCodecCont
     }
     if (formatCtx->pb)
     {
-        LOG_INFO("MediaMuxer: After header - pb position: " + std::to_string(formatCtx->pb->pos) + 
+        LOG_INFO("MediaMuxer: After header - pb position: " + std::to_string(formatCtx->pb->pos) +
                  ", bytes written: " + std::to_string(formatCtx->pb->pos));
-        
+
         // Flush buffer AVIO após escrever header para garantir que dados sejam escritos
         avio_flush(formatCtx->pb);
         LOG_INFO("MediaMuxer: Flushed AVIO buffer after header write");
+    }
+
+    // Mark the captured bytes as the complete server-side header NOW,
+    // instead of waiting for m_headerCaptureSize (64 KB) to fill. For
+    // streaming endpoints that idle until a client connects (like /raw),
+    // no media packets flow before connect — so the capture would never
+    // hit 64 KB and m_headerWritten stayed false, meaning the connecting
+    // client received zero bootstrap bytes and saw the stream mid-flow.
+    // What avformat_write_header itself wrote (PAT/PMT for MPEG-TS, plus
+    // any codec-extradata embedded by the format) is enough for the
+    // client demuxer to identify the streams and pick up parsing at the
+    // next inline keyframe — the rest of the "header" was just early
+    // media data that warmed the wire, not protocol bootstrap.
+    {
+        std::lock_guard<std::mutex> lock(m_headerMutex);
+        if (!m_headerWritten && !m_formatHeader.empty())
+        {
+            m_headerWritten = true;
+            LOG_INFO("MediaMuxer: Header marked complete with " +
+                     std::to_string(m_formatHeader.size()) + " captured bytes");
+        }
     }
     LOG_INFO("MediaMuxer: Format header written successfully");
 

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -468,8 +468,8 @@ bool MediaMuxer::initializeStreams(void *videoCodecContext, void *audioCodecCont
     }
     if (formatCtx->pb)
     {
-        LOG_INFO("MediaMuxer: After header - pb position: " + std::to_string(formatCtx->pb->pos) +
-                 ", bytes written: " + std::to_string(formatCtx->pb->pos));
+        LOG_DEBUG("MediaMuxer: After header - pb position: " + std::to_string(formatCtx->pb->pos) +
+                  ", bytes written: " + std::to_string(formatCtx->pb->pos));
 
         // Flush buffer AVIO após escrever header para garantir que dados sejam escritos
         avio_flush(formatCtx->pb);
@@ -492,8 +492,8 @@ bool MediaMuxer::initializeStreams(void *videoCodecContext, void *audioCodecCont
         if (!m_headerWritten && !m_formatHeader.empty())
         {
             m_headerWritten = true;
-            LOG_INFO("MediaMuxer: Header marked complete with " +
-                     std::to_string(m_formatHeader.size()) + " captured bytes");
+            LOG_DEBUG("MediaMuxer: Header marked complete with " +
+                      std::to_string(m_formatHeader.size()) + " captured bytes");
         }
     }
     LOG_INFO("MediaMuxer: Format header written successfully");

--- a/src/encoding/MediaSynchronizer.cpp
+++ b/src/encoding/MediaSynchronizer.cpp
@@ -326,7 +326,12 @@ void MediaSynchronizer::markAudioProcessed(size_t startIdx, size_t endIdx)
             m_audioBuffer[i].processed = true;
         }
     }
-    while (!m_audioBuffer.empty() && m_audioBuffer.front().processed)
+    // Pop processed audio from the front but keep the last few entries
+    // even if processed — calculateSyncZone needs an audio timestamp
+    // anchor to align with video; emptying the audio buffer entirely
+    // makes every subsequent iteration return SyncZone::invalid and
+    // starves the video encoder.
+    while (m_audioBuffer.size() > kAudioAnchorChunks && m_audioBuffer.front().processed)
     {
         m_audioBuffer.pop_front();
     }
@@ -362,7 +367,10 @@ void MediaSynchronizer::markAudioChunkProcessedByTimestamp(int64_t timestampUs)
             break; // Only mark first match (should be unique)
         }
     }
-    while (!m_audioBuffer.empty() && m_audioBuffer.front().processed)
+    // Same anchor-preserving drain as markAudioProcessed — leave a few
+    // chunks at the back so calculateSyncZone can still match the audio
+    // timeline against incoming video.
+    while (m_audioBuffer.size() > kAudioAnchorChunks && m_audioBuffer.front().processed)
     {
         m_audioBuffer.pop_front();
     }

--- a/src/encoding/MediaSynchronizer.cpp
+++ b/src/encoding/MediaSynchronizer.cpp
@@ -305,6 +305,15 @@ void MediaSynchronizer::markVideoProcessed(size_t startIdx, size_t endIdx)
             m_videoBuffer[i].processed = true;
         }
     }
+    // Eager front-drain — keep the bounded buffer from filling up with
+    // already-encoded frames waiting for the 5 s "old data" cleanup to
+    // catch them. Without this drain, processed frames squat on the
+    // ring slots and addVideoFrame ends up overflowing on perfectly
+    // healthy pipelines because every slot reads "already processed".
+    while (!m_videoBuffer.empty() && m_videoBuffer.front().processed)
+    {
+        m_videoBuffer.pop_front();
+    }
 }
 
 void MediaSynchronizer::markAudioProcessed(size_t startIdx, size_t endIdx)
@@ -316,6 +325,10 @@ void MediaSynchronizer::markAudioProcessed(size_t startIdx, size_t endIdx)
         {
             m_audioBuffer[i].processed = true;
         }
+    }
+    while (!m_audioBuffer.empty() && m_audioBuffer.front().processed)
+    {
+        m_audioBuffer.pop_front();
     }
 }
 
@@ -331,6 +344,10 @@ void MediaSynchronizer::markVideoFrameProcessedByTimestamp(int64_t timestampUs)
             break; // Only mark first match (should be unique)
         }
     }
+    while (!m_videoBuffer.empty() && m_videoBuffer.front().processed)
+    {
+        m_videoBuffer.pop_front();
+    }
 }
 
 void MediaSynchronizer::markAudioChunkProcessedByTimestamp(int64_t timestampUs)
@@ -344,6 +361,10 @@ void MediaSynchronizer::markAudioChunkProcessedByTimestamp(int64_t timestampUs)
             chunk.processed = true;
             break; // Only mark first match (should be unique)
         }
+    }
+    while (!m_audioBuffer.empty() && m_audioBuffer.front().processed)
+    {
+        m_audioBuffer.pop_front();
     }
 }
 

--- a/src/encoding/MediaSynchronizer.cpp
+++ b/src/encoding/MediaSynchronizer.cpp
@@ -295,6 +295,25 @@ std::vector<MediaSynchronizer::TimestampedAudio> MediaSynchronizer::getAllUnproc
     return chunks;
 }
 
+std::vector<MediaSynchronizer::TimestampedFrame> MediaSynchronizer::getAllUnprocessedVideo()
+{
+    std::lock_guard<std::mutex> lock(m_videoBufferMutex);
+    std::vector<TimestampedFrame> frames;
+    frames.reserve(m_videoBuffer.size());
+    for (const auto &f : m_videoBuffer)
+    {
+        if (!f.processed)
+        {
+            frames.push_back(f);
+        }
+    }
+    std::sort(frames.begin(), frames.end(),
+              [](const TimestampedFrame &a, const TimestampedFrame &b) {
+                  return a.captureTimestampUs < b.captureTimestampUs;
+              });
+    return frames;
+}
+
 void MediaSynchronizer::markVideoProcessed(size_t startIdx, size_t endIdx)
 {
     std::lock_guard<std::mutex> lock(m_videoBufferMutex);

--- a/src/encoding/MediaSynchronizer.h
+++ b/src/encoding/MediaSynchronizer.h
@@ -93,6 +93,15 @@ public:
     // (que causa o áudio terminar antes do vídeo no arquivo).
     std::vector<TimestampedAudio> getAllUnprocessedAudio();
 
+    // Mesma ideia para vídeo — usado pelo /raw encoder thread, onde o
+    // muxer MPEG-TS reordena pacotes por DTS de qualquer jeito, e o
+    // gating por sync zone estava produzindo segundos inteiros sem
+    // saída de vídeo sempre que o áudio momentaneamente parava de
+    // chegar. (calculateSyncZone retorna inválido quando os timestamps
+    // de áudio e vídeo não se sobrepõem dentro da tolerância, o que
+    // acontece em jitter de captura sem culpa real.)
+    std::vector<TimestampedFrame> getAllUnprocessedVideo();
+
     // Marcar dados como processados
     void markVideoProcessed(size_t startIdx, size_t endIdx);
     void markAudioProcessed(size_t startIdx, size_t endIdx);

--- a/src/encoding/MediaSynchronizer.h
+++ b/src/encoding/MediaSynchronizer.h
@@ -130,6 +130,12 @@ private:
     size_t m_maxVideoBufferSize = 15;           // Máximo de frames no buffer (reduzido para evitar atraso)
     size_t m_maxAudioBufferSize = 30;           // Máximo de chunks no buffer (reduzido para evitar atraso)
 
+    // Minimum number of audio chunks kept in the buffer after the eager
+    // mark-processed drain — calculateSyncZone needs at least one audio
+    // timestamp to align with video, and emptying the buffer would
+    // starve every subsequent encode iteration.
+    static constexpr size_t kAudioAnchorChunks = 4;
+
     // Buffers temporais ordenados por timestamp
     mutable std::mutex m_videoBufferMutex;
     std::deque<TimestampedFrame> m_videoBuffer;

--- a/src/encoding/MediaSynchronizer.h
+++ b/src/encoding/MediaSynchronizer.h
@@ -87,19 +87,19 @@ public:
     // Obter chunks de áudio de uma zona de sincronização
     std::vector<TimestampedAudio> getAudioChunks(const SyncZone &zone);
 
-    // Obter todos os chunks de áudio ainda não processados, sem gating
-    // por sync zone. Áudio é barato pra encodar e não precisa esperar o
-    // vídeo — drenar continuamente evita o synchronizer dropar chunks
-    // (que causa o áudio terminar antes do vídeo no arquivo).
+    // Drain every audio chunk that hasn't been processed yet, with no
+    // sync-zone gating. Audio is cheap to encode and doesn't need to
+    // wait on video — continuous drain stops the synchronizer from
+    // dropping chunks (which caused audio to end before video in
+    // recorded files).
     std::vector<TimestampedAudio> getAllUnprocessedAudio();
 
-    // Mesma ideia para vídeo — usado pelo /raw encoder thread, onde o
-    // muxer MPEG-TS reordena pacotes por DTS de qualquer jeito, e o
-    // gating por sync zone estava produzindo segundos inteiros sem
-    // saída de vídeo sempre que o áudio momentaneamente parava de
-    // chegar. (calculateSyncZone retorna inválido quando os timestamps
-    // de áudio e vídeo não se sobrepõem dentro da tolerância, o que
-    // acontece em jitter de captura sem culpa real.)
+    // Same idea for video — used by the /raw encoder thread, where the
+    // MPEG-TS muxer reorders packets by DTS regardless, and sync-zone
+    // gating was producing whole seconds with no video output whenever
+    // audio briefly stopped arriving. (calculateSyncZone returns invalid
+    // when audio and video timestamps don't overlap within the
+    // tolerance, which happens under normal capture jitter.)
     std::vector<TimestampedFrame> getAllUnprocessedVideo();
 
     // Marcar dados como processados

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,12 +13,14 @@ void printUsage(const char *programName)
     std::cout << "  --preset <path>        Load preset with multiple passes (.glslp)\n";
     std::cout << "\nCapture Options:\n";
 #ifdef __linux__
-    std::cout << "  --source <type>        Source type: none, v4l2 (default: v4l2)\n";
+    std::cout << "  --source <type>        Source type: none, v4l2, remote (default: v4l2)\n";
 #elif defined(_WIN32)
-    std::cout << "  --source <type>        Source type: none, ds (default: ds)\n";
+    std::cout << "  --source <type>        Source type: none, ds, remote (default: ds)\n";
 #else
-    std::cout << "  --source <type>        Source type: none (default: none)\n";
+    std::cout << "  --source <type>        Source type: none, remote (default: none)\n";
 #endif
+    std::cout << "  --remote-url <url>     Base URL of a remote RetroCapture server when --source remote\n";
+    std::cout << "                         (e.g. http://host:8080). Client fetches /raw and /meta.\n";
     std::cout << "  --width <value>        Capture width (default: 1920)\n";
     std::cout << "  --height <value>       Capture height (default: 1080)\n";
     std::cout << "  --fps <value>          Capture framerate (default: 60)\n";
@@ -96,6 +98,7 @@ int main(int argc, char *argv[])
 
     std::string shaderPath;
     std::string presetPath;
+    std::string remoteUrl; // Phase 3 of #47: base URL when --source remote
     // Detectar plataforma e definir sourceType padrão
     std::string sourceType;
 #ifdef __linux__
@@ -195,22 +198,28 @@ int main(int argc, char *argv[])
             // Converter para minúsculas para comparação case-insensitive
             std::transform(sourceType.begin(), sourceType.end(), sourceType.begin(), ::tolower);
 #ifdef __linux__
-            if (sourceType != "none" && sourceType != "v4l2")
+            if (sourceType != "none" && sourceType != "v4l2" && sourceType != "remote")
 #elif defined(_WIN32)
-            if (sourceType != "none" && sourceType != "ds")
+            if (sourceType != "none" && sourceType != "ds" && sourceType != "remote")
 #else
-            if (sourceType != "none")
+            if (sourceType != "none" && sourceType != "remote")
 #endif
             {
 #ifdef __linux__
-                LOG_ERROR("Invalid source type. Use 'none' or 'v4l2'");
+                LOG_ERROR("Invalid source type. Use 'none', 'v4l2' or 'remote'");
 #elif defined(_WIN32)
-                LOG_ERROR("Invalid source type. Use 'none' or 'ds'");
+                LOG_ERROR("Invalid source type. Use 'none', 'ds' or 'remote'");
 #else
-                LOG_ERROR("Invalid source type. Use 'none'");
+                LOG_ERROR("Invalid source type. Use 'none' or 'remote'");
 #endif
                 return 1;
             }
+        }
+        else if (arg == "--remote-url" && i + 1 < argc)
+        {
+            // Phase 3 of #47: base URL of the remote RetroCapture server.
+            // Client appends /raw (and /meta in Phase 4) by convention.
+            remoteUrl = argv[++i];
         }
         else if (arg == "--v4l2-device" && i + 1 < argc)
         {
@@ -634,6 +643,20 @@ int main(int argc, char *argv[])
 #elif defined(_WIN32)
     bool isDSSource = (sourceType == "ds");
 #endif
+    bool isRemoteSource = (sourceType == "remote");
+
+    // Phase 3 of #47: remote source needs a base URL up front.
+    if (isRemoteSource && remoteUrl.empty())
+    {
+        LOG_ERROR("--source remote requires --remote-url <base-url> (e.g. http://host:8080)");
+        return 1;
+    }
+    // Hand the URL to Application via the same devicePath field — semantically
+    // it's the "where to read frames from" string for any source kind.
+    if (isRemoteSource)
+    {
+        devicePath = remoteUrl;
+    }
 
     LOG_INFO("Initializing application...");
     LOG_INFO("Source type: " + sourceType);
@@ -648,6 +671,10 @@ int main(int argc, char *argv[])
         LOG_INFO("DirectShow device: " + devicePath);
     }
 #endif
+    if (isRemoteSource)
+    {
+        LOG_INFO("Remote URL: " + remoteUrl);
+    }
     LOG_INFO("Capture resolution: " + std::to_string(captureWidth) + "x" + std::to_string(captureHeight));
     LOG_INFO("Framerate: " + std::to_string(captureFps) + " fps");
     LOG_INFO("Window size: " + std::to_string(windowWidth) + "x" + std::to_string(windowHeight));
@@ -781,6 +808,13 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    // Phase 3 of #47: remote source carries the base URL in devicePath; the
+    // platform-conditional V4L2/DS branches above already skipped it.
+    if (isRemoteSource)
+    {
+        app.setDevicePath(devicePath);
+    }
+
     // Configure streaming
     app.setStreamingEnabled(streamingEnabled);
     app.setStreamingPort(streamingPort);
@@ -823,6 +857,8 @@ int main(int argc, char *argv[])
     if (sourceType == "ds")
         sourceTypeEnum = UIManager::SourceType::DS;
 #endif
+    if (sourceType == "remote")
+        sourceTypeEnum = UIManager::SourceType::Remote;
     app.getUIManager()->setSourceType(sourceTypeEnum);
     LOG_INFO("Source type: " + sourceType);
     

--- a/src/output/WindowManager.cpp
+++ b/src/output/WindowManager.cpp
@@ -347,6 +347,14 @@ void WindowManager::makeCurrent()
     }
 }
 
+void WindowManager::setVsync(bool enabled)
+{
+    if (m_window)
+    {
+        glfwSwapInterval(enabled ? 1 : 0);
+    }
+}
+
 void WindowManager::setResizeCallback(std::function<void(int, int)> callback)
 {
     m_resizeCallback = callback;

--- a/src/output/WindowManager.cpp
+++ b/src/output/WindowManager.cpp
@@ -355,6 +355,12 @@ void WindowManager::setVsync(bool enabled)
     }
 }
 
+bool WindowManager::isFocused() const
+{
+    if (!m_window) return false;
+    return glfwGetWindowAttrib(static_cast<GLFWwindow *>(m_window), GLFW_FOCUSED) != 0;
+}
+
 void WindowManager::setResizeCallback(std::function<void(int, int)> callback)
 {
     m_resizeCallback = callback;

--- a/src/output/WindowManager.h
+++ b/src/output/WindowManager.h
@@ -32,6 +32,14 @@ public:
     // wants vsync OFF so a backgrounded window doesn't stall the
     // capture/encoder threads waiting on a refresh that never comes.
     void setVsync(bool enabled);
+
+    // Whether the OS reports the window as focused (i.e. receiving
+    // input). The main loop uses this to disable vsync when the user
+    // alt-tabs away — most compositors park vsync at 0 Hz for
+    // backgrounded windows, which would otherwise block swapBuffers
+    // forever and stall the entire main loop (queue fills, drops
+    // pile up, no recovery until focus returns).
+    bool isFocused() const;
     
     void makeCurrent();
     

--- a/src/output/WindowManager.h
+++ b/src/output/WindowManager.h
@@ -20,10 +20,18 @@ public:
     
     bool init(const WindowConfig& config);
     void shutdown();
-    
+
     bool shouldClose() const;
     void swapBuffers();
     void pollEvents();
+
+    // Runtime vsync toggle. Mirrors what config.vsync did at init but
+    // lets the rest of the app switch the swap interval mid-session —
+    // remote-source playback wants vsync ON so frames land on display
+    // refresh boundaries (no judder), while local capture/streaming
+    // wants vsync OFF so a backgrounded window doesn't stall the
+    // capture/encoder threads waiting on a refresh that never comes.
+    void setVsync(bool enabled);
     
     void makeCurrent();
     

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -1032,14 +1032,6 @@ bool APIController::handleGETMeta(int clientFd)
     std::string presetPath = shaderEngine ? shaderEngine->getPresetPath() : "";
     std::string presetHash = presetPath.empty() ? "" : computePresetHash(presetPath);
 
-    std::string sourceType;
-    switch (m_uiManager->getSourceType())
-    {
-    case UIManager::SourceType::None: sourceType = "none";       break;
-    case UIManager::SourceType::V4L2: sourceType = "v4l2";       break;
-    case UIManager::SourceType::DS:   sourceType = "directshow"; break;
-    }
-
     std::ostringstream json;
     json << "{"
          << "\"protocolVersion\": 1, "
@@ -1072,8 +1064,6 @@ bool APIController::handleGETMeta(int clientFd)
     json <<   "]"
          << "}, "
          << "\"source\": {"
-         <<   "\"type\": "   << jsonString(sourceType)                       << ", "
-         <<   "\"device\": " << jsonString(m_uiManager->getCurrentDevice())  << ", "
          <<   "\"width\": "  << jsonNumber(m_uiManager->getCaptureWidth())   << ", "
          <<   "\"height\": " << jsonNumber(m_uiManager->getCaptureHeight())  << ", "
          <<   "\"fps\": "    << jsonNumber(m_uiManager->getCaptureFps())     << ", "
@@ -1081,32 +1071,7 @@ bool APIController::handleGETMeta(int clientFd)
          <<     "\"x\": "      << jsonNumber(m_uiManager->getSourceOverscanPercentX()) << ", "
          <<     "\"y\": "      << jsonNumber(m_uiManager->getSourceOverscanPercentY()) << ", "
          <<     "\"locked\": " << jsonBool(m_uiManager->getSourceOverscanLocked())
-         <<   "}, "
-         <<   "\"controls\": [";
-
-    // Hardware controls are source-type-aware: V4L2 has a unified getter today;
-    // DirectShow controls aren't exposed through a single read-only collection
-    // yet, so on Windows the controls array is empty (tracked alongside #47
-    // Phase 2). For "none" we also emit an empty array.
-    if (m_uiManager->getSourceType() == UIManager::SourceType::V4L2)
-    {
-        const auto &controls = m_uiManager->getV4L2Controls();
-        for (size_t i = 0; i < controls.size(); ++i)
-        {
-            if (i > 0) json << ", ";
-            const auto &c = controls[i];
-            json << "{"
-                 << "\"name\": "      << jsonString(c.name) << ", "
-                 << "\"value\": "     << jsonNumber(c.value) << ", "
-                 << "\"min\": "       << jsonNumber(c.min) << ", "
-                 << "\"max\": "       << jsonNumber(c.max) << ", "
-                 << "\"step\": "      << jsonNumber(c.step) << ", "
-                 << "\"available\": " << jsonBool(c.available)
-                 << "}";
-        }
-    }
-
-    json <<   "]"
+         <<   "}"
          << "}, "
          << "\"image\": {"
          <<   "\"brightness\": "     << jsonNumber(m_uiManager->getBrightness())     << ", "

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -13,6 +13,7 @@
 #endif
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <iomanip>
 #include <algorithm>
 #include <cstring>
 #include <vector>
@@ -20,6 +21,12 @@
 #include <cstdint>
 #include <climits>
 #include "../utils/FilesystemCompat.h"
+
+// Falls back when the CMake compile flag isn't set (e.g. when a tool
+// processes this file without going through the project's build system).
+#ifndef RETROCAPTURE_VERSION
+#define RETROCAPTURE_VERSION "0.0.0-dev"
+#endif
 
 // Simple JSON helper functions
 namespace
@@ -96,6 +103,23 @@ namespace
     {
         return value ? "true" : "false";
     }
+
+    // FNV-1a 64-bit content hash. Not cryptographic — sufficient for the
+    // remote-client cache-invalidation use case in /meta.
+    std::string fnv1a64Hex(const std::string &content)
+    {
+        const uint64_t FNV_OFFSET = 0xcbf29ce484222325ULL;
+        const uint64_t FNV_PRIME  = 0x100000001b3ULL;
+        uint64_t h = FNV_OFFSET;
+        for (unsigned char c : content)
+        {
+            h ^= c;
+            h *= FNV_PRIME;
+        }
+        std::ostringstream oss;
+        oss << "fnv1a64:" << std::hex << std::setw(16) << std::setfill('0') << h;
+        return oss.str();
+    }
 }
 
 APIController::APIController()
@@ -104,7 +128,10 @@ APIController::APIController()
 
 bool APIController::isAPIRequest(const std::string &request) const
 {
-    return request.find("/api/") != std::string::npos;
+    // Routes handled by this controller: /api/v1/* (the REST surface) and
+    // the top-level /meta endpoint used by the remote-stream client protocol.
+    return request.find("/api/") != std::string::npos ||
+           request.find(" /meta") != std::string::npos;
 }
 
 bool APIController::handleRequest(int clientFd, const std::string &request)
@@ -209,6 +236,11 @@ std::string APIController::extractMethod(const std::string &request) const
 std::string APIController::extractPath(const std::string &request) const
 {
     size_t start = request.find(" /api/");
+    if (start == std::string::npos)
+    {
+        // Fall back to top-level routes owned by this controller.
+        start = request.find(" /meta");
+    }
     if (start == std::string::npos)
         return "";
 
@@ -338,7 +370,11 @@ ssize_t APIController::sendData(int clientFd, const void *data, size_t size) con
 
 bool APIController::handleGET(int clientFd, const std::string &path, const std::string &request)
 {
-    if (path == "/api/v1/source")
+    if (path == "/meta")
+    {
+        return handleGETMeta(clientFd);
+    }
+    else if (path == "/api/v1/source")
     {
         return handleGETSource(clientFd);
     }
@@ -976,6 +1012,91 @@ bool APIController::handleGETStatus(int clientFd)
          << "}";
     sendJSONResponse(clientFd, 200, json.str());
     return true;
+}
+
+// GET /meta — full snapshot of the active shader pipeline + source state, used
+// by a remote RetroCapture client to mirror the server's configuration when
+// consuming /raw. Schema is versioned via "protocolVersion"; see
+// docs/REMOTE_STREAM_PROTOCOL.md.
+bool APIController::handleGETMeta(int clientFd)
+{
+    if (!m_application || !m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "Application or UIManager not available");
+        return true;
+    }
+
+    ShaderEngine *shaderEngine = m_application->getShaderEngine();
+    bool shaderActive = shaderEngine && shaderEngine->isShaderActive();
+    std::string presetName = m_uiManager->getCurrentShader();
+    std::string presetPath = shaderEngine ? shaderEngine->getPresetPath() : "";
+    std::string presetHash = presetPath.empty() ? "" : computePresetHash(presetPath);
+
+    std::string sourceType;
+    switch (m_uiManager->getSourceType())
+    {
+    case UIManager::SourceType::None: sourceType = "none";       break;
+    case UIManager::SourceType::V4L2: sourceType = "v4l2";       break;
+    case UIManager::SourceType::DS:   sourceType = "directshow"; break;
+    }
+
+    std::ostringstream json;
+    json << "{"
+         << "\"protocolVersion\": 1, "
+         << "\"serverVersion\": " << jsonString(RETROCAPTURE_VERSION) << ", "
+         << "\"shader\": {"
+         <<   "\"active\": "          << jsonBool(shaderActive)                          << ", "
+         <<   "\"pipelineEnabled\": " << jsonBool(m_uiManager->getShaderPipelineEnabled()) << ", "
+         <<   "\"preset\": "          << jsonString(presetName)                          << ", "
+         <<   "\"presetHash\": "      << jsonString(presetHash)                          << ", "
+         <<   "\"parameters\": [";
+
+    if (shaderActive)
+    {
+        auto params = shaderEngine->getShaderParameters();
+        for (size_t i = 0; i < params.size(); ++i)
+        {
+            if (i > 0) json << ", ";
+            const auto &p = params[i];
+            json << "{"
+                 << "\"name\": "         << jsonString(p.name)         << ", "
+                 << "\"value\": "        << jsonNumber(p.value)        << ", "
+                 << "\"defaultValue\": " << jsonNumber(p.defaultValue) << ", "
+                 << "\"min\": "          << jsonNumber(p.min)          << ", "
+                 << "\"max\": "          << jsonNumber(p.max)          << ", "
+                 << "\"step\": "         << jsonNumber(p.step)
+                 << "}";
+        }
+    }
+
+    json <<   "]"
+         << "}, "
+         << "\"source\": {"
+         <<   "\"type\": "   << jsonString(sourceType)                       << ", "
+         <<   "\"width\": "  << jsonNumber(m_uiManager->getCaptureWidth())   << ", "
+         <<   "\"height\": " << jsonNumber(m_uiManager->getCaptureHeight())  << ", "
+         <<   "\"fps\": "    << jsonNumber(m_uiManager->getCaptureFps())
+         << "}, "
+         << "\"streaming\": {"
+         <<   "\"active\": " << jsonBool(m_uiManager->getStreamingActive()) << ", "
+         <<   "\"url\": "    << jsonString(m_uiManager->getStreamUrl())
+         << "}"
+         << "}";
+
+    sendJSONResponse(clientFd, 200, json.str());
+    return true;
+}
+
+std::string APIController::computePresetHash(const std::string &presetPath) const
+{
+    std::ifstream file(presetPath, std::ios::binary);
+    if (!file.is_open())
+    {
+        return "";
+    }
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return fnv1a64Hex(buffer.str());
 }
 
 bool APIController::handleGETPlatform(int clientFd)

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -15,7 +15,9 @@
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+#include <chrono>
 #include <cstring>
+#include <thread>
 #include <vector>
 #include <fstream>
 #include <cstdint>
@@ -372,7 +374,7 @@ bool APIController::handleGET(int clientFd, const std::string &path, const std::
 {
     if (path == "/meta")
     {
-        return handleGETMeta(clientFd);
+        return handleGETMeta(clientFd, request);
     }
     else if (path == "/api/v1/source")
     {
@@ -1014,16 +1016,14 @@ bool APIController::handleGETStatus(int clientFd)
     return true;
 }
 
-// GET /meta — full snapshot of the active shader pipeline + source state, used
-// by a remote RetroCapture client to mirror the server's configuration when
-// consuming /raw. Schema is versioned via "protocolVersion"; see
-// docs/REMOTE_STREAM_PROTOCOL.md.
-bool APIController::handleGETMeta(int clientFd)
+// Builds the /meta JSON snapshot from current application state. Pure
+// helper — no I/O, no side effects — so the SSE push loop in
+// handleGETMetaSSE can call it cheaply on every tick.
+std::string APIController::buildMetaSnapshotJSON()
 {
     if (!m_application || !m_uiManager)
     {
-        sendErrorResponse(clientFd, 500, "Application or UIManager not available");
-        return true;
+        return "{}";
     }
 
     ShaderEngine *shaderEngine = m_application->getShaderEngine();
@@ -1086,7 +1086,124 @@ bool APIController::handleGETMeta(int clientFd)
          << "}"
          << "}";
 
-    sendJSONResponse(clientFd, 200, json.str());
+    return json.str();
+}
+
+// GET /meta — full snapshot of the active shader pipeline + source state, used
+// by a remote RetroCapture client to mirror the server's configuration when
+// consuming /raw. Schema is versioned via "protocolVersion"; see
+// docs/REMOTE_STREAM_PROTOCOL.md.
+//
+// Two transports on the same path (Phase 6 of #47):
+//   - regular HTTP GET → returns a one-shot JSON snapshot (Phase 1)
+//   - Accept: text/event-stream → upgrades to Server-Sent Events and
+//     pushes deltas until the client disconnects
+bool APIController::handleGETMeta(int clientFd, const std::string &request)
+{
+    if (!m_application || !m_uiManager)
+    {
+        sendErrorResponse(clientFd, 500, "Application or UIManager not available");
+        return true;
+    }
+
+    // Sniff for an SSE-flavoured request. Case-insensitive on the header
+    // name but not the value — text/event-stream is the canonical token.
+    auto headerHasSSE = [](const std::string &req) -> bool
+    {
+        size_t pos = 0;
+        while (pos < req.size())
+        {
+            size_t eol = req.find("\r\n", pos);
+            if (eol == std::string::npos) break;
+            std::string line = req.substr(pos, eol - pos);
+            if (line.size() >= 7)
+            {
+                std::string head = line.substr(0, 7);
+                for (auto &c : head) c = static_cast<char>(::tolower(c));
+                if (head == "accept:")
+                {
+                    if (line.find("text/event-stream") != std::string::npos)
+                    {
+                        return true;
+                    }
+                }
+            }
+            pos = eol + 2;
+            if (line.empty()) break; // end of headers
+        }
+        return false;
+    };
+
+    if (headerHasSSE(request))
+    {
+        return handleGETMetaSSE(clientFd);
+    }
+
+    sendJSONResponse(clientFd, 200, buildMetaSnapshotJSON());
+    return true;
+}
+
+bool APIController::handleGETMetaSSE(int clientFd)
+{
+    // Send SSE response headers. X-Accel-Buffering: no asks reverse
+    // proxies (notably nginx) not to buffer the stream — without it the
+    // client wouldn't see deltas until a buffer flushed.
+    const std::string headers =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/event-stream\r\n"
+        "Cache-Control: no-cache\r\n"
+        "Connection: keep-alive\r\n"
+        "X-Accel-Buffering: no\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "\r\n";
+
+    if (sendData(clientFd, headers.data(), headers.size()) < 0)
+    {
+        return true;
+    }
+
+    auto sendEvent = [&](const std::string &json) -> bool
+    {
+        std::string msg;
+        msg.reserve(json.size() + 16);
+        msg += "data: ";
+        msg += json;
+        msg += "\n\n";
+        return sendData(clientFd, msg.data(), msg.size()) >= 0;
+    };
+
+    std::string lastSnapshot = buildMetaSnapshotJSON();
+    if (!sendEvent(lastSnapshot))
+    {
+        return true;
+    }
+
+    auto lastKeepalive = std::chrono::steady_clock::now();
+
+    while (true)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+        std::string snap = buildMetaSnapshotJSON();
+        if (snap != lastSnapshot)
+        {
+            if (!sendEvent(snap)) break;
+            lastSnapshot = std::move(snap);
+            lastKeepalive = std::chrono::steady_clock::now();
+            continue;
+        }
+
+        // Send a comment-line keepalive every 30 s so idle TCP doesn't
+        // get reaped by NAT / proxies.
+        auto now = std::chrono::steady_clock::now();
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - lastKeepalive).count() >= 30)
+        {
+            static const char *kKeepalive = ": keepalive\n\n";
+            if (sendData(clientFd, kKeepalive, std::strlen(kKeepalive)) < 0) break;
+            lastKeepalive = now;
+        }
+    }
+
     return true;
 }
 

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -1073,9 +1073,47 @@ bool APIController::handleGETMeta(int clientFd)
          << "}, "
          << "\"source\": {"
          <<   "\"type\": "   << jsonString(sourceType)                       << ", "
+         <<   "\"device\": " << jsonString(m_uiManager->getCurrentDevice())  << ", "
          <<   "\"width\": "  << jsonNumber(m_uiManager->getCaptureWidth())   << ", "
          <<   "\"height\": " << jsonNumber(m_uiManager->getCaptureHeight())  << ", "
-         <<   "\"fps\": "    << jsonNumber(m_uiManager->getCaptureFps())
+         <<   "\"fps\": "    << jsonNumber(m_uiManager->getCaptureFps())     << ", "
+         <<   "\"overscan\": {"
+         <<     "\"x\": "      << jsonNumber(m_uiManager->getSourceOverscanPercentX()) << ", "
+         <<     "\"y\": "      << jsonNumber(m_uiManager->getSourceOverscanPercentY()) << ", "
+         <<     "\"locked\": " << jsonBool(m_uiManager->getSourceOverscanLocked())
+         <<   "}, "
+         <<   "\"controls\": [";
+
+    // Hardware controls are source-type-aware: V4L2 has a unified getter today;
+    // DirectShow controls aren't exposed through a single read-only collection
+    // yet, so on Windows the controls array is empty (tracked alongside #47
+    // Phase 2). For "none" we also emit an empty array.
+    if (m_uiManager->getSourceType() == UIManager::SourceType::V4L2)
+    {
+        const auto &controls = m_uiManager->getV4L2Controls();
+        for (size_t i = 0; i < controls.size(); ++i)
+        {
+            if (i > 0) json << ", ";
+            const auto &c = controls[i];
+            json << "{"
+                 << "\"name\": "      << jsonString(c.name) << ", "
+                 << "\"value\": "     << jsonNumber(c.value) << ", "
+                 << "\"min\": "       << jsonNumber(c.min) << ", "
+                 << "\"max\": "       << jsonNumber(c.max) << ", "
+                 << "\"step\": "      << jsonNumber(c.step) << ", "
+                 << "\"available\": " << jsonBool(c.available)
+                 << "}";
+        }
+    }
+
+    json <<   "]"
+         << "}, "
+         << "\"image\": {"
+         <<   "\"brightness\": "     << jsonNumber(m_uiManager->getBrightness())     << ", "
+         <<   "\"contrast\": "       << jsonNumber(m_uiManager->getContrast())       << ", "
+         <<   "\"maintainAspect\": " << jsonBool(m_uiManager->getMaintainAspect())   << ", "
+         <<   "\"outputWidth\": "    << jsonNumber(m_uiManager->getOutputWidth())    << ", "
+         <<   "\"outputHeight\": "   << jsonNumber(m_uiManager->getOutputHeight())
          << "}, "
          << "\"streaming\": {"
          <<   "\"active\": " << jsonBool(m_uiManager->getStreamingActive()) << ", "

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -121,7 +121,20 @@ private:
     bool handleGETV4L2Devices(int clientFd);
     bool handleGETV4L2Controls(int clientFd);
     bool handleGETStatus(int clientFd);
-    bool handleGETMeta(int clientFd);
+    bool handleGETMeta(int clientFd, const std::string &request);
+    /**
+     * Long-lived Server-Sent Events loop on /meta — pushes snapshot deltas
+     * to the connected client every ~250 ms whenever the JSON changes,
+     * plus a comment keepalive every 30 s. Returns when the client
+     * disconnects or sending fails. Phase 6 of #47.
+     */
+    bool handleGETMetaSSE(int clientFd);
+    /**
+     * Builds the /meta JSON snapshot. Pure function over current
+     * Application / UIManager / ShaderEngine state — safe to call from
+     * the SSE loop on every tick.
+     */
+    std::string buildMetaSnapshotJSON();
     bool handleRefreshV4L2Devices(int clientFd);
     bool handleGETPlatform(int clientFd);
     bool handleGETDSDevices(int clientFd);

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -96,6 +96,14 @@ private:
      */
     ssize_t sendData(int clientFd, const void *data, size_t size) const;
 
+    /**
+     * Compute a content hash of a preset file for the /meta endpoint.
+     * Returns an opaque string (e.g. "fnv1a64:abcd...") used by the remote
+     * client to decide whether its locally-cached preset is still valid.
+     * Returns empty string if the file cannot be read.
+     */
+    std::string computePresetHash(const std::string &presetPath) const;
+
     // Endpoints GET (leitura)
     bool handleGET(int clientFd, const std::string &path, const std::string &request);
     bool handleGETSource(int clientFd);
@@ -113,6 +121,7 @@ private:
     bool handleGETV4L2Devices(int clientFd);
     bool handleGETV4L2Controls(int clientFd);
     bool handleGETStatus(int clientFd);
+    bool handleGETMeta(int clientFd);
     bool handleRefreshV4L2Devices(int clientFd);
     bool handleGETPlatform(int clientFd);
     bool handleGETDSDevices(int clientFd);

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -937,6 +937,26 @@ void HTTPTSStreamer::handleClient(int clientFd)
     // different state mirrors (format header, client list, mutex).
     if (isRawRequest)
     {
+        // /raw is only meaningful while streaming is actually running —
+        // the raw encoder pipeline is brought up by initializeRawPipeline
+        // as part of start() and torn down by stop(). Without it, the
+        // HTTP socket accepts the connection and ffmpeg/avformat_open_input
+        // sees a valid TS-ish header (whatever the muxer flushed before
+        // shutdown) but no further packets ever arrive — the user-visible
+        // symptom is "client says connected but stream stays black".
+        // Bail with 503 so the client treats it as a failed connect.
+        if (!m_rawMediaEncoder.isInitialized())
+        {
+            const char *response = "HTTP/1.1 503 Service Unavailable\r\n"
+                                   "Content-Type: text/plain\r\n"
+                                   "Connection: close\r\n"
+                                   "\r\n"
+                                   "Streaming is not running on this server. "
+                                   "Start streaming on the host before connecting.";
+            m_httpServer.sendData(clientFd, response, strlen(response));
+            m_httpServer.closeClient(clientFd);
+            return;
+        }
         {
             std::lock_guard<std::mutex> headerLock(m_rawHeaderMutex);
             if (m_rawHeaderWritten && !m_rawFormatHeader.empty())

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1236,10 +1236,18 @@ bool HTTPTSStreamer::initializeEncoding()
 
 bool HTTPTSStreamer::initializeRawPipeline()
 {
-    // Configurar segundo MediaSynchronizer com os mesmos valores do /stream.
+    // The /raw synchronizer gets noticeably bigger buffers than /stream
+    // (~1 s of video and ~1 s of audio). The /raw consumer is the
+    // dedicated raw-encoder thread; bursts in the push side or brief
+    // hiccups in the encoder shouldn't show up as drops on a fed-by-
+    // identical-source pipeline whose only consumer is supposed to keep
+    // up. The bigger buffer absorbs those bursts without imposing
+    // meaningful latency — the encoder still pulls in near-real-time.
+    const size_t rawMaxVideo = std::max<size_t>(m_maxVideoBufferSize, 60);
+    const size_t rawMaxAudio = std::max<size_t>(m_maxAudioBufferSize, 120);
     m_rawStreamSynchronizer.setMaxBufferTime(m_maxBufferTimeSeconds * 1000000LL);
-    m_rawStreamSynchronizer.setMaxVideoBufferSize(m_maxVideoBufferSize);
-    m_rawStreamSynchronizer.setMaxAudioBufferSize(m_maxAudioBufferSize);
+    m_rawStreamSynchronizer.setMaxVideoBufferSize(rawMaxVideo);
+    m_rawStreamSynchronizer.setMaxAudioBufferSize(rawMaxAudio);
     m_rawStreamSynchronizer.setSyncTolerance(50 * 1000LL);
 
     // Strategy B (#47): /raw shares codec config (bitrate, codec, preset)
@@ -3061,11 +3069,23 @@ void HTTPTSStreamer::rawEncodingThread()
     int cleanupCounter = 0;
     const int CLEANUP_INTERVAL = 10;
 
+    // Rolling 1 s telemetry — surfaces whether the raw encoder is keeping
+    // up with the push rate, and how often calculateSyncZone refuses to
+    // hand frames over (which would starve the encoder even when CPU is
+    // idle).
+    auto statStart = std::chrono::steady_clock::now();
+    uint32_t statVideoEncoded   = 0;
+    uint32_t statAudioEncoded   = 0;
+    uint32_t statIterations     = 0;
+    uint32_t statSyncInvalid    = 0;
+    size_t   statMaxQueueDepth  = 0;
+
     while (m_running)
     {
         if (m_stopRequest) break;
 
         bool processedAny = false;
+        ++statIterations;
 
         cleanupCounter++;
         if (cleanupCounter >= CLEANUP_INTERVAL)
@@ -3091,6 +3111,7 @@ void HTTPTSStreamer::rawEncodingThread()
                         m_rawMediaMuxer.muxPacket(p);
                     }
                     processedAny = true;
+                    ++statAudioEncoded;
                 }
                 m_rawStreamSynchronizer.markAudioChunkProcessedByTimestamp(chunk.captureTimestampUs);
             }
@@ -3098,6 +3119,7 @@ void HTTPTSStreamer::rawEncodingThread()
 
         size_t videoBufferSize = m_rawStreamSynchronizer.getVideoBufferSize();
         size_t audioBufferSize = m_rawStreamSynchronizer.getAudioBufferSize();
+        if (videoBufferSize > statMaxQueueDepth) statMaxQueueDepth = videoBufferSize;
         bool hasBacklog = (videoBufferSize > 5 || audioBufferSize > 10);
 
         MediaSynchronizer::SyncZone syncZone = m_rawStreamSynchronizer.calculateSyncZone();
@@ -3126,6 +3148,7 @@ void HTTPTSStreamer::rawEncodingThread()
                         }
                         processedAny = true;
                         framesProcessed++;
+                        ++statVideoEncoded;
                     }
                 }
             }
@@ -3140,6 +3163,24 @@ void HTTPTSStreamer::rawEncodingThread()
                     m_rawHeaderWritten = true;
                 }
             }
+        }
+        else
+        {
+            ++statSyncInvalid;
+        }
+
+        // Emit telemetry once per second.
+        auto nowTs = std::chrono::steady_clock::now();
+        if (std::chrono::duration_cast<std::chrono::seconds>(nowTs - statStart).count() >= 1)
+        {
+            LOG_INFO("/raw encoder: video=" + std::to_string(statVideoEncoded) +
+                     "/s audio=" + std::to_string(statAudioEncoded) +
+                     "/s iters=" + std::to_string(statIterations) +
+                     " syncInvalid=" + std::to_string(statSyncInvalid) +
+                     " maxVidQueue=" + std::to_string(statMaxQueueDepth));
+            statVideoEncoded = statAudioEncoded = statIterations = statSyncInvalid = 0;
+            statMaxQueueDepth = 0;
+            statStart = nowTs;
         }
 
         if (processedAny)

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -615,10 +615,13 @@ void HTTPTSStreamer::stop()
         m_rawClientCount = 0;
     }
 
-    // Aguardar um tempo para threads processarem m_stopRequest e terminarem
-    // Como threads são detached, precisamos aguardar um tempo razoável
-    // Reduzido para evitar bloqueio prolongado - threads devem terminar rapidamente
-    std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+    // Aguardar um tempo para threads detached processarem m_stopRequest e
+    // terminarem. Os loops checam m_running/m_stopRequest a cada iteração,
+    // que para os encoder threads é <30ms e para os client handlers é a
+    // próxima recv (~10ms). 10s era exagero — congelava a UI quando o
+    // restart era disparado por um callback de setting na thread principal.
+    // 1.5s dá margem confortável sem trancar a interface.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
     // Registrar timestamp de quando parou para cooldown
     {
@@ -962,7 +965,16 @@ void HTTPTSStreamer::handleClient(int clientFd)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
 
-        m_httpServer.closeClient(clientFd);
+        // Atomically remove from the broadcast list AND close the fd,
+        // both under the list lock. Without this writeToRawClients
+        // (which also detects send failures and closes the fd) and the
+        // handler thread could double-close the same fd value — and
+        // because Linux reuses fd numbers immediately, the second close
+        // sometimes shut down a freshly-accepted unrelated connection,
+        // breaking every subsequent client until streaming was
+        // restarted. Whichever path finds the fd still in the list
+        // wins the close; the loser sees an empty find result and exits
+        // without touching the fd.
         {
             std::lock_guard<std::mutex> lock(m_rawOutputMutex);
             auto it = std::find(m_rawClientSockets.begin(), m_rawClientSockets.end(), clientFd);
@@ -970,6 +982,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
             {
                 m_rawClientSockets.erase(it);
                 m_rawClientCount = m_rawClientSockets.size();
+                m_httpServer.closeClient(clientFd);
             }
         }
         return;
@@ -1015,8 +1028,9 @@ void HTTPTSStreamer::handleClient(int clientFd)
         std::this_thread::sleep_for(std::chrono::milliseconds(10)); // evitar busy-waiting
     }
 
-    // Cliente desconectou - remover da lista
-    m_httpServer.closeClient(clientFd);
+    // Atomically remove from the broadcast list AND close the fd, same
+    // pattern as the /raw branch above — avoids the double-close race
+    // with writeToClients on disconnect.
     {
         std::lock_guard<std::mutex> lock(m_outputMutex);
         auto it = std::find(m_clientSockets.begin(), m_clientSockets.end(), clientFd);
@@ -1024,6 +1038,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
         {
             m_clientSockets.erase(it);
             m_clientCount = m_clientSockets.size();
+            m_httpServer.closeClient(clientFd);
         }
     }
 }

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -3100,7 +3100,6 @@ void HTTPTSStreamer::rawEncodingThread()
     uint32_t statVideoEncoded   = 0;
     uint32_t statAudioEncoded   = 0;
     uint32_t statIterations     = 0;
-    uint32_t statSyncInvalid    = 0;
     size_t   statMaxQueueDepth  = 0;
 
     while (m_running)
@@ -3145,49 +3144,39 @@ void HTTPTSStreamer::rawEncodingThread()
         if (videoBufferSize > statMaxQueueDepth) statMaxQueueDepth = videoBufferSize;
         bool hasBacklog = (videoBufferSize > 5 || audioBufferSize > 10);
 
-        MediaSynchronizer::SyncZone syncZone = m_rawStreamSynchronizer.calculateSyncZone();
-
-        if (syncZone.isValid())
+        // Drain video independently of the audio sync zone, mirroring
+        // the audio-drain path above. The /raw output is MPEG-TS, and
+        // av_interleaved_write_frame already orders packets across
+        // streams by DTS — we don't need calculateSyncZone to gate the
+        // per-stream encoding. Gating on it produced "video=0/s
+        // audio=0/s iters=1801 syncInvalid=1801" stalls whenever audio
+        // capture jittered briefly and the audio/video buffers fell out
+        // of the 50 ms overlap tolerance, even though the video queue
+        // had frames ready to encode.
         {
-            auto videoFrames = m_rawStreamSynchronizer.getVideoFrames(syncZone);
-
+            auto pendingVideo = m_rawStreamSynchronizer.getAllUnprocessedVideo();
             size_t framesProcessed = 0;
-            // Match the /stream side's bigger catchup batch under backlog.
             size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 30 : 2;
 
-            for (const auto &frame : videoFrames)
+            for (const auto &frame : pendingVideo)
             {
                 if (m_stopRequest) break;
                 if (framesProcessed >= MAX_FRAMES_PER_ITERATION) break;
+                if (frame.processed || !frame.data || frame.width == 0 || frame.height == 0) continue;
 
-                if (!frame.processed && frame.data && frame.width > 0 && frame.height > 0)
+                std::vector<MediaEncoder::EncodedPacket> packets;
+                if (m_rawMediaEncoder.encodeVideo(frame.data->data(), frame.width, frame.height,
+                                                 frame.captureTimestampUs, packets))
                 {
-                    std::vector<MediaEncoder::EncodedPacket> packets;
-                    if (m_rawMediaEncoder.encodeVideo(frame.data->data(), frame.width, frame.height,
-                                                     frame.captureTimestampUs, packets))
+                    for (const auto &packet : packets)
                     {
-                        for (const auto &packet : packets)
-                        {
-                            m_rawMediaMuxer.muxPacket(packet);
-                        }
-                        processedAny = true;
-                        framesProcessed++;
-                        ++statVideoEncoded;
-                        // Mark the specific frame we just encoded as
-                        // processed, by its capture timestamp. Marking by
-                        // index range (start, start+N) was broken — the
-                        // encoder loop skips frames already flagged
-                        // processed, so the indices that ended up
-                        // encoded weren't necessarily the first N
-                        // positions of the sync zone. The wrong frames
-                        // got marked, the actually-encoded ones stayed
-                        // unprocessed in the buffer and the next
-                        // iteration re-encoded them — which is exactly
-                        // why /raw was producing 200 fps from a 60 fps
-                        // push rate.
-                        m_rawStreamSynchronizer.markVideoFrameProcessedByTimestamp(frame.captureTimestampUs);
+                        m_rawMediaMuxer.muxPacket(packet);
                     }
+                    processedAny = true;
+                    framesProcessed++;
+                    ++statVideoEncoded;
                 }
+                m_rawStreamSynchronizer.markVideoFrameProcessedByTimestamp(frame.captureTimestampUs);
             }
 
             {
@@ -3199,10 +3188,6 @@ void HTTPTSStreamer::rawEncodingThread()
                 }
             }
         }
-        else
-        {
-            ++statSyncInvalid;
-        }
 
         // Emit telemetry once per second.
         auto nowTs = std::chrono::steady_clock::now();
@@ -3211,9 +3196,8 @@ void HTTPTSStreamer::rawEncodingThread()
             LOG_INFO("/raw encoder: video=" + std::to_string(statVideoEncoded) +
                      "/s audio=" + std::to_string(statAudioEncoded) +
                      "/s iters=" + std::to_string(statIterations) +
-                     " syncInvalid=" + std::to_string(statSyncInvalid) +
                      " maxVidQueue=" + std::to_string(statMaxQueueDepth));
-            statVideoEncoded = statAudioEncoded = statIterations = statSyncInvalid = 0;
+            statVideoEncoded = statAudioEncoded = statIterations = 0;
             statMaxQueueDepth = 0;
             statStart = nowTs;
         }

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1191,6 +1191,7 @@ bool HTTPTSStreamer::initializeEncoding()
     videoConfig.h265Level = m_h265Level;
     videoConfig.vp8Speed = m_vp8Speed;
     videoConfig.vp9Speed = m_vp9Speed;
+    videoConfig.hardwareEncoder = m_hardwareEncoder;
 
     MediaEncoder::AudioConfig audioConfig;
     audioConfig.sampleRate = m_audioSampleRate;
@@ -1274,6 +1275,7 @@ bool HTTPTSStreamer::initializeRawPipeline()
     videoConfig.h265Level   = m_h265Level;
     videoConfig.vp8Speed    = m_vp8Speed;
     videoConfig.vp9Speed    = m_vp9Speed;
+    videoConfig.hardwareEncoder = m_hardwareEncoder;
 
     MediaEncoder::AudioConfig audioConfig;
     audioConfig.sampleRate = m_audioSampleRate;

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -2967,7 +2967,14 @@ void HTTPTSStreamer::encodingThread()
             // Processar frames de vídeo (com controle de taxa para evitar aceleração)
             // Aumentar limite quando há backlog para evitar perda de frames
             size_t framesProcessed = 0;
-            size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 5 : 2; // Mais frames quando há backlog
+            // Bigger catchup batch under backlog — when the bound on
+            // frames-per-iteration is too small the encoder thread can't
+            // drain a transient spike before the next push, the
+            // synchronizer fills, and addVideoFrame starts dropping at
+            // the source even though the encoder is well within its
+            // throughput budget. 30 covers a full second of vsync push
+            // in a single iteration.
+            size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 30 : 2;
 
             for (const auto &frame : videoFrames)
             {
@@ -3003,8 +3010,20 @@ void HTTPTSStreamer::encodingThread()
             // Audio was already drained at the top of the loop, no need
             // to process it again here.
 
-            // Marcar frames de vídeo processados
-            m_streamSynchronizer.markVideoProcessed(syncZone.videoStartIdx, syncZone.videoEndIdx);
+            // Mark ONLY the frames we actually encoded as processed — not
+            // the entire sync zone. The previous behaviour silently
+            // dropped any frames beyond MAX_FRAMES_PER_ITERATION (they
+            // got marked processed without ever hitting the encoder),
+            // which both wastes capture work and produces visible gaps in
+            // the stream during transient bursts. Frames left unmarked
+            // here stay in the buffer and are picked up on the next loop
+            // iteration.
+            if (framesProcessed > 0)
+            {
+                m_streamSynchronizer.markVideoProcessed(
+                    syncZone.videoStartIdx,
+                    syncZone.videoStartIdx + framesProcessed);
+            }
 
             // Capturar header do formato se disponível
             {
@@ -3129,7 +3148,8 @@ void HTTPTSStreamer::rawEncodingThread()
             auto videoFrames = m_rawStreamSynchronizer.getVideoFrames(syncZone);
 
             size_t framesProcessed = 0;
-            size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 5 : 2;
+            // Match the /stream side's bigger catchup batch under backlog.
+            size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 30 : 2;
 
             for (const auto &frame : videoFrames)
             {
@@ -3153,7 +3173,17 @@ void HTTPTSStreamer::rawEncodingThread()
                 }
             }
 
-            m_rawStreamSynchronizer.markVideoProcessed(syncZone.videoStartIdx, syncZone.videoEndIdx);
+            // Mark only actually-encoded frames as processed (same fix
+            // as the /stream encodingThread). Frames beyond
+            // MAX_FRAMES_PER_ITERATION stay unprocessed and get picked
+            // up on the next iteration instead of being silently
+            // dropped.
+            if (framesProcessed > 0)
+            {
+                m_rawStreamSynchronizer.markVideoProcessed(
+                    syncZone.videoStartIdx,
+                    syncZone.videoStartIdx + framesProcessed);
+            }
 
             {
                 std::lock_guard<std::mutex> lock(m_rawHeaderMutex);

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -3003,27 +3003,21 @@ void HTTPTSStreamer::encodingThread()
                         }
                         processedAny = true;
                         framesProcessed++;
+                        // Mark this specific frame as processed by its
+                        // capture timestamp — see the matching note in
+                        // rawEncodingThread for why index-range marking
+                        // was wrong (it marked the first N slots of the
+                        // sync zone, but the loop skips already-
+                        // processed frames so the actually-encoded ones
+                        // were not at those positions and got re-encoded
+                        // on subsequent iterations).
+                        m_streamSynchronizer.markVideoFrameProcessedByTimestamp(frame.captureTimestampUs);
                     }
                 }
             }
 
             // Audio was already drained at the top of the loop, no need
             // to process it again here.
-
-            // Mark ONLY the frames we actually encoded as processed — not
-            // the entire sync zone. The previous behaviour silently
-            // dropped any frames beyond MAX_FRAMES_PER_ITERATION (they
-            // got marked processed without ever hitting the encoder),
-            // which both wastes capture work and produces visible gaps in
-            // the stream during transient bursts. Frames left unmarked
-            // here stay in the buffer and are picked up on the next loop
-            // iteration.
-            if (framesProcessed > 0)
-            {
-                m_streamSynchronizer.markVideoProcessed(
-                    syncZone.videoStartIdx,
-                    syncZone.videoStartIdx + framesProcessed);
-            }
 
             // Capturar header do formato se disponível
             {
@@ -3169,20 +3163,21 @@ void HTTPTSStreamer::rawEncodingThread()
                         processedAny = true;
                         framesProcessed++;
                         ++statVideoEncoded;
+                        // Mark the specific frame we just encoded as
+                        // processed, by its capture timestamp. Marking by
+                        // index range (start, start+N) was broken — the
+                        // encoder loop skips frames already flagged
+                        // processed, so the indices that ended up
+                        // encoded weren't necessarily the first N
+                        // positions of the sync zone. The wrong frames
+                        // got marked, the actually-encoded ones stayed
+                        // unprocessed in the buffer and the next
+                        // iteration re-encoded them — which is exactly
+                        // why /raw was producing 200 fps from a 60 fps
+                        // push rate.
+                        m_rawStreamSynchronizer.markVideoFrameProcessedByTimestamp(frame.captureTimestampUs);
                     }
                 }
-            }
-
-            // Mark only actually-encoded frames as processed (same fix
-            // as the /stream encodingThread). Frames beyond
-            // MAX_FRAMES_PER_ITERATION stay unprocessed and get picked
-            // up on the next iteration instead of being silently
-            // dropped.
-            if (framesProcessed > 0)
-            {
-                m_rawStreamSynchronizer.markVideoProcessed(
-                    syncZone.videoStartIdx,
-                    syncZone.videoStartIdx + framesProcessed);
             }
 
             {

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -155,7 +155,33 @@ bool HTTPTSStreamer::pushAudio(const int16_t *samples, size_t sampleCount)
     int64_t captureTimestampUs = getTimestampUs();
 
     // Adicionar áudio ao MediaSynchronizer
-    return m_streamSynchronizer.addAudioChunk(samples, sampleCount, captureTimestampUs, m_audioSampleRate, m_audioChannelsCount);
+    bool ok = m_streamSynchronizer.addAudioChunk(samples, sampleCount, captureTimestampUs, m_audioSampleRate, m_audioChannelsCount);
+
+    // Phase 2 of #47: same audio chunk feeds the /raw pipeline. The /raw
+    // muxer needs audio packets too — only the video frame source differs
+    // between /stream (post-shader) and /raw (pre-shader).
+    if (m_rawMediaEncoder.isInitialized())
+    {
+        m_rawStreamSynchronizer.addAudioChunk(samples, sampleCount, captureTimestampUs, m_audioSampleRate, m_audioChannelsCount);
+    }
+
+    return ok;
+}
+
+bool HTTPTSStreamer::pushRawFrame(const uint8_t *data, uint32_t width, uint32_t height)
+{
+    if (!data || !m_active || width == 0 || height == 0)
+    {
+        return false;
+    }
+    if (!m_rawMediaEncoder.isInitialized())
+    {
+        // Raw pipeline didn't come up — accept the push as a no-op so callers
+        // don't have to special-case it.
+        return false;
+    }
+    int64_t captureTimestampUs = getTimestampUs();
+    return m_rawStreamSynchronizer.addVideoFrame(data, width, height, captureTimestampUs);
 }
 
 bool HTTPTSStreamer::start()
@@ -360,6 +386,15 @@ bool HTTPTSStreamer::start()
     m_encodingThread = std::thread(&HTTPTSStreamer::encodingThread, this);
     m_encodingThread.detach();
 
+    // Phase 2 of #47: parallel encoder for the /raw output. Idles when no
+    // /raw clients are connected (Application.cpp gates pushes via
+    // hasRawClients()), so the resting CPU cost is negligible.
+    if (m_rawMediaEncoder.isInitialized())
+    {
+        m_rawEncodingThread = std::thread(&HTTPTSStreamer::rawEncodingThread, this);
+        m_rawEncodingThread.detach();
+    }
+
     return true;
 }
 
@@ -559,6 +594,17 @@ void HTTPTSStreamer::stop()
         m_clientCount = 0;
     }
 
+    // Phase 2 of #47: same for /raw clients.
+    {
+        std::lock_guard<std::mutex> lock(m_rawOutputMutex);
+        for (int clientFd : m_rawClientSockets)
+        {
+            m_httpServer.closeClient(clientFd);
+        }
+        m_rawClientSockets.clear();
+        m_rawClientCount = 0;
+    }
+
     // Aguardar um tempo para threads processarem m_stopRequest e terminarem
     // Como threads são detached, precisamos aguardar um tempo razoável
     // Reduzido para evitar bloqueio prolongado - threads devem terminar rapidamente
@@ -718,6 +764,24 @@ void HTTPTSStreamer::handleClient(int clientFd)
     // Isso garante que requisições de stream não sejam capturadas pelo portal
     bool isStreamRequest = (request.find("/stream") != std::string::npos);
 
+    // Phase 2 of #47: detect /raw with a tight match against the request-line
+    // path (vs. /stream's loose substring match, kept as-is for compat).
+    bool isRawRequest = false;
+    {
+        size_t methodEnd = request.find(' ');
+        if (methodEnd != std::string::npos)
+        {
+            size_t pathEnd = request.find(' ', methodEnd + 1);
+            if (pathEnd != std::string::npos)
+            {
+                std::string path = request.substr(methodEnd + 1, pathEnd - methodEnd - 1);
+                size_t q = path.find('?');
+                if (q != std::string::npos) path = path.substr(0, q);
+                isRawRequest = (path == "/raw");
+            }
+        }
+    }
+
     // Extrair prefixo base para verificar requisições com prefixo
     // Prioridade: 1) X-Forwarded-Prefix header, 2) path da requisição
     std::string basePrefixForDetection = "";
@@ -817,8 +881,8 @@ void HTTPTSStreamer::handleClient(int clientFd)
         // Se não foi processada, continuar para outras verificações
     }
 
-    // IMPORTANTE: Verificar portal web APENAS se NÃO for stream e se Web Portal estiver habilitado
-    if (m_webPortalEnabled && !isStreamRequest)
+    // IMPORTANTE: Verificar portal web APENAS se NÃO for stream nem /raw e se Web Portal estiver habilitado
+    if (m_webPortalEnabled && !isStreamRequest && !isRawRequest)
     {
         if (m_webPortal.isWebPortalRequest(request))
         {
@@ -831,7 +895,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
         }
     }
 
-    if (!isStreamRequest)
+    if (!isStreamRequest && !isRawRequest)
     {
         send404(clientFd);
         m_httpServer.closeClient(clientFd);
@@ -855,6 +919,53 @@ void HTTPTSStreamer::handleClient(int clientFd)
         m_httpServer.closeClient(clientFd);
         return;
     }
+
+    // Phase 2 of #47: branch on /raw vs /stream — same protocol on the wire,
+    // different state mirrors (format header, client list, mutex).
+    if (isRawRequest)
+    {
+        {
+            std::lock_guard<std::mutex> headerLock(m_rawHeaderMutex);
+            if (m_rawHeaderWritten && !m_rawFormatHeader.empty())
+            {
+                ssize_t headerSent = m_httpServer.sendData(clientFd, m_rawFormatHeader.data(), m_rawFormatHeader.size());
+                if (headerSent < 0)
+                {
+                    LOG_ERROR("Failed to send raw format header to client");
+                    m_httpServer.closeClient(clientFd);
+                    return;
+                }
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_rawOutputMutex);
+            m_rawClientSockets.push_back(clientFd);
+            m_rawClientCount = m_rawClientSockets.size();
+        }
+
+        while (!m_stopRequest && m_running)
+        {
+            char dummy;
+            ssize_t result = m_httpServer.receiveData(clientFd, &dummy, 1);
+            if (result <= 0) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        m_httpServer.closeClient(clientFd);
+        {
+            std::lock_guard<std::mutex> lock(m_rawOutputMutex);
+            auto it = std::find(m_rawClientSockets.begin(), m_rawClientSockets.end(), clientFd);
+            if (it != m_rawClientSockets.end())
+            {
+                m_rawClientSockets.erase(it);
+                m_rawClientCount = m_rawClientSockets.size();
+            }
+        }
+        return;
+    }
+
+    // /stream path — unchanged from before Phase 2.
 
     // Enviar header do formato MPEG-TS se já foi capturado
     {
@@ -1000,6 +1111,55 @@ int HTTPTSStreamer::writeToClients(const uint8_t *buf, int buf_size)
     }
 }
 
+int HTTPTSStreamer::writeToRawClients(const uint8_t *buf, int buf_size)
+{
+    // Mirror of writeToClients, operating on the /raw output state. Kept as
+    // a near-duplicate so the /stream path stays byte-for-byte unchanged.
+    if (!buf || buf_size <= 0 || m_stopRequest)
+    {
+        return buf_size;
+    }
+
+    {
+        std::lock_guard<std::mutex> headerLock(m_rawHeaderMutex);
+        if (!m_rawHeaderWritten && m_rawMediaMuxer.isHeaderWritten())
+        {
+            m_rawFormatHeader = m_rawMediaMuxer.getFormatHeader();
+            m_rawHeaderWritten = true;
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_rawOutputMutex);
+        if (m_stopRequest || m_rawClientSockets.empty())
+        {
+            return buf_size;
+        }
+
+        auto it = m_rawClientSockets.begin();
+        while (it != m_rawClientSockets.end())
+        {
+            int clientFd = *it;
+            ssize_t sent = m_httpServer.sendData(clientFd, buf, buf_size);
+            if (sent < 0)
+            {
+                m_httpServer.closeClient(clientFd);
+                it = m_rawClientSockets.erase(it);
+                m_rawClientCount = m_rawClientSockets.size();
+            }
+            else
+            {
+                // sent == 0 (would-block) and partial sends are treated the
+                // same way as in writeToClients — keep the client connected
+                // and move on.
+                ++it;
+            }
+        }
+
+        return buf_size;
+    }
+}
+
 bool HTTPTSStreamer::initializeEncoding()
 {
     // Configurar MediaSynchronizer com valores configuráveis
@@ -1062,7 +1222,100 @@ bool HTTPTSStreamer::initializeEncoding()
     }
 
     LOG_INFO("MediaMuxer inicializado com sucesso - encoding pronto para streaming");
+
+    // Phase 2 of #47: also bring up the /raw pipeline so RetroCapture remote
+    // clients can consume the pre-shader feed. Soft-fail — if /raw can't
+    // come up, log it and keep /stream working.
+    if (!initializeRawPipeline())
+    {
+        LOG_WARN("Failed to initialize /raw pipeline — /stream still functional");
+    }
+
     return true;
+}
+
+bool HTTPTSStreamer::initializeRawPipeline()
+{
+    // Configurar segundo MediaSynchronizer com os mesmos valores do /stream.
+    m_rawStreamSynchronizer.setMaxBufferTime(m_maxBufferTimeSeconds * 1000000LL);
+    m_rawStreamSynchronizer.setMaxVideoBufferSize(m_maxVideoBufferSize);
+    m_rawStreamSynchronizer.setMaxAudioBufferSize(m_maxAudioBufferSize);
+    m_rawStreamSynchronizer.setSyncTolerance(50 * 1000LL);
+
+    // Strategy B (#47): /raw shares codec config (bitrate, codec, preset)
+    // with /stream. Separate encoder/muxer state lives parallel below.
+    MediaEncoder::VideoConfig videoConfig;
+    videoConfig.width    = m_width;
+    videoConfig.height   = m_height;
+    videoConfig.fps      = m_fps;
+    videoConfig.bitrate  = m_videoBitrate;
+    videoConfig.codec    = m_videoCodecName;
+    videoConfig.preset   = (m_videoCodecName == "h264" || m_videoCodecName == "libx264") ? m_h264Preset : m_h265Preset;
+    videoConfig.profile  = (m_videoCodecName == "h264" || m_videoCodecName == "libx264") ? "baseline" : "";
+    videoConfig.h265Profile = m_h265Profile;
+    videoConfig.h265Level   = m_h265Level;
+    videoConfig.vp8Speed    = m_vp8Speed;
+    videoConfig.vp9Speed    = m_vp9Speed;
+
+    MediaEncoder::AudioConfig audioConfig;
+    audioConfig.sampleRate = m_audioSampleRate;
+    audioConfig.channels   = m_audioChannelsCount;
+    audioConfig.bitrate    = m_audioBitrate;
+    audioConfig.codec      = m_audioCodecName;
+
+    LOG_INFO("Inicializando MediaEncoder /raw (mesma config do /stream)");
+
+    if (!m_rawMediaEncoder.initialize(videoConfig, audioConfig, true))
+    {
+        LOG_ERROR("Failed to initialize raw MediaEncoder");
+        return false;
+    }
+
+    auto rawWriteCallback = [this](const uint8_t *data, size_t size) -> int
+    {
+        return this->writeToRawClients(data, size);
+    };
+
+    if (!m_rawMediaMuxer.initialize(videoConfig, audioConfig,
+                                    m_rawMediaEncoder.getVideoCodecContext(),
+                                    m_rawMediaEncoder.getAudioCodecContext(),
+                                    "", // streaming via callback
+                                    rawWriteCallback,
+                                    m_avioBufferSize))
+    {
+        LOG_ERROR("Failed to initialize raw MediaMuxer");
+        m_rawMediaEncoder.cleanup();
+        return false;
+    }
+
+    LOG_INFO("Raw pipeline inicializado — /raw pronto para servir pre-shader");
+    return true;
+}
+
+void HTTPTSStreamer::cleanupRawPipeline()
+{
+    if (m_rawMediaEncoder.isInitialized())
+    {
+        std::vector<MediaEncoder::EncodedPacket> packets;
+        m_rawMediaEncoder.flush(packets);
+        for (const auto &p : packets)
+        {
+            m_rawMediaMuxer.muxPacket(p);
+        }
+    }
+    if (m_rawMediaMuxer.isInitialized())
+    {
+        m_rawMediaMuxer.flush();
+    }
+    m_rawMediaMuxer.cleanup();
+    m_rawMediaEncoder.cleanup();
+    m_rawStreamSynchronizer.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(m_rawHeaderMutex);
+        m_rawFormatHeader.clear();
+        m_rawHeaderWritten = false;
+    }
 }
 
 void HTTPTSStreamer::cleanupEncoding()
@@ -1105,6 +1358,9 @@ void HTTPTSStreamer::cleanupEncoding()
             m_headerWritten = false;
         }
     }
+
+    // Phase 2 of #47: also tear down the /raw pipeline.
+    cleanupRawPipeline();
 }
 
 bool HTTPTSStreamer::initializeVideoCodec()
@@ -2791,4 +3047,124 @@ void HTTPTSStreamer::encodingThread()
     }
 
     return;
+}
+
+void HTTPTSStreamer::rawEncodingThread()
+{
+    // Mirror of encodingThread() but driving the /raw pipeline. Lives as a
+    // near-duplicate for Phase 2 of #47; refactoring into a shared loop body
+    // is intentionally deferred until the dual-output story is stable. Skips
+    // doing any work when no /raw client is connected — Application.cpp gates
+    // pushRawFrame via hasRawClients(), so under typical use this thread idles.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    int cleanupCounter = 0;
+    const int CLEANUP_INTERVAL = 10;
+
+    while (m_running)
+    {
+        if (m_stopRequest) break;
+
+        bool processedAny = false;
+
+        cleanupCounter++;
+        if (cleanupCounter >= CLEANUP_INTERVAL)
+        {
+            m_rawStreamSynchronizer.cleanupOldData();
+            cleanupCounter = 0;
+        }
+
+        // Drain audio independently — same reasoning as encodingThread.
+        {
+            auto pendingAudio = m_rawStreamSynchronizer.getAllUnprocessedAudio();
+            for (const auto &chunk : pendingAudio)
+            {
+                if (m_stopRequest) break;
+                if (chunk.processed || !chunk.samples || chunk.sampleCount == 0) continue;
+
+                std::vector<MediaEncoder::EncodedPacket> aPackets;
+                if (m_rawMediaEncoder.encodeAudio(chunk.samples->data(), chunk.sampleCount,
+                                                  chunk.captureTimestampUs, aPackets))
+                {
+                    for (const auto &p : aPackets)
+                    {
+                        m_rawMediaMuxer.muxPacket(p);
+                    }
+                    processedAny = true;
+                }
+                m_rawStreamSynchronizer.markAudioChunkProcessedByTimestamp(chunk.captureTimestampUs);
+            }
+        }
+
+        size_t videoBufferSize = m_rawStreamSynchronizer.getVideoBufferSize();
+        size_t audioBufferSize = m_rawStreamSynchronizer.getAudioBufferSize();
+        bool hasBacklog = (videoBufferSize > 5 || audioBufferSize > 10);
+
+        MediaSynchronizer::SyncZone syncZone = m_rawStreamSynchronizer.calculateSyncZone();
+
+        if (syncZone.isValid())
+        {
+            auto videoFrames = m_rawStreamSynchronizer.getVideoFrames(syncZone);
+
+            size_t framesProcessed = 0;
+            size_t MAX_FRAMES_PER_ITERATION = hasBacklog ? 5 : 2;
+
+            for (const auto &frame : videoFrames)
+            {
+                if (m_stopRequest) break;
+                if (framesProcessed >= MAX_FRAMES_PER_ITERATION) break;
+
+                if (!frame.processed && frame.data && frame.width > 0 && frame.height > 0)
+                {
+                    std::vector<MediaEncoder::EncodedPacket> packets;
+                    if (m_rawMediaEncoder.encodeVideo(frame.data->data(), frame.width, frame.height,
+                                                     frame.captureTimestampUs, packets))
+                    {
+                        for (const auto &packet : packets)
+                        {
+                            m_rawMediaMuxer.muxPacket(packet);
+                        }
+                        processedAny = true;
+                        framesProcessed++;
+                    }
+                }
+            }
+
+            m_rawStreamSynchronizer.markVideoProcessed(syncZone.videoStartIdx, syncZone.videoEndIdx);
+
+            {
+                std::lock_guard<std::mutex> lock(m_rawHeaderMutex);
+                if (!m_rawHeaderWritten && m_rawMediaMuxer.isHeaderWritten())
+                {
+                    m_rawFormatHeader = m_rawMediaMuxer.getFormatHeader();
+                    m_rawHeaderWritten = true;
+                }
+            }
+        }
+
+        if (processedAny)
+        {
+            if (hasBacklog)
+            {
+                std::this_thread::sleep_for(std::chrono::microseconds(100));
+            }
+            else
+            {
+                int64_t frameTimeUs = 1000000LL / static_cast<int64_t>(m_fps);
+                std::this_thread::sleep_for(std::chrono::microseconds(frameTimeUs / 2));
+            }
+        }
+        else
+        {
+            bool hasPendingData = (videoBufferSize > 0 || audioBufferSize > 0);
+            if (!hasPendingData)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            else
+            {
+                std::this_thread::sleep_for(std::chrono::microseconds(500));
+            }
+        }
+    }
 }

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -891,10 +891,11 @@ void HTTPTSStreamer::handleClient(int clientFd)
             m_httpServer.closeClient(clientFd);
             return;
         }
-        // Se não foi processada, continuar para outras verificações
+        // Fall through to other checks if not handled.
     }
 
-    // IMPORTANTE: Verificar portal web APENAS se NÃO for stream nem /raw e se Web Portal estiver habilitado
+    // Only consult the web portal when this is neither a stream nor /raw
+    // request and the portal is enabled.
     if (m_webPortalEnabled && !isStreamRequest && !isRawRequest)
     {
         if (m_webPortal.isWebPortalRequest(request))
@@ -904,7 +905,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
                 m_httpServer.closeClient(clientFd);
                 return;
             }
-            // Se não foi processada, continuar para outras verificações
+            // Fall through to other checks if not handled.
         }
     }
 
@@ -1320,7 +1321,7 @@ bool HTTPTSStreamer::initializeRawPipeline()
     audioConfig.bitrate    = m_audioBitrate;
     audioConfig.codec      = m_audioCodecName;
 
-    LOG_INFO("Inicializando MediaEncoder /raw (mesma config do /stream)");
+    LOG_INFO("Initializing /raw MediaEncoder (same config as /stream)");
 
     if (!m_rawMediaEncoder.initialize(videoConfig, audioConfig, true))
     {
@@ -1345,7 +1346,7 @@ bool HTTPTSStreamer::initializeRawPipeline()
         return false;
     }
 
-    LOG_INFO("Raw pipeline inicializado — /raw pronto para servir pre-shader");
+    LOG_INFO("Raw pipeline initialized — /raw ready to serve pre-shader frames");
     return true;
 }
 
@@ -3232,10 +3233,10 @@ void HTTPTSStreamer::rawEncodingThread()
         auto nowTs = std::chrono::steady_clock::now();
         if (std::chrono::duration_cast<std::chrono::seconds>(nowTs - statStart).count() >= 1)
         {
-            LOG_INFO("/raw encoder: video=" + std::to_string(statVideoEncoded) +
-                     "/s audio=" + std::to_string(statAudioEncoded) +
-                     "/s iters=" + std::to_string(statIterations) +
-                     " maxVidQueue=" + std::to_string(statMaxQueueDepth));
+            LOG_DEBUG("/raw encoder: video=" + std::to_string(statVideoEncoded) +
+                      "/s audio=" + std::to_string(statAudioEncoded) +
+                      "/s iters=" + std::to_string(statIterations) +
+                      " maxVidQueue=" + std::to_string(statMaxQueueDepth));
             statVideoEncoded = statAudioEncoded = statIterations = 0;
             statMaxQueueDepth = 0;
             statStart = nowTs;

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -160,7 +160,17 @@ bool HTTPTSStreamer::pushAudio(const int16_t *samples, size_t sampleCount)
     // Phase 2 of #47: same audio chunk feeds the /raw pipeline. The /raw
     // muxer needs audio packets too — only the video frame source differs
     // between /stream (post-shader) and /raw (pre-shader).
-    if (m_rawMediaEncoder.isInitialized())
+    //
+    // Gate on hasRawClients() so the /raw audio encoder doesn't start
+    // running its PTS clock before any /raw video frame is pushed. Without
+    // this gate, audio would accumulate its sample-count-based PTS for the
+    // full pre-connect window while video stays at PTS=0; the muxer then
+    // emits audio packets at "stream has been running for N seconds" while
+    // video starts at 0, which ffplay flags as "DTS … < … out of order"
+    // and our client renders as the visible ghost / back-and-forth jitter.
+    // With the gate, both streams begin their PTS counters at the same
+    // wall-clock moment — the first frame after the first client arrives.
+    if (m_rawMediaEncoder.isInitialized() && hasRawClients())
     {
         m_rawStreamSynchronizer.addAudioChunk(samples, sampleCount, captureTimestampUs, m_audioSampleRate, m_audioChannelsCount);
     }

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1192,6 +1192,7 @@ bool HTTPTSStreamer::initializeEncoding()
     videoConfig.vp8Speed = m_vp8Speed;
     videoConfig.vp9Speed = m_vp9Speed;
     videoConfig.hardwareEncoder = m_hardwareEncoder;
+    videoConfig.hwPreset = m_hardwareEncoderPreset;
 
     MediaEncoder::AudioConfig audioConfig;
     audioConfig.sampleRate = m_audioSampleRate;
@@ -1276,6 +1277,7 @@ bool HTTPTSStreamer::initializeRawPipeline()
     videoConfig.vp8Speed    = m_vp8Speed;
     videoConfig.vp9Speed    = m_vp9Speed;
     videoConfig.hardwareEncoder = m_hardwareEncoder;
+    videoConfig.hwPreset = m_hardwareEncoderPreset;
 
     MediaEncoder::AudioConfig audioConfig;
     audioConfig.sampleRate = m_audioSampleRate;

--- a/src/streaming/HTTPTSStreamer.h
+++ b/src/streaming/HTTPTSStreamer.h
@@ -83,6 +83,7 @@ public:
     void setVP9Speed(int speed) { m_vp9Speed = speed; }
     void setHardwareEncoder(MediaEncoder::HardwareEncoder h) { m_hardwareEncoder = h; }
     MediaEncoder::HardwareEncoder getHardwareEncoder() const { return m_hardwareEncoder; }
+    void setHardwareEncoderPreset(const std::string &p) { m_hardwareEncoderPreset = p; }
 
     // HTTPS configuration
     void enableHTTPS(bool enable) { m_enableHTTPS = enable; }
@@ -217,6 +218,7 @@ private:
     int m_vp8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_vp9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
     MediaEncoder::HardwareEncoder m_hardwareEncoder = MediaEncoder::HardwareEncoder::Auto;
+    std::string m_hardwareEncoderPreset;
 
     // Codec contexts (usando void* para evitar incluir headers FFmpeg no .h)
     void *m_videoCodecContext = nullptr; // AVCodecContext*

--- a/src/streaming/HTTPTSStreamer.h
+++ b/src/streaming/HTTPTSStreamer.h
@@ -56,6 +56,14 @@ public:
     uint32_t getClientCount() const override;
     void cleanup() override;
 
+    // Raw-stream pipeline (Phase 2 of #47): a second MPEG-TS output served
+    // at /raw, fed with pre-shader frames. Same codec config as /stream; the
+    // contract is that /raw is ALWAYS pre-shader regardless of any
+    // per-pipeline shader-bypass toggle that may flip /stream's contents.
+    bool pushRawFrame(const uint8_t *data, uint32_t width, uint32_t height);
+    uint32_t getRawClientCount() const { return m_rawClientCount.load(); }
+    bool hasRawClients() const { return m_rawClientCount.load() > 0; }
+
     // Additional configuration methods
     void setVideoBitrate(uint32_t bitrate) { m_videoBitrate = bitrate; }
     void setAudioBitrate(uint32_t bitrate) { m_audioBitrate = bitrate; }
@@ -163,6 +171,10 @@ private:
 
 private:
     void serverThread();
+    void rawEncodingThread();     // Phase 2 of #47 — drains the raw synchronizer.
+    bool initializeRawPipeline(); // Phase 2 of #47 — sets up the raw encoder + muxer.
+    void cleanupRawPipeline();    // Phase 2 of #47 — tears down the raw encoder + muxer.
+    int  writeToRawClients(const uint8_t *buf, int buf_size); // Phase 2 of #47.
     void handleClient(int clientFd);
     void send404(int clientFd);     // Enviar resposta 404
     void encodingThread();          // Thread para encoding com sincronização baseada em timestamps
@@ -285,7 +297,8 @@ private:
 
     // Threads
     std::thread m_serverThread;
-    std::thread m_encodingThread; // Thread única para encoding
+    std::thread m_encodingThread;    // Thread única para encoding do /stream
+    std::thread m_rawEncodingThread; // Thread única para encoding do /raw (Phase 2 de #47)
 
     // HTTP/HTTPS Server
     HTTPServer m_httpServer;
@@ -303,6 +316,25 @@ private:
     // Header do formato MPEG-TS (enviado quando cliente se conecta)
     std::vector<uint8_t> m_formatHeader;
     bool m_headerWritten = false;
+
+    // ─── Raw pipeline state (Phase 2 of #47) ──────────────────────────────
+    //
+    // Parallel mirror of the /stream pipeline above, fed with pre-shader
+    // frames. Shares the codec config (bitrate / codec / preset) — Strategy B
+    // of the design — but uses its own encoder, muxer, synchronizer, client
+    // list and format-header cache so the two outputs are fully independent.
+    MediaEncoder      m_rawMediaEncoder;
+    MediaMuxer        m_rawMediaMuxer;
+    MediaSynchronizer m_rawStreamSynchronizer;
+
+    std::mutex m_rawOutputMutex; // Proteger m_rawClientSockets e writeToRawClients
+    std::mutex m_rawHeaderMutex; // Proteger m_rawFormatHeader
+
+    std::atomic<uint32_t> m_rawClientCount{0};
+    std::vector<int>      m_rawClientSockets;
+
+    std::vector<uint8_t> m_rawFormatHeader;
+    bool                 m_rawHeaderWritten = false;
 
     // Web Portal - responsável por servir a página web
     WebPortal m_webPortal;

--- a/src/streaming/HTTPTSStreamer.h
+++ b/src/streaming/HTTPTSStreamer.h
@@ -81,6 +81,8 @@ public:
     void setH265Level(const std::string &level) { m_h265Level = level; }
     void setVP8Speed(int speed) { m_vp8Speed = speed; }
     void setVP9Speed(int speed) { m_vp9Speed = speed; }
+    void setHardwareEncoder(MediaEncoder::HardwareEncoder h) { m_hardwareEncoder = h; }
+    MediaEncoder::HardwareEncoder getHardwareEncoder() const { return m_hardwareEncoder; }
 
     // HTTPS configuration
     void enableHTTPS(bool enable) { m_enableHTTPS = enable; }
@@ -214,6 +216,7 @@ private:
     std::string m_h265Level = "auto";      // Level H.265: "auto", "1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"
     int m_vp8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_vp9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
+    MediaEncoder::HardwareEncoder m_hardwareEncoder = MediaEncoder::HardwareEncoder::Auto;
 
     // Codec contexts (usando void* para evitar incluir headers FFmpeg no .h)
     void *m_videoCodecContext = nullptr; // AVCodecContext*

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -59,6 +59,30 @@ namespace
         return !out.host.empty();
     }
 
+    // Opens a TCP connection to host:port. Returns INVALID_SOCK on failure.
+    socket_t connectTcp(const UrlParts &u)
+    {
+        addrinfo hints{};
+        hints.ai_family   = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        addrinfo *res = nullptr;
+        if (getaddrinfo(u.host.c_str(), u.port.c_str(), &hints, &res) != 0 || !res)
+        {
+            return INVALID_SOCK;
+        }
+        socket_t sock = INVALID_SOCK;
+        for (addrinfo *p = res; p != nullptr; p = p->ai_next)
+        {
+            sock = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+            if (sock == INVALID_SOCK) continue;
+            if (::connect(sock, p->ai_addr, static_cast<int>(p->ai_addrlen)) == 0) break;
+            closeSocket(sock);
+            sock = INVALID_SOCK;
+        }
+        freeaddrinfo(res);
+        return sock;
+    }
+
     // Synchronous HTTP/1.1 GET with a 5-second receive deadline. Returns
     // the response body on 2xx, empty string otherwise. Logs errors but
     // doesn't throw — callers treat empty as "skip this poll".
@@ -71,25 +95,7 @@ namespace
             return {};
         }
 
-        addrinfo hints{};
-        hints.ai_family   = AF_UNSPEC;
-        hints.ai_socktype = SOCK_STREAM;
-        addrinfo *res = nullptr;
-        if (getaddrinfo(u.host.c_str(), u.port.c_str(), &hints, &res) != 0 || !res)
-        {
-            return {};
-        }
-
-        socket_t sock = INVALID_SOCK;
-        for (addrinfo *p = res; p != nullptr; p = p->ai_next)
-        {
-            sock = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-            if (sock == INVALID_SOCK) continue;
-            if (::connect(sock, p->ai_addr, static_cast<int>(p->ai_addrlen)) == 0) break;
-            closeSocket(sock);
-            sock = INVALID_SOCK;
-        }
-        freeaddrinfo(res);
+        socket_t sock = connectTcp(u);
         if (sock == INVALID_SOCK) return {};
 
         // 5-second receive timeout so a wedged remote doesn't stall the
@@ -149,6 +155,64 @@ namespace
 
         return response.substr(sep + 4);
     }
+
+    // Parses the /meta JSON snapshot body into the Snapshot struct.
+    // Returns false on parse error. Shared by both the short-poll
+    // (httpGet) and long-poll (SSE) paths.
+    bool parseSnapshotJSON(const std::string &body, RemoteMetaSync::Snapshot &out)
+    {
+        try
+        {
+            auto j = nlohmann::json::parse(body);
+            out.protocolVersion = j.value("protocolVersion", 0);
+            out.serverVersion   = j.value("serverVersion", std::string{});
+
+            if (j.contains("shader") && j["shader"].is_object())
+            {
+                const auto &s = j["shader"];
+                out.shaderActive    = s.value("active", false);
+                out.pipelineEnabled = s.value("pipelineEnabled", true);
+                out.preset          = s.value("preset", std::string{});
+                out.presetHash      = s.value("presetHash", std::string{});
+                if (s.contains("parameters") && s["parameters"].is_array())
+                {
+                    out.parameters.clear();
+                    out.parameters.reserve(s["parameters"].size());
+                    for (const auto &p : s["parameters"])
+                    {
+                        RemoteMetaSync::ParamOverride po;
+                        po.name  = p.value("name", std::string{});
+                        po.value = p.value("value", 0.0f);
+                        if (!po.name.empty())
+                        {
+                            out.parameters.push_back(std::move(po));
+                        }
+                    }
+                }
+            }
+
+            if (j.contains("source") && j["source"].is_object())
+            {
+                const auto &s = j["source"];
+                out.sourceWidth  = s.value("width",  0u);
+                out.sourceHeight = s.value("height", 0u);
+                out.sourceFps    = s.value("fps",    0u);
+            }
+
+            if (j.contains("image") && j["image"].is_object())
+            {
+                const auto &im = j["image"];
+                out.imageBrightness = im.value("brightness", 1.0f);
+                out.imageContrast   = im.value("contrast",   1.0f);
+            }
+            return true;
+        }
+        catch (const std::exception &e)
+        {
+            LOG_WARN(std::string("RemoteMetaSync: JSON parse failed — ") + e.what());
+            return false;
+        }
+    }
 }
 
 RemoteMetaSync::RemoteMetaSync() = default;
@@ -203,94 +267,224 @@ bool RemoteMetaSync::fetchOnce(Snapshot &out)
 {
     std::string body = httpGet(m_baseUrl + "/meta");
     if (body.empty()) return false;
+    return parseSnapshotJSON(body, out);
+}
 
-    try
+void RemoteMetaSync::dispatchIfChanged(const Snapshot &snap)
+{
+    std::vector<float> currentValues;
+    currentValues.reserve(snap.parameters.size());
+    for (const auto &p : snap.parameters)
     {
-        auto j = nlohmann::json::parse(body);
-        out.protocolVersion = j.value("protocolVersion", 0);
-        out.serverVersion   = j.value("serverVersion", std::string{});
+        currentValues.push_back(p.value);
+    }
 
-        if (j.contains("shader") && j["shader"].is_object())
+    const bool presetChanged  = (snap.preset           != m_lastPreset);
+    const bool hashChanged    = (snap.presetHash       != m_lastPresetHash);
+    const bool toggleChanged  = (snap.pipelineEnabled  != m_lastPipelineEnabled);
+    const bool paramsChanged  = (currentValues         != m_lastParamValues);
+
+    if (presetChanged || hashChanged || toggleChanged || paramsChanged)
+    {
+        if (m_cb) m_cb(snap);
+        m_lastPreset          = snap.preset;
+        m_lastPresetHash      = snap.presetHash;
+        m_lastPipelineEnabled = snap.pipelineEnabled;
+        m_lastParamValues     = std::move(currentValues);
+    }
+}
+
+// Long-poll on /meta with SSE. Phase 6 of #47.
+//
+// Returns true if the SSE handshake succeeded and the connection then
+// ended (server closed, network blip, stop requested). Returns false if
+// the server's response wasn't text/event-stream — caller falls back to
+// short-poll fetchOnce(). Old RetroCapture builds (Phases 1-5) that only
+// know HTTP GET on /meta will land in the false branch and the client
+// transparently degrades to 1 s polling.
+bool RemoteMetaSync::runSSE()
+{
+    UrlParts u;
+    if (!parseHttpUrl(m_baseUrl + "/meta", u))
+    {
+        return false;
+    }
+
+    socket_t sock = connectTcp(u);
+    if (sock == INVALID_SOCK) return false;
+
+    // No recv timeout for SSE — the connection is intentionally long-lived.
+    // We rely on send-failure detection on the server side (their keepalive
+    // comment + payload writes) to notice broken sockets.
+
+    std::string req;
+    req.reserve(256);
+    req += "GET ";
+    req += u.path;
+    req += " HTTP/1.1\r\nHost: ";
+    req += u.host;
+    if (u.port != "80")
+    {
+        req += ':';
+        req += u.port;
+    }
+    req += "\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\n";
+    req += "Connection: keep-alive\r\n\r\n";
+
+    if (::send(sock, req.data(), static_cast<int>(req.size()), 0) < 0)
+    {
+        closeSocket(sock);
+        return false;
+    }
+
+    // Read response headers — accumulate until we see "\r\n\r\n".
+    std::string buf;
+    buf.reserve(2048);
+    char chunk[2048];
+    while (m_running.load())
+    {
+        int n = ::recv(sock, chunk, sizeof(chunk), 0);
+        if (n <= 0)
         {
-            const auto &s = j["shader"];
-            out.shaderActive    = s.value("active", false);
-            out.pipelineEnabled = s.value("pipelineEnabled", true);
-            out.preset          = s.value("preset", std::string{});
-            out.presetHash      = s.value("presetHash", std::string{});
-            if (s.contains("parameters") && s["parameters"].is_array())
+            closeSocket(sock);
+            return false;
+        }
+        buf.append(chunk, static_cast<size_t>(n));
+        if (buf.find("\r\n\r\n") != std::string::npos) break;
+        if (buf.size() > 16 * 1024) { closeSocket(sock); return false; }
+    }
+    if (!m_running.load()) { closeSocket(sock); return true; }
+
+    size_t headerEnd = buf.find("\r\n\r\n");
+    std::string headerSection = buf.substr(0, headerEnd);
+    // Status line check — accept any 2xx.
+    {
+        size_t sp = headerSection.find(' ');
+        if (sp == std::string::npos) { closeSocket(sock); return false; }
+        int code = std::atoi(headerSection.c_str() + sp + 1);
+        if (code < 200 || code >= 300) { closeSocket(sock); return false; }
+    }
+    // Content-Type check — must be text/event-stream for SSE.
+    {
+        std::string lower = headerSection;
+        std::transform(lower.begin(), lower.end(), lower.begin(),
+                       [](unsigned char c) { return static_cast<char>(::tolower(c)); });
+        if (lower.find("text/event-stream") == std::string::npos)
+        {
+            // Server responded with the old one-shot JSON snapshot — parse it
+            // and dispatch, then return false so the caller falls back to
+            // short-polling (since this server doesn't support SSE).
+            std::string body = buf.substr(headerEnd + 4);
+            Snapshot snap;
+            if (parseSnapshotJSON(body, snap))
             {
-                out.parameters.clear();
-                out.parameters.reserve(s["parameters"].size());
-                for (const auto &p : s["parameters"])
+                dispatchIfChanged(snap);
+            }
+            closeSocket(sock);
+            return false;
+        }
+    }
+
+    LOG_INFO("RemoteMetaSync: SSE stream established with " + m_baseUrl);
+
+    std::string body = buf.substr(headerEnd + 4);
+    buf.clear();
+
+    auto processEvents = [&](std::string &stream)
+    {
+        size_t eventEnd;
+        while ((eventEnd = stream.find("\n\n")) != std::string::npos)
+        {
+            std::string event = stream.substr(0, eventEnd);
+            stream.erase(0, eventEnd + 2);
+
+            std::string data;
+            size_t pos = 0;
+            while (pos < event.size())
+            {
+                size_t lineEnd = event.find('\n', pos);
+                std::string line = (lineEnd == std::string::npos)
+                                       ? event.substr(pos)
+                                       : event.substr(pos, lineEnd - pos);
+                pos = (lineEnd == std::string::npos) ? event.size() : lineEnd + 1;
+                // Strip CR if present.
+                if (!line.empty() && line.back() == '\r') line.pop_back();
+                if (line.empty() || line[0] == ':') continue; // blank or comment
+                if (line.compare(0, 5, "data:") == 0)
                 {
-                    ParamOverride po;
-                    po.name  = p.value("name", std::string{});
-                    po.value = p.value("value", 0.0f);
-                    if (!po.name.empty())
-                    {
-                        out.parameters.push_back(std::move(po));
-                    }
+                    std::string d = line.substr(5);
+                    if (!d.empty() && d.front() == ' ') d.erase(0, 1);
+                    if (!data.empty()) data += '\n';
+                    data += d;
+                }
+                // Other SSE fields (event:, id:, retry:) are ignored.
+            }
+
+            if (!data.empty())
+            {
+                Snapshot snap;
+                if (parseSnapshotJSON(data, snap))
+                {
+                    dispatchIfChanged(snap);
                 }
             }
         }
+    };
 
-        if (j.contains("source") && j["source"].is_object())
-        {
-            const auto &s = j["source"];
-            out.sourceWidth  = s.value("width",  0u);
-            out.sourceHeight = s.value("height", 0u);
-            out.sourceFps    = s.value("fps",    0u);
-        }
+    processEvents(body);
 
-        if (j.contains("image") && j["image"].is_object())
-        {
-            const auto &im = j["image"];
-            out.imageBrightness = im.value("brightness", 1.0f);
-            out.imageContrast   = im.value("contrast",   1.0f);
-        }
-
-        return true;
-    }
-    catch (const std::exception &e)
+    while (m_running.load())
     {
-        LOG_WARN(std::string("RemoteMetaSync: JSON parse failed — ") + e.what());
-        return false;
+        int n = ::recv(sock, chunk, sizeof(chunk), 0);
+        if (n <= 0) break;
+        body.append(chunk, static_cast<size_t>(n));
+        if (body.size() > 256 * 1024)
+        {
+            // Sanity cap. Drop anything before the last complete event boundary.
+            size_t lastSep = body.rfind("\n\n");
+            body = (lastSep == std::string::npos) ? std::string{} : body.substr(lastSep + 2);
+        }
+        processEvents(body);
     }
+
+    closeSocket(sock);
+    return true;
 }
 
 void RemoteMetaSync::pollLoop()
 {
+    // SSE-first strategy: try the long-poll, fall back to short-poll when
+    // the server doesn't speak event-stream. Reconnect with backoff on
+    // either failure mode.
+    int sseFailureStreak = 0;
     while (m_running.load())
     {
-        Snapshot snap;
-        if (fetchOnce(snap))
+        if (runSSE())
         {
-            // Build a value vector for the parameter dedup check.
-            std::vector<float> currentValues;
-            currentValues.reserve(snap.parameters.size());
-            for (const auto &p : snap.parameters)
+            // Stream ended — assume transient (network blip, server
+            // restart). Reconnect after a short pause.
+            sseFailureStreak = 0;
+        }
+        else
+        {
+            // SSE not supported / connect failure / parse error.
+            sseFailureStreak++;
+            if (sseFailureStreak == 1)
             {
-                currentValues.push_back(p.value);
+                LOG_INFO("RemoteMetaSync: SSE unavailable, falling back to short-poll");
             }
-
-            const bool presetChanged  = (snap.preset     != m_lastPreset);
-            const bool hashChanged    = (snap.presetHash != m_lastPresetHash);
-            const bool toggleChanged  = (snap.pipelineEnabled != m_lastPipelineEnabled);
-            const bool paramsChanged  = (currentValues != m_lastParamValues);
-
-            if (presetChanged || hashChanged || toggleChanged || paramsChanged)
+            // One short-poll round to keep deltas flowing.
+            Snapshot snap;
+            if (fetchOnce(snap))
             {
-                if (m_cb) m_cb(snap);
-                m_lastPreset          = snap.preset;
-                m_lastPresetHash      = snap.presetHash;
-                m_lastPipelineEnabled = snap.pipelineEnabled;
-                m_lastParamValues     = std::move(currentValues);
+                dispatchIfChanged(snap);
             }
         }
 
-        // Sleep in 100 ms slices so stop() is responsive without resorting
-        // to condition variables for this very-low-rate poller.
-        int remaining = m_pollIntervalMs;
+        // Reconnect / re-poll cadence: shorter for SSE retries (likely
+        // transient), longer for failing short-polls (likely peer down).
+        const int sleepMs = (sseFailureStreak > 3) ? m_pollIntervalMs : 500;
+        int remaining = sleepMs;
         while (remaining > 0 && m_running.load())
         {
             const int slice = std::min(remaining, 100);

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -286,14 +286,27 @@ void RemoteMetaSync::dispatchIfChanged(const Snapshot &snap)
     const bool hashChanged    = (snap.presetHash       != m_lastPresetHash);
     const bool toggleChanged  = (snap.pipelineEnabled  != m_lastPipelineEnabled);
     const bool paramsChanged  = (currentValues         != m_lastParamValues);
+    // Source resolution/fps must participate in the delta check, otherwise
+    // a host that switches capture resolution (e.g. 1920x1080 → 1280x720)
+    // never wakes the client up — the new dimensions live in every /meta
+    // payload but match preset/hash/params from before, so the snapshot
+    // gets dropped here and the client keeps allocating textures at the
+    // old size. Treat any change in source dims/fps as a delta worth
+    // dispatching so applyPendingRemoteMeta() can resize the capture.
+    const bool sourceChanged  = (snap.sourceWidth      != m_lastSourceWidth)  ||
+                                (snap.sourceHeight     != m_lastSourceHeight) ||
+                                (snap.sourceFps        != m_lastSourceFps);
 
-    if (presetChanged || hashChanged || toggleChanged || paramsChanged)
+    if (presetChanged || hashChanged || toggleChanged || paramsChanged || sourceChanged)
     {
         if (m_cb) m_cb(snap);
         m_lastPreset          = snap.preset;
         m_lastPresetHash      = snap.presetHash;
         m_lastPipelineEnabled = snap.pipelineEnabled;
         m_lastParamValues     = std::move(currentValues);
+        m_lastSourceWidth     = snap.sourceWidth;
+        m_lastSourceHeight    = snap.sourceHeight;
+        m_lastSourceFps       = snap.sourceFps;
     }
 }
 

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -202,8 +202,11 @@ namespace
             if (j.contains("image") && j["image"].is_object())
             {
                 const auto &im = j["image"];
-                out.imageBrightness = im.value("brightness", 1.0f);
-                out.imageContrast   = im.value("contrast",   1.0f);
+                out.imageBrightness     = im.value("brightness", 1.0f);
+                out.imageContrast       = im.value("contrast",   1.0f);
+                out.imageMaintainAspect = im.value("maintainAspect", true);
+                out.imageOutputWidth    = im.value("outputWidth",  0u);
+                out.imageOutputHeight   = im.value("outputHeight", 0u);
             }
             return true;
         }

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -1,0 +1,301 @@
+#include "RemoteMetaSync.h"
+#include "../utils/Logger.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+#ifdef _WIN32
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+  using socket_t = SOCKET;
+  static constexpr socket_t INVALID_SOCK = INVALID_SOCKET;
+  static int closeSocket(socket_t s) { return ::closesocket(s); }
+#else
+  #include <sys/socket.h>
+  #include <netdb.h>
+  #include <netinet/in.h>
+  #include <arpa/inet.h>
+  #include <unistd.h>
+  using socket_t = int;
+  static constexpr socket_t INVALID_SOCK = -1;
+  static int closeSocket(socket_t s) { return ::close(s); }
+#endif
+
+namespace
+{
+    struct UrlParts
+    {
+        std::string host;
+        std::string port;
+        std::string path;
+    };
+
+    // Minimal http:// parser — strict enough for /meta polling, not a
+    // general-purpose URL library. Recognises "http://<host>[:<port>][<path>]".
+    bool parseHttpUrl(const std::string &url, UrlParts &out)
+    {
+        constexpr const char *prefix = "http://";
+        if (url.compare(0, 7, prefix) != 0) return false;
+
+        std::string rest = url.substr(7);
+        size_t pathStart = rest.find('/');
+        std::string hostPort = (pathStart == std::string::npos) ? rest : rest.substr(0, pathStart);
+        out.path = (pathStart == std::string::npos) ? "/" : rest.substr(pathStart);
+
+        size_t colon = hostPort.find(':');
+        if (colon == std::string::npos)
+        {
+            out.host = hostPort;
+            out.port = "80";
+        }
+        else
+        {
+            out.host = hostPort.substr(0, colon);
+            out.port = hostPort.substr(colon + 1);
+        }
+        return !out.host.empty();
+    }
+
+    // Synchronous HTTP/1.1 GET with a 5-second receive deadline. Returns
+    // the response body on 2xx, empty string otherwise. Logs errors but
+    // doesn't throw — callers treat empty as "skip this poll".
+    std::string httpGet(const std::string &fullUrl)
+    {
+        UrlParts u;
+        if (!parseHttpUrl(fullUrl, u))
+        {
+            LOG_WARN("RemoteMetaSync: malformed URL: " + fullUrl);
+            return {};
+        }
+
+        addrinfo hints{};
+        hints.ai_family   = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        addrinfo *res = nullptr;
+        if (getaddrinfo(u.host.c_str(), u.port.c_str(), &hints, &res) != 0 || !res)
+        {
+            return {};
+        }
+
+        socket_t sock = INVALID_SOCK;
+        for (addrinfo *p = res; p != nullptr; p = p->ai_next)
+        {
+            sock = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+            if (sock == INVALID_SOCK) continue;
+            if (::connect(sock, p->ai_addr, static_cast<int>(p->ai_addrlen)) == 0) break;
+            closeSocket(sock);
+            sock = INVALID_SOCK;
+        }
+        freeaddrinfo(res);
+        if (sock == INVALID_SOCK) return {};
+
+        // 5-second receive timeout so a wedged remote doesn't stall the
+        // polling thread forever.
+#ifdef _WIN32
+        DWORD tv = 5000;
+        ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&tv), sizeof(tv));
+#else
+        timeval tv{};
+        tv.tv_sec = 5;
+        ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+#endif
+
+        std::string req;
+        req.reserve(256);
+        req += "GET ";
+        req += u.path;
+        req += " HTTP/1.1\r\nHost: ";
+        req += u.host;
+        if (u.port != "80")
+        {
+            req += ':';
+            req += u.port;
+        }
+        req += "\r\nConnection: close\r\nAccept: application/json\r\n\r\n";
+
+        if (::send(sock, req.data(), static_cast<int>(req.size()), 0) < 0)
+        {
+            closeSocket(sock);
+            return {};
+        }
+
+        std::string response;
+        response.reserve(4096);
+        char buf[2048];
+        for (;;)
+        {
+            int n = ::recv(sock, buf, sizeof(buf), 0);
+            if (n <= 0) break;
+            response.append(buf, static_cast<size_t>(n));
+            if (response.size() > 256 * 1024) break; // sanity cap
+        }
+        closeSocket(sock);
+
+        // Header / body split.
+        size_t sep = response.find("\r\n\r\n");
+        if (sep == std::string::npos) return {};
+
+        // Reject non-2xx.
+        if (response.size() < 12) return {};
+        // "HTTP/1.1 200 ..."
+        const std::string statusLine = response.substr(0, response.find("\r\n"));
+        size_t firstSpace = statusLine.find(' ');
+        if (firstSpace == std::string::npos) return {};
+        int statusCode = std::atoi(statusLine.c_str() + firstSpace + 1);
+        if (statusCode < 200 || statusCode >= 300) return {};
+
+        return response.substr(sep + 4);
+    }
+}
+
+RemoteMetaSync::RemoteMetaSync() = default;
+
+RemoteMetaSync::~RemoteMetaSync()
+{
+    stop();
+}
+
+bool RemoteMetaSync::start(const std::string &baseUrl, SnapshotCallback cb, int pollIntervalMs)
+{
+    if (m_running.load())
+    {
+        LOG_WARN("RemoteMetaSync::start — already running");
+        return false;
+    }
+    if (baseUrl.empty() || !cb)
+    {
+        return false;
+    }
+    m_baseUrl = baseUrl;
+    if (!m_baseUrl.empty() && m_baseUrl.back() == '/')
+    {
+        m_baseUrl.pop_back();
+    }
+    m_cb = std::move(cb);
+    m_pollIntervalMs = std::max(250, pollIntervalMs);
+
+    m_lastPreset.clear();
+    m_lastPresetHash.clear();
+    m_lastPipelineEnabled = true;
+    m_lastParamValues.clear();
+
+    m_running.store(true);
+    m_thread = std::thread(&RemoteMetaSync::pollLoop, this);
+    LOG_INFO("RemoteMetaSync: polling " + m_baseUrl + "/meta every " +
+             std::to_string(m_pollIntervalMs) + " ms");
+    return true;
+}
+
+void RemoteMetaSync::stop()
+{
+    if (!m_running.load()) return;
+    m_running.store(false);
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+}
+
+bool RemoteMetaSync::fetchOnce(Snapshot &out)
+{
+    std::string body = httpGet(m_baseUrl + "/meta");
+    if (body.empty()) return false;
+
+    try
+    {
+        auto j = nlohmann::json::parse(body);
+        out.protocolVersion = j.value("protocolVersion", 0);
+        out.serverVersion   = j.value("serverVersion", std::string{});
+
+        if (j.contains("shader") && j["shader"].is_object())
+        {
+            const auto &s = j["shader"];
+            out.shaderActive    = s.value("active", false);
+            out.pipelineEnabled = s.value("pipelineEnabled", true);
+            out.preset          = s.value("preset", std::string{});
+            out.presetHash      = s.value("presetHash", std::string{});
+            if (s.contains("parameters") && s["parameters"].is_array())
+            {
+                out.parameters.clear();
+                out.parameters.reserve(s["parameters"].size());
+                for (const auto &p : s["parameters"])
+                {
+                    ParamOverride po;
+                    po.name  = p.value("name", std::string{});
+                    po.value = p.value("value", 0.0f);
+                    if (!po.name.empty())
+                    {
+                        out.parameters.push_back(std::move(po));
+                    }
+                }
+            }
+        }
+
+        if (j.contains("source") && j["source"].is_object())
+        {
+            const auto &s = j["source"];
+            out.sourceWidth  = s.value("width",  0u);
+            out.sourceHeight = s.value("height", 0u);
+            out.sourceFps    = s.value("fps",    0u);
+        }
+
+        if (j.contains("image") && j["image"].is_object())
+        {
+            const auto &im = j["image"];
+            out.imageBrightness = im.value("brightness", 1.0f);
+            out.imageContrast   = im.value("contrast",   1.0f);
+        }
+
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        LOG_WARN(std::string("RemoteMetaSync: JSON parse failed — ") + e.what());
+        return false;
+    }
+}
+
+void RemoteMetaSync::pollLoop()
+{
+    while (m_running.load())
+    {
+        Snapshot snap;
+        if (fetchOnce(snap))
+        {
+            // Build a value vector for the parameter dedup check.
+            std::vector<float> currentValues;
+            currentValues.reserve(snap.parameters.size());
+            for (const auto &p : snap.parameters)
+            {
+                currentValues.push_back(p.value);
+            }
+
+            const bool presetChanged  = (snap.preset     != m_lastPreset);
+            const bool hashChanged    = (snap.presetHash != m_lastPresetHash);
+            const bool toggleChanged  = (snap.pipelineEnabled != m_lastPipelineEnabled);
+            const bool paramsChanged  = (currentValues != m_lastParamValues);
+
+            if (presetChanged || hashChanged || toggleChanged || paramsChanged)
+            {
+                if (m_cb) m_cb(snap);
+                m_lastPreset          = snap.preset;
+                m_lastPresetHash      = snap.presetHash;
+                m_lastPipelineEnabled = snap.pipelineEnabled;
+                m_lastParamValues     = std::move(currentValues);
+            }
+        }
+
+        // Sleep in 100 ms slices so stop() is responsive without resorting
+        // to condition variables for this very-low-rate poller.
+        int remaining = m_pollIntervalMs;
+        while (remaining > 0 && m_running.load())
+        {
+            const int slice = std::min(remaining, 100);
+            std::this_thread::sleep_for(std::chrono::milliseconds(slice));
+            remaining -= slice;
+        }
+    }
+}

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -82,6 +82,23 @@ private:
      */
     bool fetchOnce(Snapshot &out);
 
+    /**
+     * @brief Opens an SSE long-poll on `<baseUrl>/meta` and dispatches
+     *        snapshot deltas as they arrive. Returns true if the SSE
+     *        handshake succeeded (the connection later ended cleanly or
+     *        the server closed it), false if the server does not appear
+     *        to support text/event-stream — the caller should fall back
+     *        to short-poll fetchOnce() in that case. Phase 6 of #47.
+     */
+    bool runSSE();
+
+    /**
+     * @brief Common dispatch path — emits the callback if the snapshot
+     *        differs from the last delivered one and updates the dedup
+     *        state. Called from both polling and SSE paths.
+     */
+    void dispatchIfChanged(const Snapshot &snap);
+
     std::string         m_baseUrl;
     SnapshotCallback    m_cb;
     int                 m_pollIntervalMs = 1000;

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -44,10 +44,17 @@ public:
         uint32_t                     sourceWidth     = 0;
         uint32_t                     sourceHeight    = 0;
         uint32_t                     sourceFps       = 0;
-        // image block (mirrored for client display; may also be re-applied
-        // locally depending on where /raw is tapped in Phase 2)
-        float                        imageBrightness = 1.0f;
-        float                        imageContrast   = 1.0f;
+        // image block — client uses these as seed values on the initial
+        // connect (so the viewer starts with the same brightness /
+        // aspect-ratio / output-size as the host). After the first
+        // snapshot they're informational only; the user is free to
+        // tweak the local Image tab without the next snapshot stomping
+        // them.
+        float                        imageBrightness     = 1.0f;
+        float                        imageContrast       = 1.0f;
+        bool                         imageMaintainAspect = true;
+        uint32_t                     imageOutputWidth    = 0;
+        uint32_t                     imageOutputHeight   = 0;
     };
 
     using SnapshotCallback = std::function<void(const Snapshot &)>;

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+/**
+ * @brief Polls the remote host's /meta endpoint and dispatches snapshot
+ *        deltas via a callback.
+ *
+ * Phase 4 of issue #47. Runs in a background thread, fetches /meta every
+ * `pollIntervalMs` (default ~1 s), parses the JSON snapshot defined in
+ * docs/REMOTE_STREAM_PROTOCOL.md, and invokes the registered callback
+ * whenever the host's shader / parameters change. Callback is invoked on
+ * the polling thread — receivers must marshal back to the main / GL
+ * thread if they touch GL state (ShaderEngine::loadPreset etc.).
+ *
+ * The polling cadence is a placeholder until Phase 6 wires a WebSocket
+ * upgrade on the same endpoint for sub-second deltas.
+ */
+class RemoteMetaSync
+{
+public:
+    struct ParamOverride
+    {
+        std::string name;
+        float       value = 0.0f;
+    };
+
+    struct Snapshot
+    {
+        int                          protocolVersion = 0;
+        std::string                  serverVersion;
+        // shader block
+        bool                         shaderActive    = false;
+        bool                         pipelineEnabled = true;
+        std::string                  preset;        // e.g. "crt/crt-mattias.glslp"
+        std::string                  presetHash;
+        std::vector<ParamOverride>   parameters;
+        // source block
+        uint32_t                     sourceWidth     = 0;
+        uint32_t                     sourceHeight    = 0;
+        uint32_t                     sourceFps       = 0;
+        // image block (mirrored for client display; may also be re-applied
+        // locally depending on where /raw is tapped in Phase 2)
+        float                        imageBrightness = 1.0f;
+        float                        imageContrast   = 1.0f;
+    };
+
+    using SnapshotCallback = std::function<void(const Snapshot &)>;
+
+    RemoteMetaSync();
+    ~RemoteMetaSync();
+
+    /**
+     * @brief Start polling.
+     * @param baseUrl  Remote server base URL (e.g. "http://host:8080").
+     *                 "/meta" is appended internally.
+     * @param cb       Invoked on every snapshot that differs from the last
+     *                 one we delivered. Snapshots that match (same preset,
+     *                 same hash, same parameter values) are filtered out.
+     * @param pollIntervalMs Time between polls. Clamped to >= 250 ms.
+     */
+    bool start(const std::string &baseUrl, SnapshotCallback cb, int pollIntervalMs = 1000);
+
+    /**
+     * @brief Stop the polling thread (joins).
+     */
+    void stop();
+
+    bool isRunning() const { return m_running.load(); }
+
+private:
+    void pollLoop();
+
+    /**
+     * @brief Performs a single HTTP GET against `<baseUrl>/meta` and parses
+     *        the JSON into `out`. Returns false on network / parse error.
+     */
+    bool fetchOnce(Snapshot &out);
+
+    std::string         m_baseUrl;
+    SnapshotCallback    m_cb;
+    int                 m_pollIntervalMs = 1000;
+
+    std::thread         m_thread;
+    std::atomic<bool>   m_running{false};
+
+    // Dedup state — only fire the callback when the snapshot actually
+    // changed. Compared against the new snapshot before dispatch.
+    std::string         m_lastPreset;
+    std::string         m_lastPresetHash;
+    bool                m_lastPipelineEnabled = true;
+    std::vector<float>  m_lastParamValues;
+};

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -119,4 +119,7 @@ private:
     std::string         m_lastPresetHash;
     bool                m_lastPipelineEnabled = true;
     std::vector<float>  m_lastParamValues;
+    uint32_t            m_lastSourceWidth  = 0;
+    uint32_t            m_lastSourceHeight = 0;
+    uint32_t            m_lastSourceFps    = 0;
 };

--- a/src/streaming/StreamManager.cpp
+++ b/src/streaming/StreamManager.cpp
@@ -131,6 +131,40 @@ void StreamManager::pushAudio(const int16_t *samples, size_t sampleCount)
     }
 }
 
+void StreamManager::pushRawFrame(const uint8_t *data, uint32_t width, uint32_t height)
+{
+    if (!m_active || !data)
+    {
+        return;
+    }
+
+    // The raw output is an MPEG-TS-specific concept (Phase 2 of #47); only
+    // dispatch to streamers that actually support it. Future non-TS
+    // streamers (e.g. WebRTC) won't have the raw concept and are silently
+    // skipped here.
+    for (auto &streamer : m_streamers)
+    {
+        if (!streamer->isActive()) continue;
+        if (auto *ts = dynamic_cast<HTTPTSStreamer *>(streamer.get()))
+        {
+            ts->pushRawFrame(data, width, height);
+        }
+    }
+}
+
+bool StreamManager::hasRawClients() const
+{
+    for (const auto &streamer : m_streamers)
+    {
+        if (!streamer->isActive()) continue;
+        if (auto *ts = dynamic_cast<const HTTPTSStreamer *>(streamer.get()))
+        {
+            if (ts->hasRawClients()) return true;
+        }
+    }
+    return false;
+}
+
 std::vector<std::string> StreamManager::getStreamUrls() const
 {
     std::vector<std::string> urls;

--- a/src/streaming/StreamManager.h
+++ b/src/streaming/StreamManager.h
@@ -53,6 +53,21 @@ public:
     void pushAudio(const int16_t *samples, size_t sampleCount);
 
     /**
+     * Push a pre-shader frame to the /raw output of every MPEG-TS streamer
+     * that has at least one connected /raw client. Used by Phase 2 of the
+     * shader-preserving distributed playback work (#47). Frames pushed here
+     * MUST be pre-shader; /raw's contract is shader-free by definition.
+     */
+    void pushRawFrame(const uint8_t *data, uint32_t width, uint32_t height);
+
+    /**
+     * True if at least one MPEG-TS streamer has a connected /raw client.
+     * Application uses this to gate pushRawFrame calls (lazy encoding —
+     * no need to push pre-shader frames if nothing is listening).
+     */
+    bool hasRawClients() const;
+
+    /**
      * Get all stream URLs
      */
     std::vector<std::string> getStreamUrls() const;

--- a/src/ui/UIConfiguration.cpp
+++ b/src/ui/UIConfiguration.cpp
@@ -64,6 +64,25 @@ void UIConfiguration::render()
     ImGui::Begin("RetroCapture Controls", &m_visible,
                  ImGuiWindowFlags_NoSavedSettings);
 
+    // Phase 5 of #47: when this RetroCapture is acting as a remote viewer,
+    // configuration controls are mirrored from the host via /meta and must
+    // be inspected only. A coloured banner advertises the connection; the
+    // Info tab stays interactive (it's read-only by nature) while every
+    // other tab is wrapped in BeginDisabled / EndDisabled.
+    const bool remote = m_uiManager && m_uiManager->isRemoteSource();
+    if (remote)
+    {
+        const ImVec4 warningBg(0.45f, 0.12f, 0.12f, 0.85f);
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, warningBg);
+        ImGui::BeginChild("RemoteBanner", ImVec2(0, ImGui::GetFrameHeight() * 1.2f),
+                          false, ImGuiWindowFlags_NoScrollbar);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("  REMOTE VIEWER MODE — configuration mirrored from host, controls disabled");
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
+        ImGui::Spacing();
+    }
+
     // Criar instâncias das abas (podem ser membros da classe se necessário)
     static UIConfigurationSource sourceTab(m_uiManager);
     static UIConfigurationShader shaderTab(m_uiManager);
@@ -79,50 +98,66 @@ void UIConfiguration::render()
     {
         if (ImGui::BeginTabItem("Shaders"))
         {
+            ImGui::BeginDisabled(remote);
             shaderTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Image"))
         {
+            ImGui::BeginDisabled(remote);
             imageTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Source"))
         {
+            ImGui::BeginDisabled(remote);
             sourceTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Info"))
         {
+            // Info is read-only by construction — keep it interactive so
+            // users can copy / inspect even in remote mode.
             infoTab.render();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Streaming"))
         {
+            ImGui::BeginDisabled(remote);
             streamingTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Recording"))
         {
+            ImGui::BeginDisabled(remote);
             recordingTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Web Portal"))
         {
+            ImGui::BeginDisabled(remote);
             webPortalTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 
 #ifdef __linux__
         if (ImGui::BeginTabItem("Audio"))
         {
+            ImGui::BeginDisabled(remote);
             audioTab.render();
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 #endif

--- a/src/ui/UIConfiguration.cpp
+++ b/src/ui/UIConfiguration.cpp
@@ -65,11 +65,16 @@ void UIConfiguration::render()
                  ImGuiWindowFlags_NoSavedSettings);
 
     // Phase 5 of #47: when this RetroCapture is acting as a remote viewer,
-    // configuration controls are mirrored from the host via /meta and must
-    // be inspected only. A coloured banner advertises the connection; the
-    // Info tab stays interactive (it's read-only by nature) while every
-    // other tab is wrapped in BeginDisabled / EndDisabled.
-    const bool remote = m_uiManager && m_uiManager->isRemoteSource();
+    // the only configuration that makes sense for the user to touch is the
+    // Info panel (read-only inspection of the mirrored host state) and
+    // Shaders for completeness — but Source/Streaming/Recording/Web Portal/
+    // Audio belong to a producer role and don't apply to a viewer. Rather
+    // than show them disabled (visually noisy, hints at functionality the
+    // user can't have), we hide the entire tabs while connected. Disconnect
+    // brings them back. A banner explains the mode so the user isn't
+    // confused why the rest disappeared.
+    const bool remote = m_uiManager && m_uiManager->isRemoteSource() &&
+                        !m_uiManager->getCurrentDevice().empty();
     if (remote)
     {
         const ImVec4 warningBg(0.45f, 0.12f, 0.12f, 0.85f);
@@ -77,7 +82,7 @@ void UIConfiguration::render()
         ImGui::BeginChild("RemoteBanner", ImVec2(0, ImGui::GetFrameHeight() * 1.2f),
                           false, ImGuiWindowFlags_NoScrollbar);
         ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted("  REMOTE VIEWER MODE — configuration mirrored from host, controls disabled");
+        ImGui::TextUnformatted("  REMOTE VIEWER MODE — viewing a host stream. Disconnect from the 'Remote' menu to manage local capture.");
         ImGui::EndChild();
         ImGui::PopStyleColor();
         ImGui::Spacing();
@@ -96,6 +101,18 @@ void UIConfiguration::render()
     // Tabs
     if (ImGui::BeginTabBar("MainTabs"))
     {
+        // Info is always available — it's a read-only inspection panel that
+        // applies to both local capture and remote viewing.
+        if (ImGui::BeginTabItem("Info"))
+        {
+            infoTab.render();
+            ImGui::EndTabItem();
+        }
+
+        // Shaders stays visible in remote mode — the host's preset is
+        // mirrored via /meta and the user may want to inspect what's
+        // running. Disabled wrapper kept so they can't edit the values
+        // (those are owned by the host).
         if (ImGui::BeginTabItem("Shaders"))
         {
             ImGui::BeginDisabled(remote);
@@ -104,65 +121,48 @@ void UIConfiguration::render()
             ImGui::EndTabItem();
         }
 
-        if (ImGui::BeginTabItem("Image"))
+        // Everything below this point is producer-side configuration and
+        // is hidden while the local instance is acting as a remote viewer.
+        if (!remote)
         {
-            ImGui::BeginDisabled(remote);
-            imageTab.render();
-            ImGui::EndDisabled();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Image"))
+            {
+                imageTab.render();
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::BeginTabItem("Source"))
-        {
-            // Source tab is intentionally NOT wrapped in BeginDisabled(remote):
-            // the source-type dropdown + Remote URL field must stay
-            // interactive so the user can disconnect / point at a different
-            // remote without restarting RetroCapture.
-            sourceTab.render();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Source"))
+            {
+                sourceTab.render();
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::BeginTabItem("Info"))
-        {
-            // Info is read-only by construction — keep it interactive so
-            // users can copy / inspect even in remote mode.
-            infoTab.render();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Streaming"))
+            {
+                streamingTab.render();
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::BeginTabItem("Streaming"))
-        {
-            ImGui::BeginDisabled(remote);
-            streamingTab.render();
-            ImGui::EndDisabled();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Recording"))
+            {
+                recordingTab.render();
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::BeginTabItem("Recording"))
-        {
-            ImGui::BeginDisabled(remote);
-            recordingTab.render();
-            ImGui::EndDisabled();
-            ImGui::EndTabItem();
-        }
-
-        if (ImGui::BeginTabItem("Web Portal"))
-        {
-            ImGui::BeginDisabled(remote);
-            webPortalTab.render();
-            ImGui::EndDisabled();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Web Portal"))
+            {
+                webPortalTab.render();
+                ImGui::EndTabItem();
+            }
 
 #ifdef __linux__
-        if (ImGui::BeginTabItem("Audio"))
-        {
-            ImGui::BeginDisabled(remote);
-            audioTab.render();
-            ImGui::EndDisabled();
-            ImGui::EndTabItem();
-        }
+            if (ImGui::BeginTabItem("Audio"))
+            {
+                audioTab.render();
+                ImGui::EndTabItem();
+            }
 #endif
+        }
 
         ImGui::EndTabBar();
     }

--- a/src/ui/UIConfiguration.cpp
+++ b/src/ui/UIConfiguration.cpp
@@ -121,16 +121,21 @@ void UIConfiguration::render()
             ImGui::EndTabItem();
         }
 
+        // Image stays visible in remote mode too — brightness, contrast,
+        // aspect ratio, fullscreen and output resolution are display-side
+        // choices that make sense for a viewer to override. The server
+        // seeds defaults via /meta on the initial connect; after that
+        // the user is free to tweak.
+        if (ImGui::BeginTabItem("Image"))
+        {
+            imageTab.render();
+            ImGui::EndTabItem();
+        }
+
         // Everything below this point is producer-side configuration and
         // is hidden while the local instance is acting as a remote viewer.
         if (!remote)
         {
-            if (ImGui::BeginTabItem("Image"))
-            {
-                imageTab.render();
-                ImGui::EndTabItem();
-            }
-
             if (ImGui::BeginTabItem("Source"))
             {
                 sourceTab.render();

--- a/src/ui/UIConfiguration.cpp
+++ b/src/ui/UIConfiguration.cpp
@@ -114,9 +114,11 @@ void UIConfiguration::render()
 
         if (ImGui::BeginTabItem("Source"))
         {
-            ImGui::BeginDisabled(remote);
+            // Source tab is intentionally NOT wrapped in BeginDisabled(remote):
+            // the source-type dropdown + Remote URL field must stay
+            // interactive so the user can disconnect / point at a different
+            // remote without restarting RetroCapture.
             sourceTab.render();
-            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
 

--- a/src/ui/UIConfigurationShader.cpp
+++ b/src/ui/UIConfigurationShader.cpp
@@ -55,8 +55,14 @@ void UIConfigurationShader::renderShaderSelection()
 {
     ImGui::Text("Shader Preset:");
 
-    // Combo box for shader selection
+    // Combo box for shader selection + Rescan button on the same row.
+    // The Rescan action used to live in the File menu, but it's only
+    // meaningful in the context of this list — moved here so the user
+    // doesn't have to leave the Shaders tab to refresh after dropping
+    // a new .glslp into the shaders folder.
     std::string currentShader = m_uiManager->getCurrentShader();
+    float buttonWidth = ImGui::CalcTextSize("Rescan").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - buttonWidth - ImGui::GetStyle().ItemSpacing.x);
     if (ImGui::BeginCombo("##shader", currentShader.empty() ? "None" : currentShader.c_str()))
     {
         if (ImGui::Selectable("None", currentShader.empty()))
@@ -80,6 +86,15 @@ void UIConfigurationShader::renderShaderSelection()
             }
         }
         ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Rescan"))
+    {
+        m_uiManager->scanShaders("shaders/shaders_glsl");
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Re-scan the shaders folder for newly added .glslp presets.");
     }
 
     ImGui::Separator();

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -79,11 +79,11 @@ void UIConfigurationSource::renderSourceTypeSelection()
     ImGui::Separator();
     ImGui::Spacing();
 
-    // Dropdown para seleção do tipo de fonte de captura local.
-    // 'Remote' não vive mais aqui — virou o seu próprio menu top-level
-    // ('Remote → Connect to Remote...') com janela dedicada para URL +
-    // interpolação. A aba Source fica focada só nas opções de captura
-    // física da máquina.
+    // Dropdown for selecting the local capture source type.
+    // 'Remote' no longer lives here — it now has its own top-level menu
+    // ('Remote → Connect to Remote...') with a dedicated window for URL
+    // and interpolation. The Source tab focuses only on physical capture
+    // options local to the machine.
 #ifdef __linux__
     const char *sourceTypeNames[] = {"None", "V4L2"};
     UIManager::SourceType sourceTypeMap[] = {

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -3,6 +3,7 @@
 #include "../capture/IVideoCapture.h"
 #include <imgui.h>
 #include <algorithm>
+#include <cstring>
 #ifdef __linux__
 #include <linux/videodev2.h>
 #endif
@@ -40,6 +41,12 @@ void UIConfigurationSource::render()
 
     // Renderizar controles específicos da fonte selecionada
     UIManager::SourceType sourceType = m_uiManager->getSourceType();
+
+    if (sourceType == UIManager::SourceType::Remote)
+    {
+        renderRemoteControls();
+        return;
+    }
 #ifdef __linux__
     if (sourceType == UIManager::SourceType::V4L2)
     {
@@ -73,17 +80,24 @@ void UIConfigurationSource::renderSourceTypeSelection()
     ImGui::Spacing();
 
 // Dropdown para seleção do tipo de fonte
+// "Remote" lives on every platform — it's just an HTTP MPEG-TS consumer.
 #ifdef __linux__
-    const char *sourceTypeNames[] = {"None", "V4L2"};
-    // Mapeamento: índice 0 = None (0), índice 1 = V4L2 (1)
-    UIManager::SourceType sourceTypeMap[] = {UIManager::SourceType::None, UIManager::SourceType::V4L2};
+    const char *sourceTypeNames[] = {"None", "V4L2", "Remote"};
+    UIManager::SourceType sourceTypeMap[] = {
+        UIManager::SourceType::None,
+        UIManager::SourceType::V4L2,
+        UIManager::SourceType::Remote};
 #elif defined(_WIN32)
-    const char *sourceTypeNames[] = {"None", "DirectShow"};
-    // Mapeamento: índice 0 = None (0), índice 1 = MF (2)
-    UIManager::SourceType sourceTypeMap[] = {UIManager::SourceType::None, UIManager::SourceType::DS};
+    const char *sourceTypeNames[] = {"None", "DirectShow", "Remote"};
+    UIManager::SourceType sourceTypeMap[] = {
+        UIManager::SourceType::None,
+        UIManager::SourceType::DS,
+        UIManager::SourceType::Remote};
 #else
-    const char *sourceTypeNames[] = {"None"};
-    UIManager::SourceType sourceTypeMap[] = {UIManager::SourceType::None};
+    const char *sourceTypeNames[] = {"None", "Remote"};
+    UIManager::SourceType sourceTypeMap[] = {
+        UIManager::SourceType::None,
+        UIManager::SourceType::Remote};
 #endif
 
     // Encontrar índice atual baseado no SourceType
@@ -673,5 +687,77 @@ void UIConfigurationSource::renderQuickResolutions()
     if (ImGui::Button("3840x2160"))
     {
         m_uiManager->triggerResolutionChange(3840, 2160);
+    }
+}
+
+void UIConfigurationSource::renderRemoteControls()
+{
+    // Seed the input buffer from the current device path (which doubles as
+    // the remote URL for Remote source) the first time we render. Without
+    // this the field appears empty even if --remote-url was used.
+    if (m_remoteUrlBuffer[0] == 0)
+    {
+        std::string current = m_uiManager->getCurrentDevice();
+        if (current.empty()) current = "http://localhost:8080";
+        std::strncpy(m_remoteUrlBuffer, current.c_str(), sizeof(m_remoteUrlBuffer) - 1);
+        m_remoteUrlBuffer[sizeof(m_remoteUrlBuffer) - 1] = '\0';
+    }
+
+    ImGui::TextWrapped(
+        "Consume a remote RetroCapture stream. The client decodes the host's "
+        "/raw feed and mirrors its shader pipeline via /meta. See #47.");
+    ImGui::Spacing();
+
+    ImGui::Text("Remote base URL");
+    ImGui::SetNextItemWidth(-100.0f);
+    ImGui::InputText("##remoteUrl", m_remoteUrlBuffer, sizeof(m_remoteUrlBuffer));
+    ImGui::SameLine();
+
+    const std::string currentDevice = m_uiManager->getCurrentDevice();
+    const bool connected = !currentDevice.empty() &&
+                           (m_capture && m_capture->isOpen());
+
+    if (!connected)
+    {
+        if (ImGui::Button("Connect"))
+        {
+            std::string url(m_remoteUrlBuffer);
+            // Strip a trailing slash so the appended /raw and /meta land
+            // cleanly down in VideoCaptureRemote / RemoteMetaSync.
+            while (!url.empty() && url.back() == '/') url.pop_back();
+            if (!url.empty())
+            {
+                // setCurrentDevice fires m_onDeviceChanged, which is
+                // Application's connect-to-remote handler.
+                m_uiManager->setCurrentDevice(url);
+            }
+        }
+    }
+    else
+    {
+        if (ImGui::Button("Disconnect"))
+        {
+            m_uiManager->setCurrentDevice("");
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("connected to %s", currentDevice.c_str());
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    ImGui::TextDisabled("Status");
+    if (m_capture && m_capture->isOpen())
+    {
+        ImGui::Text(" Stream:  %ux%u",
+                    static_cast<unsigned>(m_capture->getWidth()),
+                    static_cast<unsigned>(m_capture->getHeight()));
+    }
+    else
+    {
+        ImGui::TextWrapped(
+            " Not connected. Enter the host's base URL (e.g. "
+            "http://localhost:8080) and click Connect.");
     }
 }

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -747,6 +747,40 @@ void UIConfigurationSource::renderRemoteControls()
     ImGui::Separator();
     ImGui::Spacing();
 
+    // Display-side interpolation strategy. Independent of stream rate;
+    // the server can be at 60 fps and the client can pick how to fill
+    // the panel's refresh slots between consecutive stream frames.
+    ImGui::TextDisabled("Display interpolation");
+    const char *modes[]      = {"linear", "nearest", "off"};
+    const char *modeLabels[] = {
+        "Linear (smooth, slight ghosting)",
+        "Nearest (clean frames, may stutter)",
+        "Off (strict PTS, may stutter)"
+    };
+    std::string currentMode = m_uiManager->getRemoteInterpolation();
+    int currentModeIndex = 0;
+    for (int i = 0; i < 3; ++i)
+    {
+        if (currentMode == modes[i]) { currentModeIndex = i; break; }
+    }
+    ImGui::SetNextItemWidth(-100.0f);
+    if (ImGui::Combo("##remoteInterp", &currentModeIndex, modeLabels, 3))
+    {
+        m_uiManager->triggerRemoteInterpolationChange(modes[currentModeIndex]);
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Como o client preenche os refreshes do display entre frames do stream:\n"
+                          "Linear: blend prev+next por refresh — movimento contínuo, fantasma leve em movimentos rápidos.\n"
+                          "Nearest: mostra o frame mais próximo no tempo — imagem limpa, mas tem o padrão 3:2 pulldown\n"
+                          "  em qualquer ratio não-inteiro (e.g. 60fps em 144Hz).\n"
+                          "Off: estritamente espera o target do PTS — comportamento mais simples, menor latência.");
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
     ImGui::TextDisabled("Status");
     if (m_capture && m_capture->isOpen())
     {

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -79,25 +79,25 @@ void UIConfigurationSource::renderSourceTypeSelection()
     ImGui::Separator();
     ImGui::Spacing();
 
-// Dropdown para seleção do tipo de fonte
-// "Remote" lives on every platform — it's just an HTTP MPEG-TS consumer.
+    // Dropdown para seleção do tipo de fonte de captura local.
+    // 'Remote' não vive mais aqui — virou o seu próprio menu top-level
+    // ('Remote → Connect to Remote...') com janela dedicada para URL +
+    // interpolação. A aba Source fica focada só nas opções de captura
+    // física da máquina.
 #ifdef __linux__
-    const char *sourceTypeNames[] = {"None", "V4L2", "Remote"};
+    const char *sourceTypeNames[] = {"None", "V4L2"};
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
-        UIManager::SourceType::V4L2,
-        UIManager::SourceType::Remote};
+        UIManager::SourceType::V4L2};
 #elif defined(_WIN32)
-    const char *sourceTypeNames[] = {"None", "DirectShow", "Remote"};
+    const char *sourceTypeNames[] = {"None", "DirectShow"};
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
-        UIManager::SourceType::DS,
-        UIManager::SourceType::Remote};
+        UIManager::SourceType::DS};
 #else
-    const char *sourceTypeNames[] = {"None", "Remote"};
+    const char *sourceTypeNames[] = {"None"};
     UIManager::SourceType sourceTypeMap[] = {
-        UIManager::SourceType::None,
-        UIManager::SourceType::Remote};
+        UIManager::SourceType::None};
 #endif
 
     // Encontrar índice atual baseado no SourceType
@@ -692,106 +692,22 @@ void UIConfigurationSource::renderQuickResolutions()
 
 void UIConfigurationSource::renderRemoteControls()
 {
-    // Seed the input buffer from the current device path (which doubles as
-    // the remote URL for Remote source) the first time we render. Without
-    // this the field appears empty even if --remote-url was used.
-    if (m_remoteUrlBuffer[0] == 0)
-    {
-        std::string current = m_uiManager->getCurrentDevice();
-        if (current.empty()) current = "http://localhost:8080";
-        std::strncpy(m_remoteUrlBuffer, current.c_str(), sizeof(m_remoteUrlBuffer) - 1);
-        m_remoteUrlBuffer[sizeof(m_remoteUrlBuffer) - 1] = '\0';
-    }
-
+    // Remote-mode controls moved out of the Source tab into a dedicated
+    // top-level menu entry ('Remote → Connect to Remote...'). This stub
+    // just points the user at the new location when they land here with
+    // a Remote source already loaded from config.
     ImGui::TextWrapped(
-        "Consume a remote RetroCapture stream. The client decodes the host's "
-        "/raw feed and mirrors its shader pipeline via /meta. See #47.");
+        "Remote viewer mode — connection controls moved to the 'Remote' menu. "
+        "Use 'Remote → Connect to Remote...' to manage URL, interpolation and "
+        "the connect/disconnect actions.");
     ImGui::Spacing();
-
-    ImGui::Text("Remote base URL");
-    ImGui::SetNextItemWidth(-100.0f);
-    ImGui::InputText("##remoteUrl", m_remoteUrlBuffer, sizeof(m_remoteUrlBuffer));
-    ImGui::SameLine();
-
     const std::string currentDevice = m_uiManager->getCurrentDevice();
-    const bool connected = !currentDevice.empty() &&
-                           (m_capture && m_capture->isOpen());
-
-    if (!connected)
+    if (!currentDevice.empty())
     {
-        if (ImGui::Button("Connect"))
-        {
-            std::string url(m_remoteUrlBuffer);
-            // Strip a trailing slash so the appended /raw and /meta land
-            // cleanly down in VideoCaptureRemote / RemoteMetaSync.
-            while (!url.empty() && url.back() == '/') url.pop_back();
-            if (!url.empty())
-            {
-                // setCurrentDevice fires m_onDeviceChanged, which is
-                // Application's connect-to-remote handler.
-                m_uiManager->setCurrentDevice(url);
-            }
-        }
-    }
-    else
-    {
-        if (ImGui::Button("Disconnect"))
-        {
-            m_uiManager->setCurrentDevice("");
-        }
-        ImGui::SameLine();
         ImGui::TextDisabled("connected to %s", currentDevice.c_str());
     }
-
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    // Display-side interpolation strategy. Independent of stream rate;
-    // the server can be at 60 fps and the client can pick how to fill
-    // the panel's refresh slots between consecutive stream frames.
-    ImGui::TextDisabled("Display interpolation");
-    const char *modes[]      = {"linear", "nearest", "off"};
-    const char *modeLabels[] = {
-        "Linear (smooth, slight ghosting)",
-        "Nearest (clean frames, may stutter)",
-        "Off (strict PTS, may stutter)"
-    };
-    std::string currentMode = m_uiManager->getRemoteInterpolation();
-    int currentModeIndex = 0;
-    for (int i = 0; i < 3; ++i)
-    {
-        if (currentMode == modes[i]) { currentModeIndex = i; break; }
-    }
-    ImGui::SetNextItemWidth(-100.0f);
-    if (ImGui::Combo("##remoteInterp", &currentModeIndex, modeLabels, 3))
-    {
-        m_uiManager->triggerRemoteInterpolationChange(modes[currentModeIndex]);
-    }
-    if (ImGui::IsItemHovered())
-    {
-        ImGui::SetTooltip("Como o client preenche os refreshes do display entre frames do stream:\n"
-                          "Linear: blend prev+next por refresh — movimento contínuo, fantasma leve em movimentos rápidos.\n"
-                          "Nearest: mostra o frame mais próximo no tempo — imagem limpa, mas tem o padrão 3:2 pulldown\n"
-                          "  em qualquer ratio não-inteiro (e.g. 60fps em 144Hz).\n"
-                          "Off: estritamente espera o target do PTS — comportamento mais simples, menor latência.");
-    }
-
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    ImGui::TextDisabled("Status");
-    if (m_capture && m_capture->isOpen())
-    {
-        ImGui::Text(" Stream:  %ux%u",
-                    static_cast<unsigned>(m_capture->getWidth()),
-                    static_cast<unsigned>(m_capture->getHeight()));
-    }
     else
     {
-        ImGui::TextWrapped(
-            " Not connected. Enter the host's base URL (e.g. "
-            "http://localhost:8080) and click Connect.");
+        ImGui::TextDisabled("not connected");
     }
 }

--- a/src/ui/UIConfigurationSource.h
+++ b/src/ui/UIConfigurationSource.h
@@ -33,4 +33,13 @@ private:
     void renderCaptureSettings();
     void renderQuickResolutions();
     void renderQuickFPS();
+    // Phase 6+/#47 polish: UI surface for the Remote source — base URL
+    // text input + Connect / Disconnect buttons that drive the existing
+    // OnDeviceChanged callback flow in Application.
+    void renderRemoteControls();
+
+    // Persistent buffer for the URL ImGui input. Static-on-stack inside
+    // render() would lose the typed value across re-renders, so keep it
+    // here.
+    char m_remoteUrlBuffer[256] = {0};
 };

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -344,6 +344,67 @@ void UIConfigurationStreaming::renderCodecSettings()
                               "podem falhar em runtime se driver/permissão estiverem ausentes — caso\n"
                               "isso aconteça, o stream volta a libx264 automaticamente.");
         }
+
+        // Backend-specific quality / rate-control combo. libx264 keeps
+        // its existing "Qualidade H.264" dropdown rendered below;
+        // hardware backends each expose the parameter that matters most
+        // for them. Auto is treated as software-fallback for UX purposes
+        // — the actual backend is resolved at codec-open time anyway.
+        MediaEncoder::HardwareEncoder activeHw = options[currentIndex];
+        auto renderEnumCombo = [&](const char *label, const char *const *items, int itemCount,
+                                   const std::string &currentValue,
+                                   std::function<void(const std::string &)> onChange,
+                                   const char *tooltip)
+        {
+            int idx = 0;
+            for (int i = 0; i < itemCount; ++i)
+            {
+                if (currentValue == items[i]) { idx = i; break; }
+            }
+            if (ImGui::Combo(label, &idx, items, itemCount))
+            {
+                onChange(items[idx]);
+            }
+            if (tooltip && ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("%s", tooltip);
+            }
+        };
+
+        if (activeHw == MediaEncoder::HardwareEncoder::NVENC)
+        {
+            static const char *items[] = {"p1", "p2", "p3", "p4", "p5", "p6", "p7"};
+            renderEnumCombo("Preset NVENC", items, 7, m_uiManager->getStreamingNvencPreset(),
+                            [this](const std::string &v) { m_uiManager->triggerStreamingNvencPresetChange(v); },
+                            "p1 = fastest (qualidade mais baixa) ... p7 = slowest (melhor qualidade).\n"
+                            "p4 é o equilíbrio recomendado para streaming em tempo real.");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::VAAPI)
+        {
+            static const char *items[] = {"CBR", "VBR", "CQP"};
+            renderEnumCombo("Rate Control VAAPI", items, 3, m_uiManager->getStreamingVaapiRcMode(),
+                            [this](const std::string &v) { m_uiManager->triggerStreamingVaapiRcModeChange(v); },
+                            "CBR = bitrate constante (recomendado para streaming).\n"
+                            "VBR = bitrate variável (melhor pra gravação).\n"
+                            "CQP = qualidade fixa (ignora bitrate, qualidade constante).");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::QSV)
+        {
+            static const char *items[] = {"veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow"};
+            renderEnumCombo("Preset QSV", items, 7, m_uiManager->getStreamingQsvPreset(),
+                            [this](const std::string &v) { m_uiManager->triggerStreamingQsvPresetChange(v); },
+                            "Presets do Intel Quick Sync. Mais rápido = menos qualidade.\n"
+                            "veryfast/faster são recomendados pra tempo real.");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::AMF)
+        {
+            static const char *items[] = {"speed", "balanced", "quality"};
+            renderEnumCombo("Qualidade AMF", items, 3, m_uiManager->getStreamingAmfQuality(),
+                            [this](const std::string &v) { m_uiManager->triggerStreamingAmfQualityChange(v); },
+                            "speed = mínima latência, qualidade básica.\n"
+                            "balanced = meio termo.\n"
+                            "quality = melhor visual, latência maior.");
+        }
     }
 
     // Seleção de codec de áudio

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -1,6 +1,7 @@
 #include "UIConfigurationStreaming.h"
 #include "UIManager.h"
 #include "../utils/Logger.h"
+#include "../encoding/MediaEncoder.h"
 #include <imgui.h>
 #include <algorithm>
 
@@ -305,6 +306,44 @@ void UIConfigurationStreaming::renderCodecSettings()
     if (ImGui::Combo("Codec de Vídeo", &currentVideoCodecIndex, videoCodecs, 4))
     {
         m_uiManager->triggerStreamingVideoCodecChange(videoCodecs[currentVideoCodecIndex]);
+    }
+
+    // Hardware encoder dropdown — populated from what ffmpeg was built
+    // with on this host. Auto always present; Software always present;
+    // the hardware backends only show up when the corresponding codec
+    // (h264_nvenc, h264_vaapi, …) is compiled into the linked ffmpeg.
+    // Only relevant for H.264 — the other codecs in this project go
+    // through their software encoders exclusively.
+    if (currentVideoCodec == "h264")
+    {
+        std::vector<MediaEncoder::HardwareEncoder> available = MediaEncoder::detectAvailableEncoders();
+        // Prepend Auto so the user can let the app pick.
+        std::vector<MediaEncoder::HardwareEncoder> options;
+        options.push_back(MediaEncoder::HardwareEncoder::Auto);
+        for (auto h : available) options.push_back(h);
+
+        std::vector<const char *> labels;
+        labels.reserve(options.size());
+        for (auto h : options) labels.push_back(MediaEncoder::hardwareEncoderName(h));
+
+        int current = m_uiManager->getStreamingHardwareEncoder();
+        int currentIndex = 0;
+        for (size_t i = 0; i < options.size(); ++i)
+        {
+            if (static_cast<int>(options[i]) == current) { currentIndex = static_cast<int>(i); break; }
+        }
+        if (ImGui::Combo("Encoder", &currentIndex, labels.data(), static_cast<int>(labels.size())))
+        {
+            m_uiManager->triggerStreamingHardwareEncoderChange(static_cast<int>(options[currentIndex]));
+        }
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("Auto = tenta hardware (NVENC/VAAPI/QSV/AMF) e cai pra software se falhar.\n"
+                              "Software = libx264 garantido em qualquer máquina.\n"
+                              "Backends de hardware só aparecem se o ffmpeg foi compilado com suporte e\n"
+                              "podem falhar em runtime se driver/permissão estiverem ausentes — caso\n"
+                              "isso aconteça, o stream volta a libx264 automaticamente.");
+        }
     }
 
     // Seleção de codec de áudio

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -312,9 +312,9 @@ void UIConfigurationStreaming::renderCodecSettings()
     // with on this host. Auto always present; Software always present;
     // the hardware backends only show up when the corresponding codec
     // (h264_nvenc, h264_vaapi, …) is compiled into the linked ffmpeg.
-    // Only relevant for H.264 — the other codecs in this project go
-    // through their software encoders exclusively.
-    if (currentVideoCodec == "h264")
+    // Relevant for both H.264 and H.265 — the other codecs in this
+    // project (vp8/vp9) have no hardware equivalents we support.
+    if (currentVideoCodec == "h264" || currentVideoCodec == "h265" || currentVideoCodec == "hevc")
     {
         std::vector<MediaEncoder::HardwareEncoder> available = MediaEncoder::detectAvailableEncoders();
         // Prepend Auto so the user can let the app pick.

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -1,6 +1,7 @@
 #include "UIManager.h"
 #include "UIConfiguration.h"
 #include "UICredits.h"
+#include "UIRemoteConnection.h"
 #include "UICapturePresets.h"
 #include "UIRecordings.h"
 #include "../recording/RecordingProfileManager.h"
@@ -148,6 +149,7 @@ bool UIManager::init(void *window)
     m_creditsWindow = std::make_unique<UICredits>(this);
     m_capturePresetsWindow = std::make_unique<UICapturePresets>(this);
     m_recordingsWindow = std::make_unique<UIRecordings>(this);
+    m_remoteConnectionWindow = std::make_unique<UIRemoteConnection>(this);
     m_recordingProfileManager = std::make_unique<RecordingProfileManager>();
     m_streamingProfileManager = std::make_unique<StreamingProfileManager>();
     m_configWindow->setVisible(true);
@@ -335,6 +337,22 @@ void UIManager::render()
             }
             ImGui::EndMenu();
         }
+        if (ImGui::BeginMenu("Remote"))
+        {
+            const bool connected = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
+            if (ImGui::MenuItem("Connect to Remote...", nullptr, false, !connected))
+            {
+                if (m_remoteConnectionWindow)
+                {
+                    m_remoteConnectionWindow->setVisible(true);
+                }
+            }
+            if (ImGui::MenuItem("Disconnect", nullptr, false, connected))
+            {
+                setCurrentDevice("");
+            }
+            ImGui::EndMenu();
+        }
         if (ImGui::BeginMenu("Help"))
         {
             if (m_creditsWindow)
@@ -360,6 +378,12 @@ void UIManager::render()
     if (m_creditsWindow)
     {
         m_creditsWindow->render();
+    }
+
+    // Renderizar janela de conexão remota
+    if (m_remoteConnectionWindow)
+    {
+        m_remoteConnectionWindow->render();
     }
 
     // Renderizar janela de presets

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -339,6 +339,10 @@ void UIManager::render()
         }
         if (ImGui::BeginMenu("Remote"))
         {
+            // Only a Remote-mode source with a non-empty device path counts
+            // as 'connected' for this menu — a V4L2 capture would also have
+            // a non-empty m_currentDevice (its /dev/videoN path) but isn't
+            // a remote viewer connection.
             const bool connected = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
             if (ImGui::MenuItem("Connect to Remote...", nullptr, false, !connected))
             {

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -1979,6 +1979,13 @@ void UIManager::triggerStreamingAmfQualityChange(const std::string &v)
     saveConfig();
 }
 
+void UIManager::triggerRemoteInterpolationChange(const std::string &v)
+{
+    m_remoteInterpolation = v;
+    if (m_onRemoteInterpolationChanged) m_onRemoteInterpolationChanged(v);
+    saveConfig();
+}
+
 void UIManager::triggerStreamingMaxVideoBufferSizeChange(size_t size)
 {
     m_streamingMaxVideoBufferSize = size;
@@ -2214,6 +2221,8 @@ void UIManager::loadConfig()
                 m_streamingQsvPreset = streaming["qsvPreset"].get<std::string>();
             if (streaming.contains("amfQuality"))
                 m_streamingAmfQuality = streaming["amfQuality"].get<std::string>();
+            if (streaming.contains("remoteInterpolation"))
+                m_remoteInterpolation = streaming["remoteInterpolation"].get<std::string>();
 
             // Carregar configurações de buffer
             if (streaming.contains("buffer"))
@@ -2579,6 +2588,7 @@ void UIManager::saveConfig()
             {"vaapiRcMode", m_streamingVaapiRcMode},
             {"qsvPreset",   m_streamingQsvPreset},
             {"amfQuality",  m_streamingAmfQuality},
+            {"remoteInterpolation", m_remoteInterpolation},
             {"applyShader", m_streamingApplyShader},
             {"buffer", {{"maxVideoBufferSize", m_streamingMaxVideoBufferSize}, {"maxAudioBufferSize", m_streamingMaxAudioBufferSize}, {"maxBufferTimeSeconds", m_streamingMaxBufferTimeSeconds}, {"avioBufferSize", m_streamingAVIOBufferSize}}}};
 

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -285,11 +285,8 @@ void UIManager::render()
     {
         if (ImGui::BeginMenu("File"))
         {
-            if (ImGui::MenuItem("Rescan Shaders"))
-            {
-                scanShaders(m_shaderBasePath);
-            }
-            ImGui::Separator();
+            // 'Rescan Shaders' moved next to the Shader dropdown in the
+            // Shaders tab — that's where the list it refreshes lives.
             if (ImGui::MenuItem("Exit", "Esc"))
             {
                 if (m_window)
@@ -349,18 +346,20 @@ void UIManager::render()
         }
         if (ImGui::BeginMenu("Remote"))
         {
-            // Only a Remote-mode source with a non-empty device path counts
-            // as 'connected' for this menu — a V4L2 capture would also have
-            // a non-empty m_currentDevice (its /dev/videoN path) but isn't
-            // a remote viewer connection.
-            const bool connected = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
-            if (ImGui::MenuItem("Connect to Remote...", nullptr, false, !connected))
+            // 'Connect to Remote...' is always enabled — the window shows
+            // either Connect or Disconnect based on the current state, so
+            // it doubles as a status / management panel. Disabling the
+            // menu item while connected made the window unreachable once
+            // closed, which forced users into restart-to-recover.
+            if (ImGui::MenuItem("Connect to Remote..."))
             {
                 if (m_remoteConnectionWindow)
                 {
                     m_remoteConnectionWindow->setVisible(true);
                 }
             }
+            // Quick Disconnect shortcut — only shown when relevant.
+            const bool connected = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
             if (ImGui::MenuItem("Disconnect", nullptr, false, connected))
             {
                 setCurrentDevice("");

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -1951,6 +1951,34 @@ void UIManager::triggerStreamingHardwareEncoderChange(int v)
     saveConfig();
 }
 
+void UIManager::triggerStreamingNvencPresetChange(const std::string &v)
+{
+    m_streamingNvencPreset = v;
+    if (m_onStreamingNvencPresetChanged) m_onStreamingNvencPresetChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerStreamingVaapiRcModeChange(const std::string &v)
+{
+    m_streamingVaapiRcMode = v;
+    if (m_onStreamingVaapiRcModeChanged) m_onStreamingVaapiRcModeChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerStreamingQsvPresetChange(const std::string &v)
+{
+    m_streamingQsvPreset = v;
+    if (m_onStreamingQsvPresetChanged) m_onStreamingQsvPresetChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerStreamingAmfQualityChange(const std::string &v)
+{
+    m_streamingAmfQuality = v;
+    if (m_onStreamingAmfQualityChanged) m_onStreamingAmfQualityChanged(v);
+    saveConfig();
+}
+
 void UIManager::triggerStreamingMaxVideoBufferSizeChange(size_t size)
 {
     m_streamingMaxVideoBufferSize = size;
@@ -2178,6 +2206,14 @@ void UIManager::loadConfig()
                 m_streamingVP9Speed = streaming["vp9Speed"].get<int>();
             if (streaming.contains("hardwareEncoder"))
                 m_streamingHardwareEncoder = streaming["hardwareEncoder"].get<int>();
+            if (streaming.contains("nvencPreset"))
+                m_streamingNvencPreset = streaming["nvencPreset"].get<std::string>();
+            if (streaming.contains("vaapiRcMode"))
+                m_streamingVaapiRcMode = streaming["vaapiRcMode"].get<std::string>();
+            if (streaming.contains("qsvPreset"))
+                m_streamingQsvPreset = streaming["qsvPreset"].get<std::string>();
+            if (streaming.contains("amfQuality"))
+                m_streamingAmfQuality = streaming["amfQuality"].get<std::string>();
 
             // Carregar configurações de buffer
             if (streaming.contains("buffer"))
@@ -2539,6 +2575,10 @@ void UIManager::saveConfig()
             {"vp8Speed", m_streamingVP8Speed},
             {"vp9Speed", m_streamingVP9Speed},
             {"hardwareEncoder", m_streamingHardwareEncoder},
+            {"nvencPreset", m_streamingNvencPreset},
+            {"vaapiRcMode", m_streamingVaapiRcMode},
+            {"qsvPreset",   m_streamingQsvPreset},
+            {"amfQuality",  m_streamingAmfQuality},
             {"applyShader", m_streamingApplyShader},
             {"buffer", {{"maxVideoBufferSize", m_streamingMaxVideoBufferSize}, {"maxAudioBufferSize", m_streamingMaxAudioBufferSize}, {"maxBufferTimeSeconds", m_streamingMaxBufferTimeSeconds}, {"avioBufferSize", m_streamingAVIOBufferSize}}}};
 

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -319,20 +319,30 @@ void UIManager::render()
                     m_configWindow->setVisible(!visible);
                 }
             }
-            if (m_capturePresetsWindow)
+            // Capture Presets and Recordings are producer-side windows;
+            // they operate on the local capture device, not on a stream
+            // received from a remote host. Hide them while the client is
+            // in remote viewer mode so the user can't accidentally try to
+            // apply a preset that would be a no-op or open a recordings
+            // browser that's listing the wrong machine's files.
+            const bool clientMode = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
+            if (!clientMode)
             {
-                bool visible = m_capturePresetsWindow->isVisible();
-                if (ImGui::MenuItem("Capture Presets", nullptr, visible))
+                if (m_capturePresetsWindow)
                 {
-                    m_capturePresetsWindow->setVisible(!visible);
+                    bool visible = m_capturePresetsWindow->isVisible();
+                    if (ImGui::MenuItem("Capture Presets", nullptr, visible))
+                    {
+                        m_capturePresetsWindow->setVisible(!visible);
+                    }
                 }
-            }
-            if (m_recordingsWindow)
-            {
-                bool visible = m_recordingsWindow->isVisible();
-                if (ImGui::MenuItem("Recordings", nullptr, visible))
+                if (m_recordingsWindow)
                 {
-                    m_recordingsWindow->setVisible(!visible);
+                    bool visible = m_recordingsWindow->isVisible();
+                    if (ImGui::MenuItem("Recordings", nullptr, visible))
+                    {
+                        m_recordingsWindow->setVisible(!visible);
+                    }
                 }
             }
             ImGui::EndMenu();
@@ -370,6 +380,17 @@ void UIManager::render()
             ImGui::EndMenu();
         }
         ImGui::EndMainMenuBar();
+    }
+
+    // While in client mode (Remote source + active connection), force the
+    // producer-only windows shut so the user can't accidentally have them
+    // sitting open from a previous local session — the menu hides their
+    // toggles too, so without this they'd be unreachable but still drawing.
+    const bool clientModeActive = (m_sourceType == SourceType::Remote) && !m_currentDevice.empty();
+    if (clientModeActive)
+    {
+        if (m_capturePresetsWindow) m_capturePresetsWindow->setVisible(false);
+        if (m_recordingsWindow)     m_recordingsWindow->setVisible(false);
     }
 
     // Renderizar janela de configuração

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -1941,6 +1941,16 @@ void UIManager::triggerStreamingVP9SpeedChange(int speed)
     saveConfig();
 }
 
+void UIManager::triggerStreamingHardwareEncoderChange(int v)
+{
+    m_streamingHardwareEncoder = v;
+    if (m_onStreamingHardwareEncoderChanged)
+    {
+        m_onStreamingHardwareEncoderChanged(v);
+    }
+    saveConfig();
+}
+
 void UIManager::triggerStreamingMaxVideoBufferSizeChange(size_t size)
 {
     m_streamingMaxVideoBufferSize = size;
@@ -2166,6 +2176,8 @@ void UIManager::loadConfig()
                 m_streamingVP8Speed = streaming["vp8Speed"].get<int>();
             if (streaming.contains("vp9Speed"))
                 m_streamingVP9Speed = streaming["vp9Speed"].get<int>();
+            if (streaming.contains("hardwareEncoder"))
+                m_streamingHardwareEncoder = streaming["hardwareEncoder"].get<int>();
 
             // Carregar configurações de buffer
             if (streaming.contains("buffer"))
@@ -2526,6 +2538,7 @@ void UIManager::saveConfig()
             {"h265Level", m_streamingH265Level},
             {"vp8Speed", m_streamingVP8Speed},
             {"vp9Speed", m_streamingVP9Speed},
+            {"hardwareEncoder", m_streamingHardwareEncoder},
             {"applyShader", m_streamingApplyShader},
             {"buffer", {{"maxVideoBufferSize", m_streamingMaxVideoBufferSize}, {"maxAudioBufferSize", m_streamingMaxAudioBufferSize}, {"maxBufferTimeSeconds", m_streamingMaxBufferTimeSeconds}, {"avioBufferSize", m_streamingAVIOBufferSize}}}};
 

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -285,6 +285,10 @@ public:
     int getStreamingVP8Speed() const { return m_streamingVP8Speed; }
     int getStreamingVP9Speed() const { return m_streamingVP9Speed; }
     int getStreamingHardwareEncoder() const { return m_streamingHardwareEncoder; }
+    std::string getStreamingNvencPreset() const { return m_streamingNvencPreset; }
+    std::string getStreamingVaapiRcMode() const { return m_streamingVaapiRcMode; }
+    std::string getStreamingQsvPreset()   const { return m_streamingQsvPreset; }
+    std::string getStreamingAmfQuality()  const { return m_streamingAmfQuality; }
 
     // Streaming setters com callbacks (para uso pelas classes de abas)
     void triggerStreamingPortChange(uint16_t port);
@@ -302,6 +306,10 @@ public:
     void triggerStreamingVP8SpeedChange(int speed);
     void triggerStreamingVP9SpeedChange(int speed);
     void triggerStreamingHardwareEncoderChange(int v);
+    void triggerStreamingNvencPresetChange(const std::string &v);
+    void triggerStreamingVaapiRcModeChange(const std::string &v);
+    void triggerStreamingQsvPresetChange(const std::string &v);
+    void triggerStreamingAmfQualityChange(const std::string &v);
     void triggerStreamingMaxVideoBufferSizeChange(size_t size);
     void triggerStreamingMaxAudioBufferSizeChange(size_t size);
     void triggerStreamingMaxBufferTimeSecondsChange(int64_t seconds);
@@ -399,6 +407,10 @@ public:
     void setOnStreamingVP8SpeedChanged(std::function<void(int)> callback) { m_onStreamingVP8SpeedChanged = callback; }
     void setOnStreamingVP9SpeedChanged(std::function<void(int)> callback) { m_onStreamingVP9SpeedChanged = callback; }
     void setOnStreamingHardwareEncoderChanged(std::function<void(int)> callback) { m_onStreamingHardwareEncoderChanged = callback; }
+    void setOnStreamingNvencPresetChanged(std::function<void(const std::string &)> cb) { m_onStreamingNvencPresetChanged = cb; }
+    void setOnStreamingVaapiRcModeChanged(std::function<void(const std::string &)> cb) { m_onStreamingVaapiRcModeChanged = cb; }
+    void setOnStreamingQsvPresetChanged  (std::function<void(const std::string &)> cb) { m_onStreamingQsvPresetChanged   = cb; }
+    void setOnStreamingAmfQualityChanged (std::function<void(const std::string &)> cb) { m_onStreamingAmfQualityChanged  = cb; }
     void setOnStreamingMaxVideoBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxVideoBufferSizeChanged = callback; }
     void setOnStreamingMaxAudioBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxAudioBufferSizeChanged = callback; }
     void setOnStreamingMaxBufferTimeSecondsChanged(std::function<void(int64_t)> callback) { m_onStreamingMaxBufferTimeSecondsChanged = callback; }
@@ -804,6 +816,15 @@ private:
     int m_streamingVP8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_streamingVP9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
     int m_streamingHardwareEncoder = 0;             // 0 = Auto (matches MediaEncoder::HardwareEncoder::Auto)
+    // Per-backend quality / preset values — the Streaming-tab UI shows
+    // whichever combo matches the currently selected hardware encoder.
+    // Stored separately so switching encoders preserves each backend's
+    // previously chosen value rather than collapsing them onto one
+    // shared string whose meaning would shift mid-flight.
+    std::string m_streamingNvencPreset = "p4";      // p1 (fastest) .. p7 (slowest)
+    std::string m_streamingVaapiRcMode = "CBR";     // CBR / VBR / CQP
+    std::string m_streamingQsvPreset   = "veryfast";// libx264-style names
+    std::string m_streamingAmfQuality  = "speed";   // speed / balanced / quality
     bool m_streamingActive = false;
     std::string m_streamUrl = "";
     uint32_t m_streamClientCount = 0;
@@ -837,6 +858,10 @@ private:
     std::function<void(int)> m_onStreamingVP8SpeedChanged;
     std::function<void(int)> m_onStreamingVP9SpeedChanged;
     std::function<void(int)> m_onStreamingHardwareEncoderChanged;
+    std::function<void(const std::string &)> m_onStreamingNvencPresetChanged;
+    std::function<void(const std::string &)> m_onStreamingVaapiRcModeChanged;
+    std::function<void(const std::string &)> m_onStreamingQsvPresetChanged;
+    std::function<void(const std::string &)> m_onStreamingAmfQualityChanged;
     std::function<void(size_t)> m_onStreamingMaxVideoBufferSizeChanged;
     std::function<void(size_t)> m_onStreamingMaxAudioBufferSizeChanged;
     std::function<void(int64_t)> m_onStreamingMaxBufferTimeSecondsChanged;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -252,6 +252,11 @@ public:
     void setStreamingH265Level(const std::string &level) { m_streamingH265Level = level; }
     void setStreamingVP8Speed(int speed) { m_streamingVP8Speed = speed; }
     void setStreamingVP9Speed(int speed) { m_streamingVP9Speed = speed; }
+    // Hardware encoder selection — uses int so we don't have to pull
+    // MediaEncoder.h into the UI layer. Stored as int matching the
+    // MediaEncoder::HardwareEncoder enum values (Auto=0, Software=1,
+    // NVENC=2, VAAPI=3, QSV=4, AMF=5).
+    void setStreamingHardwareEncoder(int v) { m_streamingHardwareEncoder = v; }
 
     // Buffer settings
     void setStreamingMaxVideoBufferSize(size_t size) { m_streamingMaxVideoBufferSize = size; }
@@ -279,6 +284,7 @@ public:
     std::string getStreamingH265Level() const { return m_streamingH265Level; }
     int getStreamingVP8Speed() const { return m_streamingVP8Speed; }
     int getStreamingVP9Speed() const { return m_streamingVP9Speed; }
+    int getStreamingHardwareEncoder() const { return m_streamingHardwareEncoder; }
 
     // Streaming setters com callbacks (para uso pelas classes de abas)
     void triggerStreamingPortChange(uint16_t port);
@@ -295,6 +301,7 @@ public:
     void triggerStreamingH265LevelChange(const std::string &level);
     void triggerStreamingVP8SpeedChange(int speed);
     void triggerStreamingVP9SpeedChange(int speed);
+    void triggerStreamingHardwareEncoderChange(int v);
     void triggerStreamingMaxVideoBufferSizeChange(size_t size);
     void triggerStreamingMaxAudioBufferSizeChange(size_t size);
     void triggerStreamingMaxBufferTimeSecondsChange(int64_t seconds);
@@ -391,6 +398,7 @@ public:
     void setOnStreamingH265LevelChanged(std::function<void(const std::string &)> callback) { m_onStreamingH265LevelChanged = callback; }
     void setOnStreamingVP8SpeedChanged(std::function<void(int)> callback) { m_onStreamingVP8SpeedChanged = callback; }
     void setOnStreamingVP9SpeedChanged(std::function<void(int)> callback) { m_onStreamingVP9SpeedChanged = callback; }
+    void setOnStreamingHardwareEncoderChanged(std::function<void(int)> callback) { m_onStreamingHardwareEncoderChanged = callback; }
     void setOnStreamingMaxVideoBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxVideoBufferSizeChanged = callback; }
     void setOnStreamingMaxAudioBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxAudioBufferSizeChanged = callback; }
     void setOnStreamingMaxBufferTimeSecondsChanged(std::function<void(int64_t)> callback) { m_onStreamingMaxBufferTimeSecondsChanged = callback; }
@@ -795,6 +803,7 @@ private:
     std::string m_streamingH265Level = "auto";      // Level H.265: "auto", "1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"
     int m_streamingVP8Speed = 12;                   // Speed VP8: 0-16 (0 = melhor qualidade, 16 = mais rápido, 12 = bom para streaming)
     int m_streamingVP9Speed = 6;                    // Speed VP9: 0-9 (0 = melhor qualidade, 9 = mais rápido, 6 = bom para streaming)
+    int m_streamingHardwareEncoder = 0;             // 0 = Auto (matches MediaEncoder::HardwareEncoder::Auto)
     bool m_streamingActive = false;
     std::string m_streamUrl = "";
     uint32_t m_streamClientCount = 0;
@@ -827,6 +836,7 @@ private:
     std::function<void(const std::string &)> m_onStreamingH265LevelChanged;
     std::function<void(int)> m_onStreamingVP8SpeedChanged;
     std::function<void(int)> m_onStreamingVP9SpeedChanged;
+    std::function<void(int)> m_onStreamingHardwareEncoderChanged;
     std::function<void(size_t)> m_onStreamingMaxVideoBufferSizeChanged;
     std::function<void(size_t)> m_onStreamingMaxAudioBufferSizeChanged;
     std::function<void(int64_t)> m_onStreamingMaxBufferTimeSecondsChanged;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -804,9 +804,10 @@ public:
     void loadConfig();
     std::string getConfigPath() const;
 
-private:
     // Scanning methods (tornados públicos para uso pelas classes de abas)
     void scanShaders(const std::string &basePath);
+
+private:
     void scanV4L2Devices();
 
     std::vector<std::string> m_scannedShaders;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -164,6 +164,14 @@ public:
             m_onDeviceChanged(device);
         }
     }
+    // Update the device path without firing the device-change callback.
+    // Used by Application when it needs to mark a failed connect cleared
+    // from inside the same callback — calling setCurrentDevice would
+    // re-enter and either hang or recurse depending on the guard.
+    void setCurrentDeviceSilent(const std::string &device)
+    {
+        m_currentDevice = device;
+    }
     std::string getCurrentDevice() const { return m_currentDevice; }
 
     // Métodos auxiliares para disparar callbacks via API (tornados públicos para uso pelas classes de abas)

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -289,6 +289,7 @@ public:
     std::string getStreamingVaapiRcMode() const { return m_streamingVaapiRcMode; }
     std::string getStreamingQsvPreset()   const { return m_streamingQsvPreset; }
     std::string getStreamingAmfQuality()  const { return m_streamingAmfQuality; }
+    std::string getRemoteInterpolation() const { return m_remoteInterpolation; }
 
     // Streaming setters com callbacks (para uso pelas classes de abas)
     void triggerStreamingPortChange(uint16_t port);
@@ -310,6 +311,7 @@ public:
     void triggerStreamingVaapiRcModeChange(const std::string &v);
     void triggerStreamingQsvPresetChange(const std::string &v);
     void triggerStreamingAmfQualityChange(const std::string &v);
+    void triggerRemoteInterpolationChange(const std::string &v);
     void triggerStreamingMaxVideoBufferSizeChange(size_t size);
     void triggerStreamingMaxAudioBufferSizeChange(size_t size);
     void triggerStreamingMaxBufferTimeSecondsChange(int64_t seconds);
@@ -411,6 +413,7 @@ public:
     void setOnStreamingVaapiRcModeChanged(std::function<void(const std::string &)> cb) { m_onStreamingVaapiRcModeChanged = cb; }
     void setOnStreamingQsvPresetChanged  (std::function<void(const std::string &)> cb) { m_onStreamingQsvPresetChanged   = cb; }
     void setOnStreamingAmfQualityChanged (std::function<void(const std::string &)> cb) { m_onStreamingAmfQualityChanged  = cb; }
+    void setOnRemoteInterpolationChanged (std::function<void(const std::string &)> cb) { m_onRemoteInterpolationChanged  = cb; }
     void setOnStreamingMaxVideoBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxVideoBufferSizeChanged = callback; }
     void setOnStreamingMaxAudioBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxAudioBufferSizeChanged = callback; }
     void setOnStreamingMaxBufferTimeSecondsChanged(std::function<void(int64_t)> callback) { m_onStreamingMaxBufferTimeSecondsChanged = callback; }
@@ -825,6 +828,14 @@ private:
     std::string m_streamingVaapiRcMode = "CBR";     // CBR / VBR / CQP
     std::string m_streamingQsvPreset   = "veryfast";// libx264-style names
     std::string m_streamingAmfQuality  = "speed";   // speed / balanced / quality
+
+    // Client-side interpolation mode for Remote-source playback. Picks
+    // how each display refresh resolves the time between two consecutive
+    // stream frames (see VideoCaptureRemote::captureLatestFrame):
+    //   "linear"  — LERP between prev and next (smooth motion, ghosting)
+    //   "nearest" — show the closer frame (clean image, 3:2 stutter)
+    //   "off"     — strict PTS gate, hold prev until next is due
+    std::string m_remoteInterpolation = "linear";
     bool m_streamingActive = false;
     std::string m_streamUrl = "";
     uint32_t m_streamClientCount = 0;
@@ -862,6 +873,7 @@ private:
     std::function<void(const std::string &)> m_onStreamingVaapiRcModeChanged;
     std::function<void(const std::string &)> m_onStreamingQsvPresetChanged;
     std::function<void(const std::string &)> m_onStreamingAmfQualityChanged;
+    std::function<void(const std::string &)> m_onRemoteInterpolationChanged;
     std::function<void(size_t)> m_onStreamingMaxVideoBufferSizeChanged;
     std::function<void(size_t)> m_onStreamingMaxAudioBufferSizeChanged;
     std::function<void(int64_t)> m_onStreamingMaxBufferTimeSecondsChanged;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -152,6 +152,9 @@ public:
 
     void setOnSourceTypeChanged(std::function<void(SourceType)> callback) { m_onSourceTypeChanged = callback; }
     SourceType getSourceType() const { return m_sourceType; }
+    // Phase 5 of #47: client mode (consuming a remote /raw) — UI controls
+    // should render disabled, and a banner advertises the connection.
+    bool isRemoteSource() const { return m_sourceType == SourceType::Remote; }
     void setCurrentDevice(const std::string &device)
     {
         m_currentDevice = device;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -21,6 +21,7 @@ class IAudioCapture;
 // Forward declarations
 class UIConfiguration;
 class UICredits;
+class UIRemoteConnection;
 class UICapturePresets;
 class UIRecordings;
 class RecordingProfileManager;
@@ -414,6 +415,11 @@ public:
     void setOnStreamingQsvPresetChanged  (std::function<void(const std::string &)> cb) { m_onStreamingQsvPresetChanged   = cb; }
     void setOnStreamingAmfQualityChanged (std::function<void(const std::string &)> cb) { m_onStreamingAmfQualityChanged  = cb; }
     void setOnRemoteInterpolationChanged (std::function<void(const std::string &)> cb) { m_onRemoteInterpolationChanged  = cb; }
+
+    // Accessor used by Application to keep the connection-window's
+    // capture pointer current — the window reads .isOpen() / dims to
+    // decide whether to show Connect or Disconnect.
+    UIRemoteConnection *getRemoteConnectionWindow() const { return m_remoteConnectionWindow.get(); }
     void setOnStreamingMaxVideoBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxVideoBufferSizeChanged = callback; }
     void setOnStreamingMaxAudioBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxAudioBufferSizeChanged = callback; }
     void setOnStreamingMaxBufferTimeSecondsChanged(std::function<void(int64_t)> callback) { m_onStreamingMaxBufferTimeSecondsChanged = callback; }
@@ -692,6 +698,7 @@ private:
     std::unique_ptr<class UICredits> m_creditsWindow;
     std::unique_ptr<class UICapturePresets> m_capturePresetsWindow;
     std::unique_ptr<class UIRecordings> m_recordingsWindow;
+    std::unique_ptr<class UIRemoteConnection> m_remoteConnectionWindow;
     std::unique_ptr<RecordingProfileManager> m_recordingProfileManager;
     std::unique_ptr<StreamingProfileManager> m_streamingProfileManager;
     void *m_window = nullptr; // GLFWwindow* or SDL_Window*

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -143,7 +143,8 @@ public:
     {
         None = 0,
         V4L2 = 1,
-        DS = 2 // DirectShow (Windows)
+        DS = 2, // DirectShow (Windows)
+        Remote = 3 // Remote /raw MPEG-TS from another RetroCapture (Phase 3 of #47)
     };
 
     // Source type setter (para uso pelas classes de abas)

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -20,13 +20,35 @@ void UIRemoteConnection::render()
 {
     if (!m_visible || !m_uiManager) return;
 
+    // Source-aware: getCurrentDevice() returns whatever the active capture
+    // path needs as its "device" — for V4L2/DS that's a filesystem path
+    // like /dev/video0, NOT a URL. Treat it as a URL only when the source
+    // is already Remote; otherwise seed the buffer with the default.
+    const bool sourceIsRemote = (m_uiManager->getSourceType() == UIManager::SourceType::Remote);
     if (!m_urlSeeded)
     {
-        std::string current = m_uiManager->getCurrentDevice();
+        std::string current = sourceIsRemote ? m_uiManager->getCurrentDevice() : std::string();
         if (current.empty()) current = "http://localhost:8080";
         std::strncpy(m_urlBuffer, current.c_str(), sizeof(m_urlBuffer) - 1);
         m_urlBuffer[sizeof(m_urlBuffer) - 1] = '\0';
         m_urlSeeded = true;
+    }
+    else if (sourceIsRemote)
+    {
+        // While in Remote mode, keep the buffer mirroring the active
+        // device path (so Disconnect-then-reopen shows the URL the user
+        // was last on, and an external --remote-url switch is reflected).
+        // Do NOT overwrite while typing — only sync when the user isn't
+        // editing this field.
+        if (!ImGui::IsItemActive())
+        {
+            std::string current = m_uiManager->getCurrentDevice();
+            if (!current.empty() && current != std::string(m_urlBuffer))
+            {
+                std::strncpy(m_urlBuffer, current.c_str(), sizeof(m_urlBuffer) - 1);
+                m_urlBuffer[sizeof(m_urlBuffer) - 1] = '\0';
+            }
+        }
     }
 
     ImGui::SetNextWindowSize(ImVec2(520, 320), ImGuiCond_FirstUseEver);
@@ -77,8 +99,12 @@ void UIRemoteConnection::render()
         ImGui::Separator();
         ImGui::Spacing();
 
-        const std::string currentDevice = m_uiManager->getCurrentDevice();
-        const bool connected = !currentDevice.empty() &&
+        // 'Connected' here means we're in Remote source mode AND have a
+        // URL set AND the capture is open. Without the source-type check
+        // the window mis-reported a local V4L2/DS capture as a remote
+        // connection (V4L2 also uses getCurrentDevice + isOpen).
+        const std::string currentDevice = sourceIsRemote ? m_uiManager->getCurrentDevice() : std::string();
+        const bool connected = sourceIsRemote && !currentDevice.empty() &&
                                (m_capture && m_capture->isOpen());
 
         if (!connected)

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -111,8 +111,15 @@ void UIRemoteConnection::render()
         const std::string currentDevice = sourceIsRemote ? m_uiManager->getCurrentDevice() : std::string();
         const bool connected = sourceIsRemote && !currentDevice.empty();
 
+        // Two-frame state machine: button click sets *ShowStatus, the
+        // next render of this state shows the spinning label and arms
+        // *Execute, the frame after runs the blocking call. The user
+        // gets one painted 'Connecting...' / 'Disconnecting...' before
+        // the freeze actually starts.
+        const bool inProgress = (m_pending != PendingAction::None);
         if (!connected)
         {
+            ImGui::BeginDisabled(inProgress);
             if (ImGui::Button("Connect", ImVec2(120, 0)))
             {
                 std::string url(m_urlBuffer);
@@ -121,33 +128,69 @@ void UIRemoteConnection::render()
                 while (!url.empty() && url.back() == '/') url.pop_back();
                 if (!url.empty())
                 {
-                    // Flip source to Remote only if we're not already
-                    // there — triggerSourceTypeChange always re-runs the
-                    // app-level handler (which destroys/recreates the
-                    // capture), and doing it on top of a Remote that's
-                    // halfway through a connect attempt produced the
-                    // double 'Source type changed' / segfault sequence
-                    // the user reported. setCurrentDevice fires
-                    // m_onDeviceChanged, which is the connect-to-remote
-                    // path; one trigger is enough.
-                    if (m_uiManager->getSourceType() != UIManager::SourceType::Remote)
-                    {
-                        m_uiManager->triggerSourceTypeChange(UIManager::SourceType::Remote);
-                    }
-                    m_uiManager->setCurrentDevice(url);
+                    m_pendingUrl = url;
+                    m_pending    = PendingAction::ConnectShowStatus;
                 }
             }
+            ImGui::EndDisabled();
             ImGui::SameLine();
-            ImGui::TextDisabled("not connected");
+            if (m_pending == PendingAction::ConnectShowStatus ||
+                m_pending == PendingAction::ConnectExecute)
+            {
+                ImGui::TextDisabled("connecting...");
+            }
+            else
+            {
+                ImGui::TextDisabled("not connected");
+            }
         }
         else
         {
+            ImGui::BeginDisabled(inProgress);
             if (ImGui::Button("Disconnect", ImVec2(120, 0)))
             {
-                m_uiManager->setCurrentDevice("");
+                m_pending = PendingAction::DisconnectShowStatus;
             }
+            ImGui::EndDisabled();
             ImGui::SameLine();
-            ImGui::TextDisabled("connected to %s", currentDevice.c_str());
+            if (m_pending == PendingAction::DisconnectShowStatus ||
+                m_pending == PendingAction::DisconnectExecute)
+            {
+                ImGui::TextDisabled("disconnecting...");
+            }
+            else
+            {
+                ImGui::TextDisabled("connected to %s", currentDevice.c_str());
+            }
+        }
+
+        // Advance the state machine AFTER all UI for this frame has been
+        // emitted. ShowStatus → Execute on this very frame (the label is
+        // already in ImGui's draw list). Execute runs the blocking call
+        // on the NEXT frame, by which point ShowStatus has painted.
+        switch (m_pending)
+        {
+            case PendingAction::ConnectShowStatus:
+                m_pending = PendingAction::ConnectExecute;
+                break;
+            case PendingAction::ConnectExecute:
+                if (m_uiManager->getSourceType() != UIManager::SourceType::Remote)
+                {
+                    m_uiManager->triggerSourceTypeChange(UIManager::SourceType::Remote);
+                }
+                m_uiManager->setCurrentDevice(m_pendingUrl);
+                m_pendingUrl.clear();
+                m_pending = PendingAction::None;
+                break;
+            case PendingAction::DisconnectShowStatus:
+                m_pending = PendingAction::DisconnectExecute;
+                break;
+            case PendingAction::DisconnectExecute:
+                m_uiManager->setCurrentDevice("");
+                m_pending = PendingAction::None;
+                break;
+            case PendingAction::None:
+                break;
         }
 
         ImGui::Spacing();

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -1,0 +1,131 @@
+#include "UIRemoteConnection.h"
+#include "UIManager.h"
+#include "../capture/IVideoCapture.h"
+#include <imgui.h>
+#include <cstring>
+
+UIRemoteConnection::UIRemoteConnection(UIManager *uiManager)
+    : m_uiManager(uiManager)
+{
+}
+
+UIRemoteConnection::~UIRemoteConnection() = default;
+
+void UIRemoteConnection::setVisible(bool visible)
+{
+    m_visible = visible;
+}
+
+void UIRemoteConnection::render()
+{
+    if (!m_visible || !m_uiManager) return;
+
+    if (!m_urlSeeded)
+    {
+        std::string current = m_uiManager->getCurrentDevice();
+        if (current.empty()) current = "http://localhost:8080";
+        std::strncpy(m_urlBuffer, current.c_str(), sizeof(m_urlBuffer) - 1);
+        m_urlBuffer[sizeof(m_urlBuffer) - 1] = '\0';
+        m_urlSeeded = true;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(520, 320), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("Connect to Remote", &m_visible))
+    {
+        ImGui::TextWrapped(
+            "Consume a remote RetroCapture stream. The client decodes the "
+            "host's /raw feed and mirrors its shader pipeline via /meta.");
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        ImGui::Text("Remote base URL");
+        ImGui::SetNextItemWidth(-1);
+        ImGui::InputText("##remoteUrl", m_urlBuffer, sizeof(m_urlBuffer));
+
+        ImGui::Spacing();
+
+        // Interpolation mode dropdown — same options the Source-tab path
+        // used to expose. Lives here now so all the Remote-mode controls
+        // are co-located.
+        const char *modes[]      = {"linear", "nearest", "off"};
+        const char *modeLabels[] = {
+            "Linear (smooth, slight ghosting)",
+            "Nearest (clean frames, may stutter)",
+            "Off (strict PTS, may stutter)"
+        };
+        std::string currentMode = m_uiManager->getRemoteInterpolation();
+        int currentModeIndex = 0;
+        for (int i = 0; i < 3; ++i)
+        {
+            if (currentMode == modes[i]) { currentModeIndex = i; break; }
+        }
+        ImGui::Text("Display interpolation");
+        ImGui::SetNextItemWidth(-1);
+        if (ImGui::Combo("##remoteInterp", &currentModeIndex, modeLabels, 3))
+        {
+            m_uiManager->triggerRemoteInterpolationChange(modes[currentModeIndex]);
+        }
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("Linear: blend prev+next por refresh — fluido, leve fantasma em movimento rápido.\n"
+                              "Nearest: frame mais próximo no tempo — limpo, com 3:2 pulldown em ratio não-inteiro.\n"
+                              "Off: estritamente espera o PTS — comportamento simples, sem ghosting nem suavização.");
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        const std::string currentDevice = m_uiManager->getCurrentDevice();
+        const bool connected = !currentDevice.empty() &&
+                               (m_capture && m_capture->isOpen());
+
+        if (!connected)
+        {
+            if (ImGui::Button("Connect", ImVec2(120, 0)))
+            {
+                std::string url(m_urlBuffer);
+                // Strip a trailing slash so the appended /raw and /meta land
+                // cleanly down in VideoCaptureRemote / RemoteMetaSync.
+                while (!url.empty() && url.back() == '/') url.pop_back();
+                if (!url.empty())
+                {
+                    // setCurrentDevice fires m_onDeviceChanged, Application's
+                    // connect-to-remote handler. Also flips Source to Remote
+                    // so the existing remote-capture path takes over.
+                    m_uiManager->setSourceType(UIManager::SourceType::Remote);
+                    m_uiManager->triggerSourceTypeChange(UIManager::SourceType::Remote);
+                    m_uiManager->setCurrentDevice(url);
+                }
+            }
+            ImGui::SameLine();
+            ImGui::TextDisabled("not connected");
+        }
+        else
+        {
+            if (ImGui::Button("Disconnect", ImVec2(120, 0)))
+            {
+                m_uiManager->setCurrentDevice("");
+            }
+            ImGui::SameLine();
+            ImGui::TextDisabled("connected to %s", currentDevice.c_str());
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        ImGui::TextDisabled("Status");
+        if (m_capture && m_capture->isOpen())
+        {
+            ImGui::Text("Stream: %ux%u",
+                        m_capture->getWidth(), m_capture->getHeight());
+        }
+        else
+        {
+            ImGui::Text("Idle.");
+        }
+    }
+    ImGui::End();
+}

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -1,6 +1,5 @@
 #include "UIRemoteConnection.h"
 #include "UIManager.h"
-#include "../capture/IVideoCapture.h"
 #include <imgui.h>
 #include <cstring>
 
@@ -103,9 +102,14 @@ void UIRemoteConnection::render()
         // URL set AND the capture is open. Without the source-type check
         // the window mis-reported a local V4L2/DS capture as a remote
         // connection (V4L2 also uses getCurrentDevice + isOpen).
+        // Liveness derived from UIManager only — the old code dereferenced
+        // a cached IVideoCapture* that went dangling the moment the user
+        // pressed Connect (the connect handler destroys-and-recreates
+        // m_capture inside the same frame). UIManager's caller-side info
+        // is updated by Application after the swap completes, so it's
+        // safe to consult from here.
         const std::string currentDevice = sourceIsRemote ? m_uiManager->getCurrentDevice() : std::string();
-        const bool connected = sourceIsRemote && !currentDevice.empty() &&
-                               (m_capture && m_capture->isOpen());
+        const bool connected = sourceIsRemote && !currentDevice.empty();
 
         if (!connected)
         {
@@ -117,11 +121,19 @@ void UIRemoteConnection::render()
                 while (!url.empty() && url.back() == '/') url.pop_back();
                 if (!url.empty())
                 {
-                    // setCurrentDevice fires m_onDeviceChanged, Application's
-                    // connect-to-remote handler. Also flips Source to Remote
-                    // so the existing remote-capture path takes over.
-                    m_uiManager->setSourceType(UIManager::SourceType::Remote);
-                    m_uiManager->triggerSourceTypeChange(UIManager::SourceType::Remote);
+                    // Flip source to Remote only if we're not already
+                    // there — triggerSourceTypeChange always re-runs the
+                    // app-level handler (which destroys/recreates the
+                    // capture), and doing it on top of a Remote that's
+                    // halfway through a connect attempt produced the
+                    // double 'Source type changed' / segfault sequence
+                    // the user reported. setCurrentDevice fires
+                    // m_onDeviceChanged, which is the connect-to-remote
+                    // path; one trigger is enough.
+                    if (m_uiManager->getSourceType() != UIManager::SourceType::Remote)
+                    {
+                        m_uiManager->triggerSourceTypeChange(UIManager::SourceType::Remote);
+                    }
                     m_uiManager->setCurrentDevice(url);
                 }
             }
@@ -143,10 +155,12 @@ void UIRemoteConnection::render()
         ImGui::Spacing();
 
         ImGui::TextDisabled("Status");
-        if (m_capture && m_capture->isOpen())
+        if (connected)
         {
-            ImGui::Text("Stream: %ux%u",
-                        m_capture->getWidth(), m_capture->getHeight());
+            const uint32_t w = m_uiManager->getCaptureWidth();
+            const uint32_t h = m_uiManager->getCaptureHeight();
+            if (w > 0 && h > 0) ImGui::Text("Stream: %ux%u", w, h);
+            else                ImGui::Text("Connecting...");
         }
         else
         {

--- a/src/ui/UIRemoteConnection.h
+++ b/src/ui/UIRemoteConnection.h
@@ -29,13 +29,17 @@ public:
     void setVisible(bool visible);
     bool isVisible() const { return m_visible; }
 
-    // Capture pointer is consulted to decide whether to show
-    // Connect or Disconnect, and to read the live status / dims.
-    void setCapture(IVideoCapture *capture) { m_capture = capture; }
+    // setCapture is intentionally a no-op kept for ABI compatibility
+    // with the wiring in Application. The window was crashing on
+    // use-after-free because the m_capture pointer it cached went
+    // dangling the moment the user clicked Connect (the device-change
+    // callback destroys and recreates m_capture inside the same frame).
+    // Now we read all connection state through UIManager getters which
+    // remain valid across the swap.
+    void setCapture(IVideoCapture *) {}
 
 private:
     UIManager *m_uiManager = nullptr;
-    IVideoCapture *m_capture = nullptr;
     bool m_visible = false;
 
     // ImGui InputText buffer, seeded from the saved device path on

--- a/src/ui/UIRemoteConnection.h
+++ b/src/ui/UIRemoteConnection.h
@@ -46,4 +46,22 @@ private:
     // first render so the user's previous URL persists across sessions.
     char m_urlBuffer[256] = {};
     bool m_urlSeeded = false;
+
+    // Two-frame state machine for connect/disconnect feedback. The
+    // setCurrentDevice() path blocks ~50-100 ms; if we executed it on
+    // the same frame as the button click, the user never sees a
+    // status change — the click and the result render together. By
+    // deferring the actual call to the NEXT frame we get one paint of
+    // 'Connecting...' / 'Disconnecting...' on screen before the
+    // blocking call starts.
+    enum class PendingAction
+    {
+        None,
+        ConnectShowStatus,   // show 'Connecting...' this frame
+        ConnectExecute,      // run the blocking call this frame
+        DisconnectShowStatus,
+        DisconnectExecute,
+    };
+    PendingAction m_pending = PendingAction::None;
+    std::string m_pendingUrl;
 };

--- a/src/ui/UIRemoteConnection.h
+++ b/src/ui/UIRemoteConnection.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+class UIManager;
+class IVideoCapture;
+
+/**
+ * UIRemoteConnection — dedicated window for the Remote viewer mode.
+ *
+ * Surfaces:
+ *  - Remote base URL input
+ *  - Display interpolation dropdown (linear / nearest / off)
+ *  - Connect / Disconnect button
+ *  - Connection status / stream dims
+ *
+ * Lives outside the Source tab on purpose: connecting to a remote
+ * RetroCapture instance is conceptually a different operating mode
+ * ("client viewer") rather than a capture-source choice, so it sits
+ * under its own top-level menu.
+ */
+class UIRemoteConnection
+{
+public:
+    UIRemoteConnection(UIManager *uiManager);
+    ~UIRemoteConnection();
+
+    void render();
+    void setVisible(bool visible);
+    bool isVisible() const { return m_visible; }
+
+    // Capture pointer is consulted to decide whether to show
+    // Connect or Disconnect, and to read the live status / dims.
+    void setCapture(IVideoCapture *capture) { m_capture = capture; }
+
+private:
+    UIManager *m_uiManager = nullptr;
+    IVideoCapture *m_capture = nullptr;
+    bool m_visible = false;
+
+    // ImGui InputText buffer, seeded from the saved device path on
+    // first render so the user's previous URL persists across sessions.
+    char m_urlBuffer[256] = {};
+    bool m_urlSeeded = false;
+};

--- a/src/utils/PresetManager.cpp
+++ b/src/utils/PresetManager.cpp
@@ -231,6 +231,7 @@ bool PresetManager::savePreset(const std::string& name, const PresetData& data)
             }
             presetJson["streaming"]["vp8Speed"] = data.streamingVP8Speed;
             presetJson["streaming"]["vp9Speed"] = data.streamingVP9Speed;
+            presetJson["streaming"]["hardwareEncoder"] = data.streamingHardwareEncoder;
         }
 
         // V4L2 controls (if any)
@@ -436,6 +437,10 @@ bool PresetManager::loadPreset(const std::string& name, PresetData& data)
             if (streaming.contains("vp9Speed"))
             {
                 data.streamingVP9Speed = streaming["vp9Speed"].get<int>();
+            }
+            if (streaming.contains("hardwareEncoder"))
+            {
+                data.streamingHardwareEncoder = streaming["hardwareEncoder"].get<int>();
             }
         }
 

--- a/src/utils/PresetManager.h
+++ b/src/utils/PresetManager.h
@@ -56,6 +56,7 @@ public:
         std::string streamingH265Level;
         int streamingVP8Speed = 0;
         int streamingVP9Speed = 0;
+        int streamingHardwareEncoder = 0; // 0 = Auto (MediaEncoder::HardwareEncoder enum value)
         
         // V4L2 controls (optional)
         std::map<std::string, int32_t> v4l2Controls;


### PR DESCRIPTION
Closes #47.

## Summary

Implements the full **shader-preserving distributed playback** epic from #47: server exposes `/raw` (unshaded MPEG-TS) and `/meta` (JSON state + SSE deltas) alongside the existing `/stream`, and a second RetroCapture instance can connect with `--source remote --remote-url <host>` to view the host's stream with the host's shader applied at the **client's** native resolution.

All six phases from the issue are delivered, plus a substantial set of capabilities discovered as necessary during implementation (full breakdown in the [updated issue body](../issues/47)).

## What's in this PR

**Original scope (#47 phases 1–6)**
- `/meta` snapshot endpoint with versioned JSON schema (`docs/REMOTE_STREAM_PROTOCOL.md`).
- `/raw` pre-shader MPEG-TS endpoint sharing the encoder pipeline with `/stream`.
- New `remote` source type plumbed through `Application::init` / source factory / CLI.
- Shader sync: client fetches `/meta`, resolves preset locally by name + hash, applies parameter overrides.
- Read-only UI mode in client: producer-only tabs (Capture Presets, Recording, Source) hidden; Image / Info / Shaders-inspect visible.
- SSE channel on `/meta` for sub-second deltas, with graceful fallback to short-poll on older servers.

**Delivered beyond the original scope** (the part of the work that made the feature actually usable)
- **Hardware encoders**: NVENC / VAAPI / QSV / AMF with backend-aware UI; H.265 / HEVC with inline VPS/SPS/PPS for mid-join clients; VAAPI Main-profile fix.
- **B-frame correctness**: removed a DTS-bumps-PTS clamp in `MediaMuxer::ensureMonotonicPTS` that broke encoded ordering at slower presets.
- **Audio path**: `IAudioPlayback` interface with `AudioPlaybackPulse` (Linux, `pa_simple`) and `AudioPlaybackWASAPI` (Windows, event-driven IAudioRenderClient with AvSetMmThreadCharacteristics "Pro Audio"); audio-as-master A/V sync in the client with ±500 ms drift sanity gate; SwrContext layout handling via `swr_alloc_set_opts2` (legacy fallback for older FFmpeg); probesize tuned to 256 KB / 1 s for reliable AAC detection without catch-up bursts.
- **Display quality**: per-refresh frame interpolation (off / nearest / linear) configurable from the Remote window; focus-aware vsync; vsync-driven remote pacing with wall-clock fallback; forward watchdog on PTS anchor (fixes the "first-frame translucent ghost" symptom).
- **UX**: dedicated **Remote** top-level menu with its own connection window (URL + interpolation), "Connecting…" / "Disconnecting…" feedback via two-frame state machine, FFmpeg interrupt callback for prompt disconnect, immediate frame clear on disconnect, host-seeded Image tab on initial connect (user override preserved), source resolution propagation via `/meta` deltas.
- **Streaming robustness**: 503 on `/raw` before pipeline init; atomic client-list erase + fd close fixes a use-after-free race; `HTTPTSStreamer::stop()` blocking time dropped from ~10 s to ~1.5 s; client decode reconnect loop on `av_read_frame` failure.

**Deferred to follow-up**
- Phase 4b — `/meta/shader-bundle?preset=<name>` tarball fetch + client cache under `~/.cache/retrocapture/remote-shaders/<host>/`. Currently the client logs a warning and keeps the existing shader when a preset isn't available locally. Tracked separately (see issue list).

## Files touched

38 files, +5709 / -182. Highlights:
- `src/capture/VideoCaptureRemote.{h,cpp}` — new remote source with decode + audio + interpolation.
- `src/audio/IAudioPlayback.h` + `AudioPlaybackPulse.{h,cpp}` + `AudioPlaybackWASAPI.{h,cpp}` — audio playback layer.
- `src/streaming/RemoteMetaSync.{h,cpp}` — `/meta` poller / SSE consumer with dedup.
- `src/streaming/HTTPTSStreamer.{h,cpp}` + `APIController.{h,cpp}` — `/raw` and `/meta` endpoints, SSE.
- `src/streaming/StreamManager.{h,cpp}` — dual-pipeline lifecycle.
- `src/encoding/MediaEncoder.{h,cpp}` + `MediaMuxer.cpp` + `MediaSynchronizer.{h,cpp}` — hardware encoder dispatch, HEVC global-header policy fix, B-frame ordering, drain helpers.
- `src/ui/UIManager.{h,cpp}` + `UIRemoteConnection.{h,cpp}` + `UIConfiguration*.cpp` — Remote menu, connection window, read-only client mode.
- `src/core/Application.{h,cpp}` — remote-source wiring, `applyPendingRemoteMeta`, image seed lifecycle, vsync / focus handling, remote pacing.

## Build matrix

All four targets compile clean on master HEAD of this branch:
- `linux-x86_64` ✅
- `windows-x86_64` (MXE cross-compile) ✅
- `linux-arm64v8` (Raspberry Pi 4 / 5) ✅
- `linux-arm32v7` (Raspberry Pi 3) ✅

## Test plan

- [ ] Host on Linux + client on Linux: end-to-end stream with a CRT preset; verify shader runs on client at client's native resolution.
- [ ] Host on Linux + client on Windows (via Wine or native): same.
- [ ] Mid-stream preset change on host: confirm SSE delta lands on client within ~250 ms and shader reloads without disconnecting `/raw`.
- [ ] Mid-stream resolution change on host: confirm `/meta` delta wakes the client and `setTargetResolution` rebuilds swsCtx at the new dims.
- [ ] Audio: Linux Pulse output appears in `pavucontrol` Playback streams; Windows WASAPI plays through default device.
- [ ] Audio sync: long-session lip-sync check (10+ min); confirm no monotonic drift.
- [ ] Hardware encoders: smoke-test each backend (NVENC / VAAPI / QSV / AMF) that's available on the test rig.
- [ ] HEVC mid-join: connect a client to a running HEVC stream and verify it picks up VPS/SPS/PPS within the next keyframe.
- [ ] Interpolation modes: cycle off / nearest / linear at 144 Hz client display, confirm linear eliminates the 60→144 judder visually.
- [ ] Disconnect responsiveness: click Disconnect with the host offline; UI should return to idle within ~1.5 s.
- [ ] `/stream` (the existing post-shader endpoint) byte-for-byte unchanged for VLC / mpv / ffplay consumers.

## Notes for reviewers

- The branch is 65 commits; many are intentional small fixes during the discovery phase. Each commit message is self-contained and the recent ones (audio path, probesize, `/meta` dedup, log cleanup) are particularly atomic if you want to read incrementally rather than as a single diff.
- Phase 4b (shader bundle fetch) deliberately left out — adding it would add an HTTP server endpoint + a client cache + a tarball format decision that don't unblock anything in the current acceptance criteria.
