### PR TITLE
Polish directory 56 57 58

### DIFF
--- a/docs/DIRECTORY_PROTOCOL.md
+++ b/docs/DIRECTORY_PROTOCOL.md
@@ -258,8 +258,20 @@ Request body:
 { "reason": "explicit name", "reporterContact": "optional email or @handle" }
 ```
 
-Response `202 Accepted`. The directory logs the report and the
-moderator decides what to do with it. **No automatic takedown.**
+Response `202`:
+
+```json
+{ "data": { "reportId": "R-AB12CD34" }, "error": null }
+```
+
+`reportId` is a short human-readable receipt the reporter can quote if
+they later need to reference the report when contacting the
+maintainer (`R-` + 8 uppercase hex chars). The same id is persisted
+on the moderation row and logged at info level on the service so the
+maintainer can pivot from a quoted receipt back to the original row.
+
+The directory logs the report and the moderator decides what to do
+with it. **No automatic takedown.**
 
 Rate-limited per source IP to prevent griefing.
 

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -31,6 +31,12 @@ services:
       DIRECTORY_DB_PATH: "/data/directory.db"
       DIRECTORY_LOG_LEVEL: "debug"
       DIRECTORY_TTL_SECONDS: "120"
+      # When the directory is deployed behind a reverse proxy (FRP,
+      # nginx, Cloudflare), set this to "true" so the recorded
+      # publicIp / reporter_ip is the real client, not the proxy.
+      # Off by default in the compose example because plain
+      # `docker compose up` exposes 8081 directly on the host.
+      DIRECTORY_TRUST_PROXY_HEADERS: "false"
     restart: unless-stopped
     # No container-side healthcheck: the runtime image is FROM scratch
     # and has no shell / curl to probe with. Liveness is the

--- a/platform/services/directory/cmd/directory/main.go
+++ b/platform/services/directory/cmd/directory/main.go
@@ -68,14 +68,15 @@ func run() error {
 	limReport := ratelimit.New(ratelimit.PerHour(cfg.RateReportPerHour))
 
 	server := &api.Server{
-		Logger:         logger,
-		Store:          st,
-		TTL:            cfg.TTL,
-		LimitRegister:  limRegister,
-		LimitHeartbeat: limHeartbeat,
-		LimitPatch:     limPatch,
-		LimitList:      limList,
-		LimitReport:    limReport,
+		Logger:            logger,
+		Store:             st,
+		TTL:               cfg.TTL,
+		LimitRegister:     limRegister,
+		LimitHeartbeat:    limHeartbeat,
+		LimitPatch:        limPatch,
+		LimitList:         limList,
+		LimitReport:       limReport,
+		TrustProxyHeaders: cfg.TrustProxyHeaders,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/platform/services/directory/internal/api/handlers.go
+++ b/platform/services/directory/internal/api/handlers.go
@@ -455,6 +455,9 @@ func validateRegister(req *RegisterRequest) error {
 	if len(req.Endpoint) > maxEndpointLen {
 		return fmt.Errorf("endpoint too long (max %d)", maxEndpointLen)
 	}
+	if err := isValidEndpointURL(req.Endpoint); err != nil {
+		return fmt.Errorf("endpoint is invalid: %v", err)
+	}
 	if !isValidEndpointMode(req.EndpointMode) {
 		return fmt.Errorf("endpointMode must be direct, tunnel-cloudflare or custom")
 	}
@@ -492,6 +495,9 @@ func validatePatch(req *PatchRequest) error {
 		if v == "" || len(v) > maxEndpointLen {
 			return fmt.Errorf("endpoint must be 1..%d chars", maxEndpointLen)
 		}
+		if err := isValidEndpointURL(v); err != nil {
+			return fmt.Errorf("endpoint is invalid: %v", err)
+		}
 		*req.Endpoint = v
 	}
 	if req.EndpointMode != nil && !isValidEndpointMode(*req.EndpointMode) {
@@ -506,6 +512,51 @@ func isValidEndpointMode(m string) bool {
 		return true
 	}
 	return false
+}
+
+// isValidEndpointURL rejects the typo class that used to land in the
+// directory and rot — htts://foo, https//foo (missing colon), schemes
+// other than http(s), ports outside 1..65535, hostless URLs. Matches
+// the client-side check in UIConfigurationStreaming.cpp so a request
+// that the UI would have blocked is also blocked here as defence in
+// depth (#56).
+func isValidEndpointURL(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("malformed URL: %v", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("host is empty")
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("host is empty")
+	}
+	// Host must contain at least one alphanumeric char — catches "...",
+	// "---", literal "localhost" excluded? no, "localhost" matches.
+	hasAlnum := false
+	for _, c := range hostname {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			hasAlnum = true
+			break
+		}
+	}
+	if !hasAlnum {
+		return fmt.Errorf("host must contain a letter or digit")
+	}
+	if portStr := u.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return fmt.Errorf("invalid port")
+		}
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("port out of range (1..65535)")
+		}
+	}
+	return nil
 }
 
 // --- helpers ---

--- a/platform/services/directory/internal/api/handlers.go
+++ b/platform/services/directory/internal/api/handlers.go
@@ -422,18 +422,24 @@ func (s *Server) handleReportStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.Store.InsertReport(r.Context(), streamID, s.clientIP(r), req.Reason, req.ReporterContact); err != nil {
-		s.Logger.Error("report_failed", "err", err, "stream_id", streamID)
-		writeError(w, http.StatusInternalServerError, CodeInternal, "failed to record report")
-		return
-	}
 	// Receipt ID handed back to the user so they have a reference to
 	// quote if they ever need to follow up with the maintainer. Short
 	// hex + R- prefix so it's recognisable as a report id and not
 	// confused with a tunnel id or any other UUID floating around.
-	// Logged at info so the maintainer can grep the log for a given
-	// receipt and find the original row.
-	reportID, _ := newReceiptID()
+	// Generated before InsertReport so it's persisted alongside the
+	// row (and indexed) — the maintainer can pivot from a quoted
+	// receipt back to the original report without grepping the log.
+	reportID, err := newReceiptID()
+	if err != nil {
+		s.Logger.Error("report_receipt_failed", "err", err)
+		writeError(w, http.StatusInternalServerError, CodeInternal, "failed to generate report id")
+		return
+	}
+	if err := s.Store.InsertReport(r.Context(), streamID, reportID, s.clientIP(r), req.Reason, req.ReporterContact); err != nil {
+		s.Logger.Error("report_failed", "err", err, "stream_id", streamID)
+		writeError(w, http.StatusInternalServerError, CodeInternal, "failed to record report")
+		return
+	}
 	s.Logger.Info("report_received",
 		"stream_id", streamID,
 		"reporter_ip", s.clientIP(r),

--- a/platform/services/directory/internal/api/handlers.go
+++ b/platform/services/directory/internal/api/handlers.go
@@ -67,6 +67,15 @@ type Server struct {
 	LimitPatch     *ratelimit.Limiter // PATCH /streams/{id}
 	LimitList      *ratelimit.Limiter // GET /streams and GET /streams/{id}
 	LimitReport    *ratelimit.Limiter // POST /streams/{id}/report
+
+	// When true, the source IP returned by clientIP() honours
+	// Cf-Connecting-Ip / True-Client-Ip / X-Real-Ip / X-Forwarded-For
+	// in that order before falling back to the TCP RemoteAddr. Should
+	// be ON when the directory sits behind a reverse proxy that
+	// forwards the real client IP via headers (FRP + cloudflared,
+	// nginx with proxy_protocol off, etc.) and OFF when the service is
+	// exposed directly. main.go reads DIRECTORY_TRUST_PROXY_HEADERS.
+	TrustProxyHeaders bool
 }
 
 // Routes returns the http.Handler the service should serve from.
@@ -76,29 +85,33 @@ type Server struct {
 // through unchanged.
 func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
+	// Rate limits key off s.clientIP so the same proxy IP doesn't
+	// burn the whole bucket for everyone behind it when the service
+	// is deployed behind FRP / Cloudflare and TrustProxyHeaders is on.
+	keyFn := func(r *http.Request) string { return s.clientIP(r) }
 	mux.HandleFunc("GET /health", s.handleHealth) // unlimited
 
 	mux.HandleFunc("POST /register",
-		ratelimit.Wrap(s.LimitRegister, ratelimit.ClientIPKey, s.handleRegister))
+		ratelimit.Wrap(s.LimitRegister, keyFn, s.handleRegister))
 
 	mux.HandleFunc("POST /heartbeat",
-		ratelimit.Wrap(s.LimitHeartbeat, ratelimit.ClientIPKey, s.handleHeartbeat))
+		ratelimit.Wrap(s.LimitHeartbeat, keyFn, s.handleHeartbeat))
 
 	mux.HandleFunc("GET /streams",
-		ratelimit.Wrap(s.LimitList, ratelimit.ClientIPKey, s.handleListStreams))
+		ratelimit.Wrap(s.LimitList, keyFn, s.handleListStreams))
 
 	mux.HandleFunc("GET /streams/{id}",
-		ratelimit.Wrap(s.LimitList, ratelimit.ClientIPKey, s.handleGetStream))
+		ratelimit.Wrap(s.LimitList, keyFn, s.handleGetStream))
 
 	mux.HandleFunc("PATCH /streams/{id}",
-		ratelimit.Wrap(s.LimitPatch, ratelimit.ClientIPKey, s.handlePatchStream))
+		ratelimit.Wrap(s.LimitPatch, keyFn, s.handlePatchStream))
 
 	// DELETE is intentionally unlimited per the spec — the owner
 	// token gates abuse, and we want disconnect to always succeed.
 	mux.HandleFunc("DELETE /streams/{id}", s.handleDeleteStream)
 
 	mux.HandleFunc("POST /streams/{id}/report",
-		ratelimit.Wrap(s.LimitReport, ratelimit.ClientIPKey, s.handleReportStream))
+		ratelimit.Wrap(s.LimitReport, keyFn, s.handleReportStream))
 
 	return s.withRequestLogging(mux)
 }
@@ -115,7 +128,7 @@ func (s *Server) withRequestLogging(next http.Handler) http.Handler {
 			"path", r.URL.Path,
 			"status", rw.status,
 			"duration_ms", time.Since(start).Milliseconds(),
-			"remote", clientIP(r),
+			"remote", s.clientIP(r),
 		)
 	})
 }
@@ -174,7 +187,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Cloudflare's egress, not from where the stream lives).
 	finalEndpoint := req.Endpoint
 	if req.EndpointMode == "direct" {
-		if rewritten, ok := rewriteEndpointHost(req.Endpoint, clientIP(r)); ok {
+		if rewritten, ok := rewriteEndpointHost(req.Endpoint, s.clientIP(r)); ok {
 			finalEndpoint = rewritten
 		}
 	}
@@ -193,7 +206,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		Endpoint:         finalEndpoint,
 		EndpointMode:     req.EndpointMode,
 		ClientCount:      0,
-		PublicIP:         clientIP(r),
+		PublicIP:         s.clientIP(r),
 		Version:          req.Version,
 		RegisteredAt:     now,
 		LastHeartbeatAt:  now,
@@ -409,17 +422,37 @@ func (s *Server) handleReportStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.Store.InsertReport(r.Context(), streamID, clientIP(r), req.Reason, req.ReporterContact); err != nil {
+	if err := s.Store.InsertReport(r.Context(), streamID, s.clientIP(r), req.Reason, req.ReporterContact); err != nil {
 		s.Logger.Error("report_failed", "err", err, "stream_id", streamID)
 		writeError(w, http.StatusInternalServerError, CodeInternal, "failed to record report")
 		return
 	}
+	// Receipt ID handed back to the user so they have a reference to
+	// quote if they ever need to follow up with the maintainer. Short
+	// hex + R- prefix so it's recognisable as a report id and not
+	// confused with a tunnel id or any other UUID floating around.
+	// Logged at info so the maintainer can grep the log for a given
+	// receipt and find the original row.
+	reportID, _ := newReceiptID()
 	s.Logger.Info("report_received",
 		"stream_id", streamID,
-		"reporter_ip", clientIP(r),
+		"reporter_ip", s.clientIP(r),
 		"reason_len", len(req.Reason),
+		"report_id", reportID,
 	)
-	w.WriteHeader(http.StatusAccepted)
+	writeJSON(w, http.StatusAccepted, ReportResponse{ReportID: reportID})
+}
+
+// newReceiptID returns a short user-facing identifier of the form
+// R-XXXXXXXX (8 hex chars after the prefix). 32 bits of entropy is
+// more than enough — collisions don't matter for human reference,
+// the canonical record is the stream_reports row keyed by db PK.
+func newReceiptID() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "R-" + strings.ToUpper(hex.EncodeToString(b[:])), nil
 }
 
 // --- validation ---
@@ -633,12 +666,38 @@ func newToken() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
-// clientIP extracts the request's source IP without the port. Falls
-// back to the raw RemoteAddr if the host:port split fails. We do NOT
-// honour X-Forwarded-For at this layer — the cloudflared / reverse
-// proxy in front of the directory is responsible for the source IP
-// it presents to us.
-func clientIP(r *http.Request) string {
+// clientIP extracts the request's source IP. When TrustProxyHeaders
+// is on (the typical deployment with FRP/Cloudflare in front), it
+// looks at Cf-Connecting-Ip / True-Client-Ip / X-Real-Ip /
+// X-Forwarded-For first and falls back to the TCP RemoteAddr. When
+// off (the service is exposed directly), it uses RemoteAddr only —
+// which is the correct, spoofing-resistant choice in that case.
+//
+// X-Forwarded-For can be a comma-separated chain (proxy1, proxy2,
+// real-client); we take the FIRST entry which is the original
+// client. Note: in trust-proxy mode a malicious client connecting
+// *direct* to the directory could forge these headers and obscure
+// their real IP. That's an accepted tradeoff — the same IP appears
+// in `publicIp` on the listing anyway, which is the audit signal
+// for moderation.
+func (s *Server) clientIP(r *http.Request) string {
+	if s.TrustProxyHeaders {
+		for _, h := range []string{"Cf-Connecting-Ip", "True-Client-Ip", "X-Real-Ip"} {
+			if v := strings.TrimSpace(r.Header.Get(h)); v != "" {
+				return v
+			}
+		}
+		if v := r.Header.Get("X-Forwarded-For"); v != "" {
+			// Pick the left-most entry — the original client. Anything
+			// to the right is a proxy hop appended along the way.
+			if comma := strings.Index(v, ","); comma >= 0 {
+				v = v[:comma]
+			}
+			if v = strings.TrimSpace(v); v != "" {
+				return v
+			}
+		}
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr

--- a/platform/services/directory/internal/api/register_test.go
+++ b/platform/services/directory/internal/api/register_test.go
@@ -95,6 +95,18 @@ func TestRegister_Validation(t *testing.T) {
 		{"fps absurd", func(r *RegisterRequest) { r.FPS = 100_000 }},
 		{"bad codec", func(r *RegisterRequest) { r.Codec = "av1" }},
 		{"bad endpoint mode", func(r *RegisterRequest) { r.EndpointMode = "bogus" }},
+		// #56 — defence-in-depth URL validation. The client already
+		// blocks publish on these in UIConfigurationStreaming, but
+		// the service rejects them too so a hand-rolled curl can't
+		// poison the listing.
+		{"endpoint typo scheme", func(r *RegisterRequest) { r.Endpoint = "htts://foo.com" }},
+		{"endpoint missing colon", func(r *RegisterRequest) { r.Endpoint = "https//foo.com" }},
+		{"endpoint plain text", func(r *RegisterRequest) { r.Endpoint = "not-a-url" }},
+		{"endpoint scheme only", func(r *RegisterRequest) { r.Endpoint = "https://" }},
+		{"endpoint port too high", func(r *RegisterRequest) { r.Endpoint = "http://foo.com:99999" }},
+		{"endpoint port zero", func(r *RegisterRequest) { r.Endpoint = "http://foo.com:0" }},
+		{"endpoint port non-numeric", func(r *RegisterRequest) { r.Endpoint = "http://foo.com:abc" }},
+		{"endpoint host punct only", func(r *RegisterRequest) { r.Endpoint = "http://..." }},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/platform/services/directory/internal/api/types.go
+++ b/platform/services/directory/internal/api/types.go
@@ -130,3 +130,12 @@ type ReportRequest struct {
 	Reason          string `json:"reason"`
 	ReporterContact string `json:"reporterContact"`
 }
+
+// ReportResponse is what POST /streams/{id}/report returns on success.
+// The reportId is a short human-readable receipt the user can quote if
+// they later need to reference the report when contacting the
+// maintainer. The same id is logged on the service side, so the
+// maintainer can grep the log to find the original report.
+type ReportResponse struct {
+	ReportID string `json:"reportId"`
+}

--- a/platform/services/directory/internal/config/config.go
+++ b/platform/services/directory/internal/config/config.go
@@ -31,6 +31,17 @@ type Config struct {
 	RatePatchPerHour     int
 	RateListPerHour      int
 	RateReportPerHour    int
+
+	// When true, the service reads the source IP from
+	// Cf-Connecting-Ip / True-Client-Ip / X-Real-Ip / X-Forwarded-For
+	// before falling back to the TCP RemoteAddr. Required when the
+	// directory is deployed behind a reverse proxy (FRP, nginx,
+	// Cloudflare) that doesn't rewrite RemoteAddr but does forward
+	// the real client IP via these headers. Without this the
+	// publicIp on every entry and the reporter_ip on every report
+	// would be the proxy's IP, and per-IP rate limits would treat
+	// the whole internet as one bucket.
+	TrustProxyHeaders bool
 }
 
 // Load reads environment variables and returns a populated Config.
@@ -47,6 +58,10 @@ func Load() (Config, error) {
 		RatePatchPerHour:     60,
 		RateListPerHour:      600,
 		RateReportPerHour:    30,
+		// Default OFF so a fresh deployment exposed directly is
+		// spoofing-resistant by default. Operators behind a proxy
+		// flip DIRECTORY_TRUST_PROXY_HEADERS=true to opt in.
+		TrustProxyHeaders: false,
 	}
 
 	parsePositiveInt := func(name string, dst *int) error {
@@ -100,6 +115,17 @@ func Load() (Config, error) {
 	if err := parsePositiveInt("DIRECTORY_RATE_PATCH_PER_HOUR",     &cfg.RatePatchPerHour);     err != nil { return cfg, err }
 	if err := parsePositiveInt("DIRECTORY_RATE_LIST_PER_HOUR",      &cfg.RateListPerHour);      err != nil { return cfg, err }
 	if err := parsePositiveInt("DIRECTORY_RATE_REPORT_PER_HOUR",    &cfg.RateReportPerHour);    err != nil { return cfg, err }
+
+	if v := os.Getenv("DIRECTORY_TRUST_PROXY_HEADERS"); v != "" {
+		switch strings.ToLower(v) {
+		case "1", "true", "yes", "on":
+			cfg.TrustProxyHeaders = true
+		case "0", "false", "no", "off":
+			cfg.TrustProxyHeaders = false
+		default:
+			return cfg, fmt.Errorf("DIRECTORY_TRUST_PROXY_HEADERS must be true/false, got %q", v)
+		}
+	}
 
 	return cfg, nil
 }

--- a/platform/services/directory/internal/store/migrations/002_report_id.sql
+++ b/platform/services/directory/internal/store/migrations/002_report_id.sql
@@ -1,0 +1,13 @@
+-- 002_report_id.sql — add the user-facing receipt id to stream_reports.
+--
+-- Each row gains a `report_id` column populated at INSERT time with
+-- the same R-XXXXXXXX string the directory hands back to the user in
+-- the POST /streams/<id>/report response. Lets the maintainer pivot
+-- from "user quoted protocol R-AB12CD34" directly to the original
+-- report row, without having to grep the service log.
+--
+-- Existing rows (pre-migration) get the empty default; they
+-- predate the receipt feature and their reporters never had a
+-- number to quote.
+ALTER TABLE stream_reports ADD COLUMN report_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX idx_reports_report_id ON stream_reports(report_id);

--- a/platform/services/directory/internal/store/store.go
+++ b/platform/services/directory/internal/store/store.go
@@ -394,12 +394,14 @@ func (s *Store) DeleteExpired(ctx context.Context, cutoff time.Time) (int64, err
 
 // InsertReport appends a moderation report row. Append-only — the
 // directory itself never reads these back; the operator pulls them
-// out manually for triage.
-func (s *Store) InsertReport(ctx context.Context, streamID, reporterIP, reason, contact string) error {
+// out manually for triage. The reportID is the same R-XXXXXXXX
+// receipt handed back to the user, indexed so the maintainer can
+// look up a report by the number the reporter quoted.
+func (s *Store) InsertReport(ctx context.Context, streamID, reportID, reporterIP, reason, contact string) error {
 	_, err := s.db.ExecContext(ctx, `
-        INSERT INTO stream_reports(stream_id, reporter_ip, reason, contact, reported_at)
-        VALUES(?,?,?,?,?)
-    `, streamID, reporterIP, reason, contact, time.Now().Unix())
+        INSERT INTO stream_reports(stream_id, report_id, reporter_ip, reason, contact, reported_at)
+        VALUES(?,?,?,?,?,?)
+    `, streamID, reportID, reporterIP, reason, contact, time.Now().Unix())
 	return err
 }
 

--- a/platform/services/directory/internal/store/store_test.go
+++ b/platform/services/directory/internal/store/store_test.go
@@ -290,7 +290,7 @@ func TestDeleteExpired(t *testing.T) {
 
 func TestInsertReport(t *testing.T) {
 	s := newTestStore(t)
-	if err := s.InsertReport(context.Background(), "anyid", "9.9.9.9", "spam", "alice@example"); err != nil {
+	if err := s.InsertReport(context.Background(), "anyid", "R-AB12CD34", "9.9.9.9", "spam", "alice@example"); err != nil {
 		t.Fatalf("insert report: %v", err)
 	}
 }

--- a/src/capture/IVideoCapture.h
+++ b/src/capture/IVideoCapture.h
@@ -51,5 +51,13 @@ public:
     virtual uint32_t getWidth() const = 0;
     virtual uint32_t getHeight() const = 0;
     virtual uint32_t getPixelFormat() const = 0;
+
+    /**
+     * Hint for the UI that a remote capture has been failing to
+     * reconnect for long enough that the host is probably down (not
+     * just hiccupping). Local capture backends always return false.
+     * See VideoCaptureRemote for the threshold (#58).
+     */
+    virtual bool isHostLikelyOffline() const { return false; }
 };
 

--- a/src/capture/IVideoCapture.h
+++ b/src/capture/IVideoCapture.h
@@ -59,5 +59,18 @@ public:
      * See VideoCaptureRemote for the threshold (#58).
      */
     virtual bool isHostLikelyOffline() const { return false; }
+
+    /**
+     * True iff this capture is actively producing frames right now.
+     * Distinct from isOpen() — a remote capture stays open across
+     * reconnects (URL is still armed) but isReceivingFrames() flips
+     * to false while the decode loop is mid-handshake. The overlay
+     * uses this to drive "Connecting / Reconnecting" feedback that
+     * the cached captureWidth/Height can't supply (those stay at
+     * the last value forever after the stream drops).
+     * Local backends return true whenever isOpen() is true — they
+     * never hold a "reconnect" state.
+     */
+    virtual bool isReceivingFrames() const { return isOpen(); }
 };
 

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -873,6 +873,10 @@ void VideoCaptureRemote::decodeLoop()
             const int64_t nowWallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                                           std::chrono::steady_clock::now().time_since_epoch()).count();
             int64_t targetWallUs = nowWallUs;
+            // Record arrival time of every decoded frame so the UI
+            // overlay can tell a live stream from a stalled one
+            // even when m_streamAnchored hasn't been reset yet.
+            m_lastFrameAtSteadyUs.store(nowWallUs);
             if (!m_streamAnchored.load())
             {
                 m_streamAnchored.store(true);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -658,9 +658,43 @@ void VideoCaptureRemote::decodeLoop()
             cleanupDecoder(); // belt-and-braces: drop any half-init state
             if (!initDecoder())
             {
-                LOG_WARN("VideoCaptureRemote: reconnect to " + m_url + " failed, retrying in 2 s");
+                // #58 — capped exponential backoff. A host that's
+                // briefly hiccuping (Cloudflare blip, TLS glitch,
+                // app restart) reconnects within the first 2 s slot.
+                // A host that's offline for the night used to mean
+                // the client re-shook hands every 2 s indefinitely;
+                // that's a TLS handshake per try, which is rude on
+                // laptops and visible on the host's tunnel logs when
+                // it comes back. Step the delay up to a 60 s ceiling
+                // after a handful of failures so a long outage costs
+                // ~1 retry per minute instead of 30.
+                static const int kBackoffSecs[] = { 2, 2, 5, 5, 15, 30, 60 };
+                static const size_t kBackoffN   = sizeof(kBackoffSecs) / sizeof(kBackoffSecs[0]);
+                const uint32_t failures = m_consecutiveReconnectFailures.fetch_add(1) + 1;
+                const int      slot     = static_cast<int>(std::min<size_t>(failures - 1, kBackoffN - 1));
+                const int      delaySec = kBackoffSecs[slot];
+
+                // After ~30 consecutive failures (~15 min at the
+                // ceiling) flip the UI hint so the user understands
+                // we're still trying but the host doesn't look like
+                // it's coming back on its own. We don't auto-disconnect
+                // — the URL stays armed and a brief recovery still
+                // grabs the next slot.
+                if (failures >= 30 && !m_hostLikelyOffline.load())
+                {
+                    m_hostLikelyOffline.store(true);
+                    LOG_WARN("VideoCaptureRemote: " + std::to_string(failures) +
+                             " consecutive reconnect failures — host appears offline");
+                }
+
+                LOG_WARN("VideoCaptureRemote: reconnect to " + m_url + " failed (" +
+                         std::to_string(failures) + " in a row), retrying in " +
+                         std::to_string(delaySec) + " s");
                 cleanupDecoder();
-                for (int i = 0; i < 20 && m_decodeRunning.load(); ++i)
+                // Sleep in 100 ms slices so a stopCapture() call lands
+                // within ~100 ms even if we're 60 s into the wait.
+                const int slices = delaySec * 10;
+                for (int i = 0; i < slices && m_decodeRunning.load(); ++i)
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 }
@@ -679,6 +713,10 @@ void VideoCaptureRemote::decodeLoop()
                 m_frameQueue.clear();
             }
             rgbW = 0; rgbH = 0; rgbBuf.clear();
+            // Reconnect succeeded — drop backoff state so the next
+            // hiccup starts from the 2 s slot again.
+            m_consecutiveReconnectFailures.store(0);
+            m_hostLikelyOffline.store(false);
             LOG_INFO("VideoCaptureRemote: reconnected to " + m_url);
         }
 

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -217,6 +217,11 @@ private:
     // judder we get when network/decoder bursts let us poll multiple
     // new frames in quick succession.
     std::atomic<bool> m_streamAnchored{false};
+    // Steady-clock microseconds of the most recently decoded frame.
+    // Read by isReceivingFrames() to detect a stalled stream that
+    // m_streamAnchored hasn't reset yet (TCP read still blocking
+    // post host-disappear). Updated on every decoded video frame.
+    std::atomic<int64_t> m_lastFrameAtSteadyUs{0};
     int64_t m_streamStartWallUs  = 0;
     int64_t m_firstPtsTicks      = 0;
     // PTS of the first video frame in microseconds. Lets the audio
@@ -250,11 +255,26 @@ public:
      * Cleared as soon as any reconnect succeeds.
      */
     bool isHostLikelyOffline() const override { return m_hostLikelyOffline.load(); }
-    // m_streamAnchored is set true on the first decoded frame and
-    // reset to false in cleanupDecoder() / on av_read_frame failure
-    // — exactly the "are we actively decoding right now" signal the
-    // UI overlay needs.
-    bool isReceivingFrames() const override { return m_streamAnchored.load(); }
+    // 'Are we actively decoding right now?' — combines the
+    // m_streamAnchored handshake bit (true once the first frame
+    // decoded, reset in cleanupDecoder() / av_read_frame failure)
+    // with a 'last frame seen recently' staleness check. The
+    // staleness check matters because when the host disappears the
+    // TCP/TLS read can block for up to ~10 s before av_read_frame
+    // surfaces an error — without the staleness fallback the
+    // overlay would think we're still connected the whole time.
+    bool isReceivingFrames() const override
+    {
+        if (!m_streamAnchored.load()) return false;
+        const int64_t lastUs = m_lastFrameAtSteadyUs.load();
+        if (lastUs == 0) return false;
+        const int64_t nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                  std::chrono::steady_clock::now().time_since_epoch()).count();
+        // 2 s without a frame on a 60 fps stream = ~120 frames gap.
+        // Plenty of headroom for a hiccup but tight enough that a
+        // killed host is reflected in the overlay quickly.
+        return (nowUs - lastUs) < 2'000'000;
+    }
 
 private:
     // Capped exponential backoff state. The table is consulted with

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -250,6 +250,11 @@ public:
      * Cleared as soon as any reconnect succeeds.
      */
     bool isHostLikelyOffline() const override { return m_hostLikelyOffline.load(); }
+    // m_streamAnchored is set true on the first decoded frame and
+    // reset to false in cleanupDecoder() / on av_read_frame failure
+    // — exactly the "are we actively decoding right now" signal the
+    // UI overlay needs.
+    bool isReceivingFrames() const override { return m_streamAnchored.load(); }
 
 private:
     // Capped exponential backoff state. The table is consulted with

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -235,4 +235,27 @@ private:
     uint32_t m_statConsumed = 0;
     uint32_t m_statDropped  = 0;
     std::chrono::steady_clock::time_point m_statStart;
+
+public:
+    /**
+     * Reconnect-backoff signal for the UI (#58).
+     *
+     * True once `decodeLoop` has retried the connection enough times
+     * to suspect the host is gone for good rather than briefly
+     * hiccuping (~15 min at the 60s ceiling = 30 consecutive
+     * failures). The remote-connection window reads this and shows
+     * "Host appears offline" so the user can stop expecting a quick
+     * recovery and disconnect/reconnect manually if they want.
+     *
+     * Cleared as soon as any reconnect succeeds.
+     */
+    bool isHostLikelyOffline() const override { return m_hostLikelyOffline.load(); }
+
+private:
+    // Capped exponential backoff state. The table is consulted with
+    // `m_consecutiveReconnectFailures` clamped to the table size; on
+    // any successful reconnect the counter resets to 0 (and the
+    // offline hint clears with it).
+    std::atomic<uint32_t> m_consecutiveReconnectFailures{0};
+    std::atomic<bool>     m_hostLikelyOffline{false};
 };

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5460,6 +5460,20 @@ void Application::syncDirectoryClient()
 {
     if (!m_ui) return;
 
+    // Mirror the remote capture's reconnect-backoff flag onto
+    // UIManager so the Info panel and other UI surfaces can read it
+    // without holding the VideoCaptureRemote pointer themselves. In
+    // host mode m_capture isn't a VideoCaptureRemote and the
+    // dynamic_cast falls through to false (#58 follow-up).
+    {
+        bool offline = false;
+        if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
+        {
+            offline = remote->isHostLikelyOffline();
+        }
+        m_ui->setRemoteHostLikelyOffline(offline);
+    }
+
     // #49 Phase 3 — keep the server-side password gate in sync with
     // whatever the user typed in the publish UI. We hash on every
     // call (cheap, sha256 of < 1 KB), but the StreamManager setter

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2676,6 +2676,24 @@ void Application::handleKeyInput()
         {
             f12Pressed = false;
         }
+
+        // F11 toggles fullscreen. Edge-triggered like F12 so holding
+        // the key down doesn't oscillate the window state.
+        static bool f11Pressed = false;
+        bool f11Now = sdlWindow->isKeyPressed(SDLK_F11);
+        if (f11Now && !f11Pressed)
+        {
+            m_fullscreen = !m_fullscreen;
+            m_window->setFullscreen(m_fullscreen, m_monitorIndex);
+            if (m_ui) m_ui->setFullscreen(m_fullscreen);
+            LOG_INFO(std::string("Fullscreen toggled: ") +
+                     (m_fullscreen ? "ON" : "OFF"));
+            f11Pressed = true;
+        }
+        else if (!f11Now)
+        {
+            f11Pressed = false;
+        }
     }
 #else
     GLFWwindow *window = static_cast<GLFWwindow *>(m_window->getWindow());
@@ -2696,6 +2714,25 @@ void Application::handleKeyInput()
     else
     {
         f12Pressed = false;
+    }
+
+    // F11 toggles fullscreen.
+    static bool f11Pressed = false;
+    if (glfwGetKey(window, GLFW_KEY_F11) == GLFW_PRESS)
+    {
+        if (!f11Pressed)
+        {
+            m_fullscreen = !m_fullscreen;
+            m_window->setFullscreen(m_fullscreen, m_monitorIndex);
+            if (m_ui) m_ui->setFullscreen(m_fullscreen);
+            LOG_INFO(std::string("Fullscreen toggled: ") +
+                     (m_fullscreen ? "ON" : "OFF"));
+            f11Pressed = true;
+        }
+    }
+    else
+    {
+        f11Pressed = false;
     }
 #endif // USE_SDL2
 }

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5460,18 +5460,31 @@ void Application::syncDirectoryClient()
 {
     if (!m_ui) return;
 
-    // Mirror the remote capture's reconnect-backoff flag onto
-    // UIManager so the Info panel and other UI surfaces can read it
-    // without holding the VideoCaptureRemote pointer themselves. In
-    // host mode m_capture isn't a VideoCaptureRemote and the
-    // dynamic_cast falls through to false (#58 follow-up).
+    // Mirror the remote capture's reconnect-backoff flag and the
+    // "currently decoding frames" flag onto UIManager so the Info
+    // panel and the connection overlay can read them without holding
+    // the VideoCaptureRemote pointer themselves. In host mode
+    // m_capture isn't a VideoCaptureRemote and the dynamic_cast
+    // falls through to defaults (offline=false, receivingFrames=
+    // whatever the base class reports — which is isOpen() for local
+    // backends).
     {
-        bool offline = false;
-        if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
+        bool offline   = false;
+        bool receiving = false;
+        if (m_capture)
         {
-            offline = remote->isHostLikelyOffline();
+            if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
+            {
+                offline   = remote->isHostLikelyOffline();
+                receiving = remote->isReceivingFrames();
+            }
+            else
+            {
+                receiving = m_capture->isReceivingFrames();
+            }
         }
         m_ui->setRemoteHostLikelyOffline(offline);
+        m_ui->setRemoteReceivingFrames(receiving);
     }
 
     // #49 Phase 3 — keep the server-side password gate in sync with

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -4,8 +4,97 @@
 #include "../encoding/MediaEncoder.h"
 #include <imgui.h>
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <thread>
+
+namespace
+{
+    // #56 — minimal URL validation for the "Custom" endpoint mode.
+    // Catches the typo class that used to leak into the directory
+    // ("htts://foo", "https//foo.com", missing port number etc.) and
+    // makes the receiving service look broken to anyone browsing.
+    // The companion guard on the service side rejects malformed
+    // endpoints with 400, but the inline UI check catches the typo
+    // before the user toggles Publish on at all.
+    bool validateCustomEndpoint(const std::string &url, std::string &errOut)
+    {
+        errOut.clear();
+        if (url.empty())
+        {
+            errOut = "URL is empty";
+            return false;
+        }
+        size_t schemeEnd;
+        if (url.rfind("http://", 0) == 0)       schemeEnd = 7;
+        else if (url.rfind("https://", 0) == 0) schemeEnd = 8;
+        else
+        {
+            errOut = "URL must start with http:// or https://";
+            return false;
+        }
+        size_t i         = schemeEnd;
+        size_t hostStart = i;
+        while (i < url.size() && url[i] != ':' && url[i] != '/') ++i;
+        const std::string host = url.substr(hostStart, i - hostStart);
+        if (host.empty())
+        {
+            errOut = "Host is empty";
+            return false;
+        }
+        for (char c : host)
+        {
+            if (!(std::isalnum(static_cast<unsigned char>(c)) ||
+                  c == '.' || c == '-'))
+            {
+                errOut = "Invalid character in host";
+                return false;
+            }
+        }
+        // Host must contain at least one alphanumeric (eg. "..." or
+        // "---" alone is meaningless).
+        bool anyAlnum = false;
+        for (char c : host)
+        {
+            if (std::isalnum(static_cast<unsigned char>(c))) { anyAlnum = true; break; }
+        }
+        if (!anyAlnum)
+        {
+            errOut = "Host must contain a letter or digit";
+            return false;
+        }
+        if (i < url.size() && url[i] == ':')
+        {
+            ++i;
+            const size_t portStart = i;
+            while (i < url.size() && url[i] != '/') ++i;
+            const std::string portStr = url.substr(portStart, i - portStart);
+            if (portStr.empty())
+            {
+                errOut = "Port is empty";
+                return false;
+            }
+            long port = 0;
+            try { port = std::stol(portStr); }
+            catch (...) { errOut = "Invalid port"; return false; }
+            for (char c : portStr)
+            {
+                if (!std::isdigit(static_cast<unsigned char>(c)))
+                {
+                    errOut = "Invalid port";
+                    return false;
+                }
+            }
+            if (port < 1 || port > 65535)
+            {
+                errOut = "Port out of range (1..65535)";
+                return false;
+            }
+        }
+        // Anything after the host[:port] is the path — accepted as-is.
+        return true;
+    }
+}
 
 UIConfigurationStreaming::UIConfigurationStreaming(UIManager *uiManager)
     : m_uiManager(uiManager)
@@ -932,6 +1021,19 @@ void UIConfigurationStreaming::renderDirectoryPublish()
             ImGui::SetTooltip("Paste the public URL you've already set up\n"
                               "(FRP, Tailscale Funnel, ngrok, your own domain…).");
         }
+        // Inline validation — shown only when the user has typed
+        // *something*, so an empty field doesn't shout at them
+        // before they've had a chance to fill it in. The 'fill it in'
+        // case is handled by the publish-toggle gate below.
+        {
+            const std::string current = m_uiManager->getDirectoryCustomEndpoint();
+            std::string err;
+            if (!current.empty() && !validateCustomEndpoint(current, err))
+            {
+                ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.40f, 1.0f),
+                                   "Invalid URL: %s", err.c_str());
+            }
+        }
     }
     else if (endpointMode == "tunnel-cloudflare")
     {
@@ -1048,6 +1150,15 @@ void UIConfigurationStreaming::renderDirectoryPublish()
     else if (mode == "custom" && trimmedCustom.empty())
     {
         blockedReason = "Fill in the custom endpoint URL to enable publishing.";
+    }
+    else if (mode == "custom")
+    {
+        std::string customErr;
+        if (!validateCustomEndpoint(trimmedCustom, customErr))
+        {
+            blockedReason = "Custom endpoint URL is invalid (" + customErr +
+                            "). Fix it to enable publishing.";
+        }
     }
     const bool canToggle = blockedReason.empty();
 

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -2,6 +2,7 @@
 #include "UIManager.h"
 #include "UIRemoteConnection.h"
 #include "../streaming/DirectoryBrowser.h"
+#include "../utils/HttpClient.h"
 #include "../utils/PasswordHash.h"
 
 #include <imgui.h>
@@ -10,6 +11,7 @@
 #include <cctype>
 #include <cstdio>
 #include <cstring>
+#include <thread>
 
 #ifndef RETROCAPTURE_VERSION
 #define RETROCAPTURE_VERSION "0.0.0-dev"
@@ -95,6 +97,7 @@ void UIDirectoryBrowser::render()
     // is on screen; rendering it here keeps it visible even if the
     // main window scrolls away.
     renderPasswordModal();
+    renderReportModal();
 }
 
 void UIDirectoryBrowser::renderTable()
@@ -234,6 +237,26 @@ void UIDirectoryBrowser::renderTable()
                     "Wire protocol may differ — connection may fail or behave oddly.",
                     e.version.c_str(), RETROCAPTURE_VERSION);
             }
+            // #57 — right-click → flag this stream for the maintainer
+            // to review. Service endpoint POST /streams/<id>/report
+            // already exists; this is the UI half.
+            if (ImGui::BeginPopupContextItem("##rowctx"))
+            {
+                if (ImGui::Selectable("Report this stream..."))
+                {
+                    m_reportStreamId   = e.streamId;
+                    m_reportStreamName = e.name;
+                    m_reportReason[0]  = '\0';
+                    m_reportContact[0] = '\0';
+                    {
+                        std::lock_guard<std::mutex> lock(m_reportMu);
+                        m_reportStatus = ReportStatus::Idle;
+                        m_reportError.clear();
+                    }
+                    m_showReportModal = true;
+                }
+                ImGui::EndPopup();
+            }
             ImGui::TableNextColumn();
             if (e.passwordRequired)
             {
@@ -314,4 +337,194 @@ void UIDirectoryBrowser::renderPasswordModal()
         }
         ImGui::EndPopup();
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Report-this-stream modal (#57)
+//
+// User opens it from the row context menu. Reason is required; contact
+// is optional. POST /streams/<id>/report is rate-limited at 30/hour
+// per source IP server-side, so the modal surfaces 429s clearly.
+// There's deliberately no feedback about what the maintainer did with
+// the report — the spec is firm that this is a one-way flag, not a
+// community-moderation system.
+// ─────────────────────────────────────────────────────────────────────
+void UIDirectoryBrowser::renderReportModal()
+{
+    if (m_showReportModal) ImGui::OpenPopup("Report Stream");
+    if (!ImGui::BeginPopupModal("Report Stream", nullptr,
+                                ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        return;
+    }
+
+    ImGui::Text("Stream: %s",
+                m_reportStreamName.empty() ? "(unnamed)" : m_reportStreamName.c_str());
+    ImGui::Spacing();
+    ImGui::TextWrapped(
+        "Flag this stream for the maintainer to review. There's no "
+        "automated takedown — the maintainer drains the report log "
+        "manually.");
+    ImGui::Spacing();
+    ImGui::Text("Reason (required):");
+    ImGui::SetNextItemWidth(420);
+    ImGui::InputTextMultiline("##reportReason", m_reportReason,
+                              sizeof(m_reportReason),
+                              ImVec2(420, 80));
+    ImGui::Spacing();
+    ImGui::Text("Your contact (optional — email or @handle):");
+    ImGui::SetNextItemWidth(420);
+    ImGui::InputText("##reportContact", m_reportContact, sizeof(m_reportContact));
+
+    ImGui::Spacing();
+    ReportStatus statusSnap;
+    std::string  errSnap;
+    {
+        std::lock_guard<std::mutex> lock(m_reportMu);
+        statusSnap = m_reportStatus;
+        errSnap    = m_reportError;
+    }
+
+    if (statusSnap == ReportStatus::Success)
+    {
+        ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f),
+                           "Thanks — the maintainer will review this.");
+        ImGui::Spacing();
+        if (ImGui::Button("Close", ImVec2(120, 0)))
+        {
+            m_showReportModal = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+        return;
+    }
+
+    if (statusSnap == ReportStatus::Failed)
+    {
+        ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.40f, 1.0f),
+                           "Submit failed:");
+        ImGui::TextWrapped("%s", errSnap.c_str());
+        ImGui::Spacing();
+    }
+
+    const bool busy        = (statusSnap == ReportStatus::Sending);
+    const bool reasonOk    = (std::strlen(m_reportReason) > 0 &&
+                              std::strlen(m_reportReason) <= 200);
+
+    ImGui::BeginDisabled(busy || !reasonOk || m_reportStreamId.empty());
+    if (ImGui::Button(busy ? "Sending..." : "Submit", ImVec2(120, 0)))
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_reportMu);
+            m_reportStatus = ReportStatus::Sending;
+            m_reportError.clear();
+        }
+        m_reportInFlight.store(true);
+        // Snapshot the fields before kicking off the thread — the
+        // user can still close the modal while the POST is in flight.
+        const std::string directoryUrl = m_uiManager
+            ? m_uiManager->getDirectoryUrl() : std::string();
+        const std::string streamId = m_reportStreamId;
+        std::string reason  = m_reportReason;
+        std::string contact = m_reportContact;
+        std::thread([this, directoryUrl, streamId, reason, contact]() {
+            // Trim trailing slash from the directory URL so we don't
+            // produce //streams/<id>/report.
+            std::string base = directoryUrl;
+            while (!base.empty() && base.back() == '/') base.pop_back();
+            const std::string url = base + "/streams/" + streamId + "/report";
+
+            // Build the JSON body. nlohmann::json is already pulled in
+            // by DirectoryClient; using string concat instead keeps
+            // this translation unit free of one more include.
+            auto escapeJson = [](const std::string &s) {
+                std::string out;
+                out.reserve(s.size() + 2);
+                for (char c : s)
+                {
+                    switch (c)
+                    {
+                        case '"':  out += "\\\""; break;
+                        case '\\': out += "\\\\"; break;
+                        case '\n': out += "\\n";  break;
+                        case '\r': out += "\\r";  break;
+                        case '\t': out += "\\t";  break;
+                        default:
+                            if (static_cast<unsigned char>(c) < 0x20)
+                            {
+                                char buf[8];
+                                std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                                out += buf;
+                            }
+                            else out += c;
+                    }
+                }
+                return out;
+            };
+            std::string body = "{\"reason\":\"" + escapeJson(reason) + "\"";
+            if (!contact.empty())
+            {
+                body += ",\"reporterContact\":\"" + escapeJson(contact) + "\"";
+            }
+            body += "}";
+
+            HttpClient::Response resp = HttpClient::send(
+                HttpClient::Method::POST, url, body, /*timeoutMs=*/5000);
+
+            std::lock_guard<std::mutex> lock(m_reportMu);
+            if (resp.ok && resp.statusCode >= 200 && resp.statusCode < 300)
+            {
+                m_reportStatus = ReportStatus::Success;
+            }
+            else
+            {
+                m_reportStatus = ReportStatus::Failed;
+                if (resp.statusCode == 429)
+                {
+                    m_reportError = "Too many reports from this network — "
+                                    "try again later.";
+                    if (!resp.retryAfter.empty())
+                    {
+                        m_reportError += " (Retry-After: " + resp.retryAfter + " s)";
+                    }
+                }
+                else if (resp.statusCode > 0)
+                {
+                    m_reportError = "Directory returned HTTP " +
+                                    std::to_string(resp.statusCode);
+                    if (!resp.body.empty())
+                    {
+                        // First line of the body — usually the JSON
+                        // error message — is enough context.
+                        size_t nl = resp.body.find('\n');
+                        m_reportError += ": " +
+                            resp.body.substr(0, nl == std::string::npos
+                                                    ? resp.body.size() : nl);
+                    }
+                }
+                else
+                {
+                    m_reportError = resp.error.empty()
+                        ? "Couldn't reach the directory service."
+                        : resp.error;
+                }
+            }
+            m_reportInFlight.store(false);
+        }).detach();
+    }
+    ImGui::EndDisabled();
+    if (!reasonOk && std::strlen(m_reportReason) == 0)
+    {
+        ImGui::SameLine();
+        ImGui::TextDisabled("(reason can't be empty)");
+    }
+    ImGui::SameLine();
+    ImGui::BeginDisabled(busy);
+    if (ImGui::Button("Cancel", ImVec2(120, 0)))
+    {
+        m_showReportModal = false;
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndDisabled();
+    ImGui::EndPopup();
 }

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -191,7 +191,7 @@ void UIDirectoryBrowser::renderTable()
                                      | ImGuiTableFlags_BordersInnerH
                                      | ImGuiTableFlags_ScrollY
                                      | ImGuiTableFlags_SizingStretchProp;
-    if (ImGui::BeginTable("##dirTable", 8, tableFlags, ImVec2(0, -ImGui::GetFrameHeightWithSpacing())))
+    if (ImGui::BeginTable("##dirTable", 10, tableFlags, ImVec2(0, -ImGui::GetFrameHeightWithSpacing())))
     {
         ImGui::TableSetupScrollFreeze(0, 1);
         ImGui::TableSetupColumn("Name",     ImGuiTableColumnFlags_WidthStretch, 3.0f);
@@ -205,6 +205,13 @@ void UIDirectoryBrowser::renderTable()
         ImGui::TableSetupColumn("Codec",    ImGuiTableColumnFlags_WidthFixed, 45.0f);
         ImGui::TableSetupColumn("Clients (\xe2\x89\x88)", ImGuiTableColumnFlags_WidthFixed, 60.0f);
         ImGui::TableSetupColumn("Mode",     ImGuiTableColumnFlags_WidthFixed, 80.0f);
+        // Explicit action buttons per row. Previously the user clicked
+        // the row to connect and right-clicked for Report; the context
+        // menu wasn't discoverable and click-anywhere-to-connect was
+        // easy to trigger accidentally. Both actions are now their
+        // own column.
+        ImGui::TableSetupColumn("##connect", ImGuiTableColumnFlags_WidthFixed, 80.0f);
+        ImGui::TableSetupColumn("##report",  ImGuiTableColumnFlags_WidthFixed, 70.0f);
         ImGui::TableHeadersRow();
 
         if (entries.empty())
@@ -225,38 +232,22 @@ void UIDirectoryBrowser::renderTable()
             const bool versionMismatch = !e.version.empty() &&
                                          e.version != std::string(RETROCAPTURE_VERSION);
 
-            std::string label;
-            if (versionMismatch) label += "\xe2\x9a\xa0 ";
-            label += e.name;
-            const bool clicked = ImGui::Selectable(label.c_str(), false,
-                                                   ImGuiSelectableFlags_SpanAllColumns);
-            if (versionMismatch && ImGui::IsItemHovered())
+            // Name cell: plain text with optional ⚠ prefix when the
+            // host announces a different protocol version.
+            if (versionMismatch)
             {
-                ImGui::SetTooltip(
-                    "Host version: %s\nThis client: %s\n"
-                    "Wire protocol may differ — connection may fail or behave oddly.",
-                    e.version.c_str(), RETROCAPTURE_VERSION);
-            }
-            // #57 — right-click → flag this stream for the maintainer
-            // to review. Service endpoint POST /streams/<id>/report
-            // already exists; this is the UI half.
-            if (ImGui::BeginPopupContextItem("##rowctx"))
-            {
-                if (ImGui::Selectable("Report this stream..."))
+                ImGui::TextUnformatted("\xe2\x9a\xa0");
+                if (ImGui::IsItemHovered())
                 {
-                    m_reportStreamId   = e.streamId;
-                    m_reportStreamName = e.name;
-                    m_reportReason[0]  = '\0';
-                    m_reportContact[0] = '\0';
-                    {
-                        std::lock_guard<std::mutex> lock(m_reportMu);
-                        m_reportStatus = ReportStatus::Idle;
-                        m_reportError.clear();
-                    }
-                    m_showReportModal = true;
+                    ImGui::SetTooltip(
+                        "Host version: %s\nThis client: %s\n"
+                        "Wire protocol may differ — connection may fail or behave oddly.",
+                        e.version.c_str(), RETROCAPTURE_VERSION);
                 }
-                ImGui::EndPopup();
+                ImGui::SameLine();
             }
+            ImGui::TextUnformatted(e.name.c_str());
+
             ImGui::TableNextColumn();
             if (e.passwordRequired)
             {
@@ -276,7 +267,11 @@ void UIDirectoryBrowser::renderTable()
             ImGui::TableNextColumn();
             ImGui::TextDisabled("%s", endpointModeIcon(e.endpointMode));
 
-            if (clicked)
+            // Connect button — column 9. Stretches to fill the
+            // 80-px column so the click target is generous. Triggers
+            // the password modal first when the stream is gated.
+            ImGui::TableNextColumn();
+            if (ImGui::Button("Connect", ImVec2(-1, 0)))
             {
                 if (e.passwordRequired)
                 {
@@ -290,6 +285,28 @@ void UIDirectoryBrowser::renderTable()
                     m_remoteWindow->triggerConnect(e.endpoint);
                 }
             }
+
+            // Report button — column 10. Opens the same modal the
+            // old right-click context menu used.
+            ImGui::TableNextColumn();
+            if (ImGui::Button("Report", ImVec2(-1, 0)))
+            {
+                m_reportStreamId   = e.streamId;
+                m_reportStreamName = e.name;
+                m_reportReason[0]  = '\0';
+                m_reportContact[0] = '\0';
+                {
+                    std::lock_guard<std::mutex> lock(m_reportMu);
+                    m_reportStatus = ReportStatus::Idle;
+                    m_reportError.clear();
+                }
+                m_showReportModal = true;
+            }
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Flag this stream for the maintainer to review.");
+            }
+
             ImGui::PopID();
         }
         ImGui::EndTable();

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -408,54 +408,26 @@ void UIDirectoryBrowser::renderReportModal()
 
     if (statusSnap == ReportStatus::Success)
     {
-        // Auto-close after a short window so the user doesn't have to
-        // dismiss anything manually, but long enough to read + copy
-        // the receipt id. 8 s landed after a few self-test reads:
-        // shorter than 6 felt rushed when the receipt was the thing
-        // the user wanted to save, longer than 10 felt like the modal
-        // was stuck.
-        constexpr int kAutoCloseSeconds = 8;
-        const auto now = std::chrono::steady_clock::now();
-        const int elapsedSec = static_cast<int>(
-            std::chrono::duration_cast<std::chrono::seconds>(now - m_reportSuccessAt).count());
-        const int remaining  = kAutoCloseSeconds - elapsedSec;
-
-        ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f),
-                           "Thanks — the maintainer will review this.");
+        // One screen, full message, single button. The protocol
+        // number is the only thing the user might want to copy, so
+        // it sits in a read-only InputText right after the line that
+        // names it.
+        ImGui::TextWrapped(
+            "Thanks for reporting. The Directory owner will review it.");
+        ImGui::Spacing();
         if (!receiptSnap.empty())
         {
-            ImGui::Spacing();
             ImGui::Text("Protocol number:");
             ImGui::SameLine();
-            // Read-only InputText so the receipt is copy-pasteable
-            // without us having to ship a clipboard helper. Small
-            // enough to fit on one line.
             char receiptBuf[64];
             std::snprintf(receiptBuf, sizeof(receiptBuf), "%s", receiptSnap.c_str());
             ImGui::SetNextItemWidth(180);
             ImGui::InputText("##receipt", receiptBuf, sizeof(receiptBuf),
                              ImGuiInputTextFlags_ReadOnly);
-            ImGui::TextDisabled("Save this number — quote it if you contact the maintainer\n"
-                                "about this report.");
         }
         ImGui::Spacing();
-        if (remaining > 0)
+        if (ImGui::Button("Close", ImVec2(120, 0)))
         {
-            // Manual override stays available — the user who already
-            // copied the receipt can dismiss early.
-            char btnLbl[40];
-            std::snprintf(btnLbl, sizeof(btnLbl), "Close (auto in %ds)", remaining);
-            if (ImGui::Button(btnLbl, ImVec2(180, 0)))
-            {
-                m_showReportModal = false;
-                ImGui::CloseCurrentPopup();
-            }
-        }
-        else
-        {
-            // Time's up — close ourselves. CloseCurrentPopup must be
-            // called from within the BeginPopupModal block, which is
-            // why this happens here rather than from the worker thread.
             m_showReportModal = false;
             ImGui::CloseCurrentPopup();
         }
@@ -538,8 +510,7 @@ void UIDirectoryBrowser::renderReportModal()
             std::lock_guard<std::mutex> lock(m_reportMu);
             if (resp.ok && resp.statusCode >= 200 && resp.statusCode < 300)
             {
-                m_reportStatus    = ReportStatus::Success;
-                m_reportSuccessAt = std::chrono::steady_clock::now();
+                m_reportStatus = ReportStatus::Success;
                 // Parse the reportId out of the response. Tiny ad-hoc
                 // parser to avoid pulling nlohmann::json into this TU
                 // for one field; the response shape is fixed at

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -299,6 +299,7 @@ void UIDirectoryBrowser::renderTable()
                     std::lock_guard<std::mutex> lock(m_reportMu);
                     m_reportStatus = ReportStatus::Idle;
                     m_reportError.clear();
+                    m_reportReceiptId.clear();
                 }
                 m_showReportModal = true;
             }
@@ -379,7 +380,8 @@ void UIDirectoryBrowser::renderReportModal()
                 m_reportStreamName.empty() ? "(unnamed)" : m_reportStreamName.c_str());
     ImGui::Spacing();
     ImGui::TextWrapped(
-        "Flag this stream for the maintainer to review. There's no "
+        "This report goes to the directory maintainer, not to the "
+        "host of the stream and not to Cloudflare. There's no "
         "automated takedown — the maintainer drains the report log "
         "manually.");
     ImGui::Spacing();
@@ -396,16 +398,33 @@ void UIDirectoryBrowser::renderReportModal()
     ImGui::Spacing();
     ReportStatus statusSnap;
     std::string  errSnap;
+    std::string  receiptSnap;
     {
         std::lock_guard<std::mutex> lock(m_reportMu);
-        statusSnap = m_reportStatus;
-        errSnap    = m_reportError;
+        statusSnap  = m_reportStatus;
+        errSnap     = m_reportError;
+        receiptSnap = m_reportReceiptId;
     }
 
     if (statusSnap == ReportStatus::Success)
     {
         ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f),
                            "Thanks — the maintainer will review this.");
+        if (!receiptSnap.empty())
+        {
+            ImGui::Spacing();
+            ImGui::Text("Reference:");
+            ImGui::SameLine();
+            // Read-only InputText so the receipt is copy-pasteable
+            // without us having to ship a clipboard helper. Small
+            // enough to fit on one line.
+            char receiptBuf[64];
+            std::snprintf(receiptBuf, sizeof(receiptBuf), "%s", receiptSnap.c_str());
+            ImGui::SetNextItemWidth(180);
+            ImGui::InputText("##receipt", receiptBuf, sizeof(receiptBuf),
+                             ImGuiInputTextFlags_ReadOnly);
+            ImGui::TextDisabled("Quote this if you contact the maintainer about it.");
+        }
         ImGui::Spacing();
         if (ImGui::Button("Close", ImVec2(120, 0)))
         {
@@ -492,6 +511,30 @@ void UIDirectoryBrowser::renderReportModal()
             if (resp.ok && resp.statusCode >= 200 && resp.statusCode < 300)
             {
                 m_reportStatus = ReportStatus::Success;
+                // Parse the reportId out of the response. Tiny ad-hoc
+                // parser to avoid pulling nlohmann::json into this TU
+                // for one field; the response shape is fixed at
+                // {"reportId":"R-XXXXXXXX"}.
+                m_reportReceiptId.clear();
+                const std::string &b = resp.body;
+                const std::string key = "\"reportId\"";
+                size_t k = b.find(key);
+                if (k != std::string::npos)
+                {
+                    size_t colon = b.find(':', k + key.size());
+                    if (colon != std::string::npos)
+                    {
+                        size_t q1 = b.find('"', colon + 1);
+                        if (q1 != std::string::npos)
+                        {
+                            size_t q2 = b.find('"', q1 + 1);
+                            if (q2 != std::string::npos && q2 > q1 + 1)
+                            {
+                                m_reportReceiptId = b.substr(q1 + 1, q2 - q1 - 1);
+                            }
+                        }
+                    }
+                }
             }
             else
             {

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -98,6 +98,7 @@ void UIDirectoryBrowser::render()
     // main window scrolls away.
     renderPasswordModal();
     renderReportModal();
+    renderReportFeedbackModal();
 }
 
 void UIDirectoryBrowser::renderTable()
@@ -408,29 +409,19 @@ void UIDirectoryBrowser::renderReportModal()
 
     if (statusSnap == ReportStatus::Success)
     {
-        // One screen, full message, single button. The protocol
-        // number is the only thing the user might want to copy, so
-        // it sits in a read-only InputText right after the line that
-        // names it.
-        ImGui::TextWrapped(
-            "Thanks for reporting. The Directory owner will review it.");
-        ImGui::Spacing();
-        if (!receiptSnap.empty())
+        // Hand off to the dedicated feedback modal. We dismiss this
+        // input modal in the same frame and open the feedback one,
+        // which renders the confirmation message + protocol number.
+        // Reset status so a later "Report another stream" cycle
+        // doesn't replay this branch on the input modal.
         {
-            ImGui::Text("Protocol number:");
-            ImGui::SameLine();
-            char receiptBuf[64];
-            std::snprintf(receiptBuf, sizeof(receiptBuf), "%s", receiptSnap.c_str());
-            ImGui::SetNextItemWidth(180);
-            ImGui::InputText("##receipt", receiptBuf, sizeof(receiptBuf),
-                             ImGuiInputTextFlags_ReadOnly);
+            std::lock_guard<std::mutex> lock(m_reportMu);
+            m_reportFeedbackReceiptId = receiptSnap;
+            m_reportStatus = ReportStatus::Idle;
         }
-        ImGui::Spacing();
-        if (ImGui::Button("Close", ImVec2(120, 0)))
-        {
-            m_showReportModal = false;
-            ImGui::CloseCurrentPopup();
-        }
+        m_showReportFeedbackModal = true;
+        m_showReportModal         = false;
+        ImGui::CloseCurrentPopup();
         ImGui::EndPopup();
         return;
     }
@@ -586,5 +577,60 @@ void UIDirectoryBrowser::renderReportModal()
         ImGui::CloseCurrentPopup();
     }
     ImGui::EndDisabled();
+    ImGui::EndPopup();
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Report-feedback modal (#57 follow-up)
+//
+// Opened by renderReportModal() the moment a submit succeeds. The
+// input modal closes; this modal opens fresh. Single concern: tell
+// the user their report landed and give them the protocol number to
+// quote. Independent state from the input modal so the user can
+// dismiss this one without re-arming the report form.
+// ─────────────────────────────────────────────────────────────────────
+void UIDirectoryBrowser::renderReportFeedbackModal()
+{
+    if (m_showReportFeedbackModal) ImGui::OpenPopup("Report Sent");
+    if (!ImGui::BeginPopupModal("Report Sent", nullptr,
+                                ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        return;
+    }
+
+    ImGui::TextWrapped(
+        "Thanks for reporting. The Directory owner will review it.");
+    ImGui::Spacing();
+
+    if (!m_reportFeedbackReceiptId.empty())
+    {
+        ImGui::Text("Protocol number:");
+        ImGui::SameLine();
+        char receiptBuf[64];
+        std::snprintf(receiptBuf, sizeof(receiptBuf), "%s",
+                      m_reportFeedbackReceiptId.c_str());
+        ImGui::SetNextItemWidth(200);
+        ImGui::InputText("##feedbackReceipt", receiptBuf, sizeof(receiptBuf),
+                         ImGuiInputTextFlags_ReadOnly);
+        ImGui::TextDisabled("Quote this if you contact the maintainer.");
+    }
+    else
+    {
+        // Service didn't echo a reportId (older deploy, or transport
+        // dropped the body). The report still landed — the 2xx we
+        // got back is the signal — but there's no number to hand
+        // over. Be honest about it.
+        ImGui::TextDisabled(
+            "The directory service did not return a protocol number\n"
+            "for this report. The report itself was accepted.");
+    }
+
+    ImGui::Spacing();
+    if (ImGui::Button("Close", ImVec2(120, 0)))
+    {
+        m_showReportFeedbackModal = false;
+        m_reportFeedbackReceiptId.clear();
+        ImGui::CloseCurrentPopup();
+    }
     ImGui::EndPopup();
 }

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -408,12 +408,24 @@ void UIDirectoryBrowser::renderReportModal()
 
     if (statusSnap == ReportStatus::Success)
     {
+        // Auto-close after a short window so the user doesn't have to
+        // dismiss anything manually, but long enough to read + copy
+        // the receipt id. 8 s landed after a few self-test reads:
+        // shorter than 6 felt rushed when the receipt was the thing
+        // the user wanted to save, longer than 10 felt like the modal
+        // was stuck.
+        constexpr int kAutoCloseSeconds = 8;
+        const auto now = std::chrono::steady_clock::now();
+        const int elapsedSec = static_cast<int>(
+            std::chrono::duration_cast<std::chrono::seconds>(now - m_reportSuccessAt).count());
+        const int remaining  = kAutoCloseSeconds - elapsedSec;
+
         ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f),
                            "Thanks — the maintainer will review this.");
         if (!receiptSnap.empty())
         {
             ImGui::Spacing();
-            ImGui::Text("Reference:");
+            ImGui::Text("Protocol number:");
             ImGui::SameLine();
             // Read-only InputText so the receipt is copy-pasteable
             // without us having to ship a clipboard helper. Small
@@ -423,11 +435,27 @@ void UIDirectoryBrowser::renderReportModal()
             ImGui::SetNextItemWidth(180);
             ImGui::InputText("##receipt", receiptBuf, sizeof(receiptBuf),
                              ImGuiInputTextFlags_ReadOnly);
-            ImGui::TextDisabled("Quote this if you contact the maintainer about it.");
+            ImGui::TextDisabled("Save this number — quote it if you contact the maintainer\n"
+                                "about this report.");
         }
         ImGui::Spacing();
-        if (ImGui::Button("Close", ImVec2(120, 0)))
+        if (remaining > 0)
         {
+            // Manual override stays available — the user who already
+            // copied the receipt can dismiss early.
+            char btnLbl[40];
+            std::snprintf(btnLbl, sizeof(btnLbl), "Close (auto in %ds)", remaining);
+            if (ImGui::Button(btnLbl, ImVec2(180, 0)))
+            {
+                m_showReportModal = false;
+                ImGui::CloseCurrentPopup();
+            }
+        }
+        else
+        {
+            // Time's up — close ourselves. CloseCurrentPopup must be
+            // called from within the BeginPopupModal block, which is
+            // why this happens here rather than from the worker thread.
             m_showReportModal = false;
             ImGui::CloseCurrentPopup();
         }
@@ -510,7 +538,8 @@ void UIDirectoryBrowser::renderReportModal()
             std::lock_guard<std::mutex> lock(m_reportMu);
             if (resp.ok && resp.statusCode >= 200 && resp.statusCode < 300)
             {
-                m_reportStatus = ReportStatus::Success;
+                m_reportStatus    = ReportStatus::Success;
+                m_reportSuccessAt = std::chrono::steady_clock::now();
                 // Parse the reportId out of the response. Tiny ad-hoc
                 // parser to avoid pulling nlohmann::json into this TU
                 // for one field; the response shape is fixed at

--- a/src/ui/UIDirectoryBrowser.h
+++ b/src/ui/UIDirectoryBrowser.h
@@ -48,6 +48,7 @@ private:
     void renderTable();
     void renderPasswordModal();
     void renderReportModal();
+    void renderReportFeedbackModal();
 
     UIManager          *m_uiManager     = nullptr;
     DirectoryBrowser   *m_browser       = nullptr;
@@ -88,4 +89,13 @@ private:
     std::string          m_reportError;          // set when Failed
     std::string          m_reportReceiptId;      // set when Success, echoed from /report response
     std::atomic<bool>    m_reportInFlight{false};
+
+    // Feedback-modal state. After a successful submit the input
+    // modal closes and this one opens, single-purpose: confirm the
+    // report landed + hand the user the protocol number. Decoupled
+    // from m_reportStatus so a later "I want to report something
+    // else" cycle doesn't lose the receipt the user is still
+    // looking at.
+    bool         m_showReportFeedbackModal = false;
+    std::string  m_reportFeedbackReceiptId;
 };

--- a/src/ui/UIDirectoryBrowser.h
+++ b/src/ui/UIDirectoryBrowser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <string>
 
@@ -87,5 +88,9 @@ private:
     ReportStatus         m_reportStatus = ReportStatus::Idle;
     std::string          m_reportError;          // set when Failed
     std::string          m_reportReceiptId;      // set when Success, echoed from /report response
+    // Timestamp of the transition into Success state. Used to drive
+    // the auto-close countdown so the user reads the receipt without
+    // having to dismiss the modal manually.
+    std::chrono::steady_clock::time_point m_reportSuccessAt{};
     std::atomic<bool>    m_reportInFlight{false};
 };

--- a/src/ui/UIDirectoryBrowser.h
+++ b/src/ui/UIDirectoryBrowser.h
@@ -86,5 +86,6 @@ private:
     mutable std::mutex   m_reportMu;
     ReportStatus         m_reportStatus = ReportStatus::Idle;
     std::string          m_reportError;          // set when Failed
+    std::string          m_reportReceiptId;      // set when Success, echoed from /report response
     std::atomic<bool>    m_reportInFlight{false};
 };

--- a/src/ui/UIDirectoryBrowser.h
+++ b/src/ui/UIDirectoryBrowser.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <mutex>
 #include <string>
 
@@ -88,9 +87,5 @@ private:
     ReportStatus         m_reportStatus = ReportStatus::Idle;
     std::string          m_reportError;          // set when Failed
     std::string          m_reportReceiptId;      // set when Success, echoed from /report response
-    // Timestamp of the transition into Success state. Used to drive
-    // the auto-close countdown so the user reads the receipt without
-    // having to dismiss the modal manually.
-    std::chrono::steady_clock::time_point m_reportSuccessAt{};
     std::atomic<bool>    m_reportInFlight{false};
 };

--- a/src/ui/UIDirectoryBrowser.h
+++ b/src/ui/UIDirectoryBrowser.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <mutex>
 #include <string>
 
 class UIManager;
@@ -45,6 +47,7 @@ public:
 private:
     void renderTable();
     void renderPasswordModal();
+    void renderReportModal();
 
     UIManager          *m_uiManager     = nullptr;
     DirectoryBrowser   *m_browser       = nullptr;
@@ -62,4 +65,26 @@ private:
     bool         m_showPasswordModal = false;
     char         m_passwordBuffer[128] = {};
     std::string  m_pendingProtectedUrl;
+
+    // Report-this-stream state (#57). When the user right-clicks a
+    // row and picks "Report this stream..." the modal opens with
+    // these fields. Submission runs on a detached thread and updates
+    // m_reportStatus under m_reportMu so the UI thread sees the
+    // result on the next frame.
+    bool         m_showReportModal = false;
+    std::string  m_reportStreamId;
+    std::string  m_reportStreamName;     // shown in the modal header
+    char         m_reportReason[256]  = {};
+    char         m_reportContact[96]  = {};
+    enum class ReportStatus
+    {
+        Idle,        // modal just opened
+        Sending,     // POST in flight
+        Success,
+        Failed,
+    };
+    mutable std::mutex   m_reportMu;
+    ReportStatus         m_reportStatus = ReportStatus::Idle;
+    std::string          m_reportError;          // set when Failed
+    std::atomic<bool>    m_reportInFlight{false};
 };

--- a/src/ui/UIInfoPanel.cpp
+++ b/src/ui/UIInfoPanel.cpp
@@ -1,6 +1,11 @@
 #include "UIInfoPanel.h"
 #include "UIManager.h"
+#include "../capture/IVideoCapture.h"
 #include <imgui.h>
+
+#ifndef RETROCAPTURE_VERSION
+#define RETROCAPTURE_VERSION "0.0.0-dev"
+#endif
 
 UIInfoPanel::UIInfoPanel(UIManager *uiManager)
     : m_uiManager(uiManager)
@@ -18,52 +23,113 @@ void UIInfoPanel::render()
         return;
     }
 
-    renderCaptureInfo();
-    ImGui::Separator();
-    renderStreamingInfo();
+    // Client mode (Remote source active) and host mode are two very
+    // different things — same Info tab used to show 'Capture Information'
+    // with the remote URL as a 'device' and an inactive 'streaming
+    // status', which is meaningless to a viewer. Split them.
+    const bool isClient = (m_uiManager->getSourceType() == UIManager::SourceType::Remote) &&
+                          !m_uiManager->getCurrentDevice().empty();
+    if (isClient)
+    {
+        renderRemoteInfo();
+    }
+    else
+    {
+        renderCaptureInfo();
+        ImGui::Separator();
+        renderStreamingInfo();
+    }
     ImGui::Separator();
     renderSystemInfo();
 }
 
 void UIInfoPanel::renderCaptureInfo()
 {
-    ImGui::Text("Capture Information");
+    ImGui::Text("Capture");
     ImGui::Separator();
 
-    ImGui::Text("Device: %s", m_uiManager->getCaptureDevice().c_str());
-    ImGui::Text("Resolution: %ux%u", m_uiManager->getCaptureWidth(), m_uiManager->getCaptureHeight());
+    const std::string device = m_uiManager->getCaptureDevice();
+    ImGui::Text("Device: %s", device.empty() ? "(none)" : device.c_str());
+    ImGui::Text("Resolution: %ux%u",
+                m_uiManager->getCaptureWidth(),
+                m_uiManager->getCaptureHeight());
     ImGui::Text("FPS: %u", m_uiManager->getCaptureFps());
 }
 
 void UIInfoPanel::renderStreamingInfo()
 {
-    ImGui::Text("Streaming Information");
+    ImGui::Text("Streaming");
     ImGui::Separator();
 
     bool active = m_uiManager->getStreamingActive();
-    ImGui::Text("Status: %s", active ? "Ativo" : "Inativo");
+    ImGui::Text("Status:");
+    ImGui::SameLine();
     if (active)
     {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "●");
-
+        ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f), "active");
         std::string url = m_uiManager->getStreamUrl();
         if (!url.empty())
         {
             ImGui::Text("URL: %s", url.c_str());
         }
-        ImGui::Text("Clientes conectados: %u", m_uiManager->getStreamClientCount());
+        ImGui::Text("Connected clients: %u", m_uiManager->getStreamClientCount());
     }
     else
     {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
+        ImGui::TextDisabled("inactive");
+    }
+}
+
+void UIInfoPanel::renderRemoteInfo()
+{
+    ImGui::Text("Remote Stream");
+    ImGui::Separator();
+
+    ImGui::Text("Host URL: %s", m_uiManager->getCurrentDevice().c_str());
+    const uint32_t w = m_uiManager->getCaptureWidth();
+    const uint32_t h = m_uiManager->getCaptureHeight();
+    if (w > 0 && h > 0)
+    {
+        ImGui::Text("Incoming resolution: %ux%u", w, h);
+    }
+    else
+    {
+        ImGui::TextDisabled("Incoming resolution: (negotiating)");
+    }
+    const std::string interp = m_uiManager->getRemoteInterpolation();
+    ImGui::Text("Display interpolation: %s",
+                interp.empty() ? "linear" : interp.c_str());
+
+    ImGui::Spacing();
+    ImGui::Text("Connection");
+    ImGui::Separator();
+
+    IVideoCapture *cap = m_uiManager->getCapture();
+    if (!cap || !cap->isOpen())
+    {
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f), "Reconnecting...");
+        ImGui::TextWrapped("Waiting for the host to come back. "
+                           "Reconnect attempts back off up to 60 s "
+                           "between tries.");
+    }
+    else if (cap->isHostLikelyOffline())
+    {
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f), "Host likely offline");
+        ImGui::TextWrapped("The client is still retrying in the background. "
+                           "Disconnect and reconnect from the Remote menu "
+                           "to retry immediately.");
+    }
+    else
+    {
+        ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f), "Connected");
     }
 }
 
 void UIInfoPanel::renderSystemInfo()
 {
-    ImGui::Text("Application Info");
-    ImGui::Text("RetroCapture v0.1.0");
-    ImGui::Text("ImGui: %s", ImGui::GetVersion());
+    ImGui::Text("Application");
+    ImGui::Separator();
+
+    ImGui::Text("RetroCapture: %s", RETROCAPTURE_VERSION);
+    ImGui::Text("Dear ImGui: %s", ImGui::GetVersion());
 }

--- a/src/ui/UIInfoPanel.cpp
+++ b/src/ui/UIInfoPanel.cpp
@@ -104,24 +104,37 @@ void UIInfoPanel::renderRemoteInfo()
     ImGui::Text("Connection");
     ImGui::Separator();
 
-    IVideoCapture *cap = m_uiManager->getCapture();
-    if (!cap || !cap->isOpen())
-    {
-        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f), "Reconnecting...");
-        ImGui::TextWrapped("Waiting for the host to come back. "
-                           "Reconnect attempts back off up to 60 s "
-                           "between tries.");
-    }
-    else if (cap->isHostLikelyOffline())
+    // UIManager::getCapture() is null in Remote mode (Application
+    // passes nullptr to setCaptureControls so the V4L2/DS-specific
+    // hardware controls UI hides itself). So we can't reach the
+    // VideoCaptureRemote through that path — Application mirrors the
+    // offline flag onto UIManager every frame instead.
+    //
+    // 'Connected' here means we've received at least one frame, which
+    // is what getCaptureWidth/Height > 0 already signals (it's the
+    // same heuristic UIRemoteConnection's footer uses). 'Reconnecting'
+    // means we're armed but haven't decoded a frame yet. 'Host likely
+    // offline' is the long-failure hint from #58 — it can fire while
+    // Connected if a previously-good stream just dropped, so it takes
+    // priority over the connected indicator.
+    const bool hasFrames = (w > 0 && h > 0);
+    if (m_uiManager->getRemoteHostLikelyOffline())
     {
         ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f), "Host likely offline");
         ImGui::TextWrapped("The client is still retrying in the background. "
                            "Disconnect and reconnect from the Remote menu "
                            "to retry immediately.");
     }
-    else
+    else if (hasFrames)
     {
         ImGui::TextColored(ImVec4(0.40f, 0.80f, 0.40f, 1.0f), "Connected");
+    }
+    else
+    {
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f), "Reconnecting...");
+        ImGui::TextWrapped("Waiting for the host's first frame. "
+                           "Reconnect attempts back off up to 60 s "
+                           "between tries.");
     }
 }
 

--- a/src/ui/UIInfoPanel.h
+++ b/src/ui/UIInfoPanel.h
@@ -22,5 +22,6 @@ private:
 
     void renderCaptureInfo();
     void renderStreamingInfo();
+    void renderRemoteInfo();   // shown in place of capture+streaming when in client mode
     void renderSystemInfo();
 };

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -263,16 +263,15 @@ void UIManager::endFrame()
         return;
     }
 
-    if (m_uiVisible)
-    {
-        ImGui::Render();
-        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-    }
-    else
-    {
-        // Quando oculta, ainda precisamos finalizar o frame para manter o estado correto
-        ImGui::EndFrame();
-    }
+    // Always paint the frame, even when the main UI is hidden.
+    // renderConnectionOverlay() runs before render()'s m_uiVisible
+    // gate, so when F12 hides the rest of the UI the draw list still
+    // has the overlay in it. Calling EndFrame instead of Render
+    // discarded that, leaving the user with a frozen-looking stream
+    // during reconnects. With nothing added to the draw list this is
+    // effectively a no-op anyway.
+    ImGui::Render();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     
     // Keep ImGui mouse disabled when UI is hidden
     // This prevents ImGui from interfering with cursor visibility

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -3592,7 +3592,14 @@ void UIManager::renderConnectionOverlay()
 
     const double now      = ImGui::GetTime();
     const std::string dev = m_currentDevice;
-    const bool hasFrames  = (m_captureWidth > 0 && m_captureHeight > 0);
+    // 'Has frames' means decoding right NOW — not 'has ever had
+    // frames'. captureWidth/Height stay at the last seen value
+    // forever after the stream drops, so they're a "we know the
+    // resolution" signal, not a liveness one. Use the mirrored
+    // VideoCaptureRemote::isReceivingFrames() flag instead, which
+    // flips back to false the moment the decode loop loses the
+    // connection.
+    const bool hasFrames  = m_remoteReceivingFrames;
     const bool offline    = m_remoteHostLikelyOffline;
 
     // Detect 'device just became empty' — that's the disconnect

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -301,7 +301,16 @@ void UIManager::setVisible(bool visible)
 
 void UIManager::render()
 {
-    if (!m_initialized || !m_uiVisible)
+    if (!m_initialized) return;
+
+    // Connection overlay runs before the visibility gate so the user
+    // sees Connecting / Reconnecting / Disconnecting / Connected
+    // feedback even with the full UI hidden via F12. Otherwise the
+    // screen looks frozen during a reconnect with no hint that the
+    // client is still working in the background.
+    renderConnectionOverlay();
+
+    if (!m_uiVisible)
     {
         return;
     }
@@ -3548,4 +3557,135 @@ bool UIManager::loadStreamingProfile(const std::string &name)
     triggerStreamingMaxBufferTimeSecondsChange(s.maxBufferTimeSeconds);
     triggerStreamingAVIOBufferSizeChange(s.avioBufferSize);
     return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Always-on-top connection state overlay.
+//
+// Reads the same signals UIInfoPanel does (source type, current
+// device, capture dims, host-likely-offline mirror) and renders a
+// small fixed window in the bottom-right corner whenever the user
+// needs to know something is happening:
+//
+//   Connecting...   — Remote source armed, no frames yet, fresh URL
+//   Reconnecting... — Remote source armed, frames stopped or host-likely-offline
+//   Disconnecting...— transient ~1.5s after currentDevice clears
+//   Connected       — flashes for ~3 s on the first frame
+//
+// Renders BEFORE UIManager::render()'s m_uiVisible gate so the user
+// sees state changes with the full UI hidden too. The window itself
+// uses NoInputs so it never steals clicks from the underlying stream
+// view.
+// ─────────────────────────────────────────────────────────────────────
+void UIManager::renderConnectionOverlay()
+{
+    if (m_sourceType != SourceType::Remote)
+    {
+        // Not in client mode — nothing to surface. Also clear the
+        // tracking state so a later mode switch starts fresh.
+        m_overlayLastDevice.clear();
+        m_overlayLastHadFrames = false;
+        m_overlayConnectedSince     = 0.0;
+        m_overlayDisconnectingUntil = 0.0;
+        return;
+    }
+
+    const double now      = ImGui::GetTime();
+    const std::string dev = m_currentDevice;
+    const bool hasFrames  = (m_captureWidth > 0 && m_captureHeight > 0);
+    const bool offline    = m_remoteHostLikelyOffline;
+
+    // Detect 'device just became empty' — that's the disconnect
+    // transition. We arm a short window so the overlay can render
+    // "Disconnecting..." while the detached teardown runs.
+    if (!m_overlayLastDevice.empty() && dev.empty())
+    {
+        m_overlayDisconnectingUntil = now + 1.5;
+    }
+
+    // Track first-frame-arrived to drive the "Connected" flash.
+    if (!m_overlayLastHadFrames && hasFrames && !dev.empty())
+    {
+        m_overlayConnectedSince = now;
+    }
+    if (!hasFrames)
+    {
+        m_overlayConnectedSince = 0.0;
+    }
+
+    // Decide what to render.
+    const char *label    = nullptr;
+    ImVec4      color    = ImVec4(0.95f, 0.7f, 0.3f, 1.0f); // orange default
+    bool        spinning = false;
+
+    if (now < m_overlayDisconnectingUntil)
+    {
+        label    = "Disconnecting...";
+        spinning = true;
+    }
+    else if (dev.empty())
+    {
+        // No URL armed and we're past the disconnect tail — nothing
+        // to say.
+    }
+    else if (offline)
+    {
+        label    = "Host appears offline";
+        spinning = true;
+    }
+    else if (!hasFrames)
+    {
+        // No first frame yet. If we just came from a connected
+        // state (had frames, now don't) it's a reconnect; if we
+        // never had frames it's the first connect. Same visual
+        // either way.
+        label    = m_overlayLastHadFrames ? "Reconnecting..." : "Connecting...";
+        spinning = true;
+    }
+    else if (m_overlayConnectedSince > 0.0 && now - m_overlayConnectedSince < 3.0)
+    {
+        label    = "Connected";
+        color    = ImVec4(0.40f, 0.80f, 0.40f, 1.0f);
+        spinning = false;
+    }
+
+    // Always update the tracking BEFORE the early-return so transitions
+    // we detect this frame land in next frame's state.
+    m_overlayLastDevice    = dev;
+    m_overlayLastHadFrames = hasFrames;
+
+    if (!label) return;
+
+    // Bottom-right anchor. SetNextWindowPos with pivot (1,1) puts
+    // the window's bottom-right corner at the screen point we pass.
+    // Padding of 16 px so it doesn't kiss the screen edges.
+    const ImGuiViewport *vp = ImGui::GetMainViewport();
+    const ImVec2 anchor(vp->WorkPos.x + vp->WorkSize.x - 16.0f,
+                        vp->WorkPos.y + vp->WorkSize.y - 16.0f);
+    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+    ImGui::SetNextWindowBgAlpha(0.85f);
+
+    const ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoDecoration       | ImGuiWindowFlags_AlwaysAutoResize |
+        ImGuiWindowFlags_NoSavedSettings    | ImGuiWindowFlags_NoFocusOnAppearing |
+        ImGuiWindowFlags_NoNav              | ImGuiWindowFlags_NoMove;
+
+    if (ImGui::Begin("##connOverlay", nullptr, flags))
+    {
+        if (spinning)
+        {
+            // Simple ASCII spinner — 4-frame cycle, ~6 fps. ImGui
+            // doesn't ship a spinner widget but a one-char rotation
+            // is enough to signal "working" without pulling extra
+            // primitives.
+            static const char *spin = "|/-\\";
+            const int idx = static_cast<int>(now * 6.0) & 0x3;
+            ImGui::TextColored(color, "%c %s", spin[idx], label);
+        }
+        else
+        {
+            ImGui::TextColored(color, "%s", label);
+        }
+    }
+    ImGui::End();
 }

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -415,6 +415,15 @@ public:
     uint32_t getCaptureHeight() const { return m_captureHeight; }
     uint32_t getActualCaptureWidth() const { return m_actualCaptureWidth; }
     uint32_t getActualCaptureHeight() const { return m_actualCaptureHeight; }
+
+    // Mirror of VideoCaptureRemote::isHostLikelyOffline() pushed by
+    // Application every frame. Lives here because in Remote mode the
+    // UIManager's m_capture pointer is null (Application passes
+    // nullptr to setCaptureControls to suppress the V4L2/DS hardware
+    // controls) so the Info panel can't dynamic-cast its way to the
+    // flag. Default false in host mode (#58).
+    bool getRemoteHostLikelyOffline() const { return m_remoteHostLikelyOffline; }
+    void setRemoteHostLikelyOffline(bool v) { m_remoteHostLikelyOffline = v; }
     float getSourceOverscanPercentX() const { return m_sourceOverscanPercentX; }
     float getSourceOverscanPercentY() const { return m_sourceOverscanPercentY; }
     bool getSourceOverscanLocked() const { return m_sourceOverscanLocked; }
@@ -842,6 +851,7 @@ private:
     uint32_t m_actualCaptureWidth = 0;
     uint32_t m_actualCaptureHeight = 0;
     uint32_t m_captureFps = 0;
+    bool     m_remoteHostLikelyOffline = false;
     // Overscan: crop % das bordas do source antes do downscale.
     // X horizontal, Y vertical. Locked espelha um no outro.
     float m_sourceOverscanPercentX = 0.0f;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -42,6 +42,13 @@ public:
 
     void render();
 
+    /// Always-on-top corner overlay that surfaces remote-connection
+    /// state transitions (Connecting / Reconnecting / Disconnecting
+    /// / Connected). Rendered before render()'s F12-visibility gate
+    /// so the user sees connection feedback even with the rest of
+    /// the IMGUI surface hidden.
+    void renderConnectionOverlay();
+
     // Callbacks para interação
     void setShaderList(const std::vector<std::string> &shaders) { m_shaderList = shaders; }
     void setCurrentShader(const std::string &shader)
@@ -852,6 +859,15 @@ private:
     uint32_t m_actualCaptureHeight = 0;
     uint32_t m_captureFps = 0;
     bool     m_remoteHostLikelyOffline = false;
+    // Connection-overlay frame-to-frame tracking. We detect
+    // transitions (e.g. currentDevice just became empty -> show
+    // "Disconnecting...") by comparing this frame's state with last
+    // frame's. Held in member fields rather than statics so the data
+    // is reset alongside UIManager.
+    std::string m_overlayLastDevice;
+    bool        m_overlayLastHadFrames = false;
+    double      m_overlayConnectedSince = 0.0;     // ImGui::GetTime()
+    double      m_overlayDisconnectingUntil = 0.0; // disconnect feedback decays at this time
     // Overscan: crop % das bordas do source antes do downscale.
     // X horizontal, Y vertical. Locked espelha um no outro.
     float m_sourceOverscanPercentX = 0.0f;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -431,6 +431,12 @@ public:
     // flag. Default false in host mode (#58).
     bool getRemoteHostLikelyOffline() const { return m_remoteHostLikelyOffline; }
     void setRemoteHostLikelyOffline(bool v) { m_remoteHostLikelyOffline = v; }
+    // 'Are we decoding frames right now' — distinct from
+    // captureWidth > 0, which stays at the last seen value after
+    // the stream drops. Mirrored by Application from
+    // VideoCaptureRemote::isReceivingFrames() every frame.
+    bool getRemoteReceivingFrames() const { return m_remoteReceivingFrames; }
+    void setRemoteReceivingFrames(bool v) { m_remoteReceivingFrames = v; }
     float getSourceOverscanPercentX() const { return m_sourceOverscanPercentX; }
     float getSourceOverscanPercentY() const { return m_sourceOverscanPercentY; }
     bool getSourceOverscanLocked() const { return m_sourceOverscanLocked; }
@@ -859,6 +865,7 @@ private:
     uint32_t m_actualCaptureHeight = 0;
     uint32_t m_captureFps = 0;
     bool     m_remoteHostLikelyOffline = false;
+    bool     m_remoteReceivingFrames   = false;
     // Connection-overlay frame-to-frame tracking. We detect
     // transitions (e.g. currentDevice just became empty -> show
     // "Disconnecting...") by comparing this frame's state with last

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -234,8 +234,13 @@ void UIRemoteConnection::renderStatusFooter(bool connected)
     // wants the message regardless of whether we're mid-handshake or
     // already given up on this attempt. Cleared automatically by
     // VideoCaptureRemote on the next successful reconnect.
-    IVideoCapture *cap = m_uiManager ? m_uiManager->getCapture() : nullptr;
-    if (cap && cap->isHostLikelyOffline())
+    //
+    // The flag is mirrored onto UIManager every frame by
+    // Application::syncDirectoryClient — m_uiManager->getCapture()
+    // returns null in Remote mode (Application passes nullptr to
+    // setCaptureControls to hide the V4L2/DS hardware-controls UI),
+    // so we'd never see the flag if we went through that pointer.
+    if (m_uiManager && m_uiManager->getRemoteHostLikelyOffline())
     {
         ImGui::Spacing();
         ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f),

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -1,5 +1,6 @@
 #include "UIRemoteConnection.h"
 #include "UIManager.h"
+#include "../capture/IVideoCapture.h"
 #include "../streaming/DirectoryBrowser.h"
 #include "../utils/PasswordHash.h"
 
@@ -226,6 +227,22 @@ void UIRemoteConnection::renderStatusFooter(bool connected)
     else
     {
         ImGui::Text("Idle.");
+    }
+
+    // #58 — surface the prolonged-reconnect-failure hint. Visible on
+    // any state because once the host is suspected offline the user
+    // wants the message regardless of whether we're mid-handshake or
+    // already given up on this attempt. Cleared automatically by
+    // VideoCaptureRemote on the next successful reconnect.
+    IVideoCapture *cap = m_uiManager ? m_uiManager->getCapture() : nullptr;
+    if (cap && cap->isHostLikelyOffline())
+    {
+        ImGui::Spacing();
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f),
+                           "Host appears offline.");
+        ImGui::TextWrapped("RetroCapture is still retrying in the background "
+                           "but the host hasn't answered for a while. "
+                           "Disconnect and reconnect to retry immediately.");
     }
 }
 

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -33,19 +33,32 @@ void UIRemoteConnection::triggerConnect(const std::string &url)
     if (clean.empty()) return;
 
     // Mirror into the URL input so the user sees what they just
-    // committed to, plus arm the existing state machine. Pop the
-    // window open so the connection feedback is visible — the user
-    // may have arrived here from the Browse window.
+    // committed to, plus arm the existing state machine. We
+    // intentionally do NOT flip m_visible here — when the user
+    // clicked Connect on a Browse-window row they're already in a
+    // window that gives them context, and popping the
+    // Connect-to-Remote window on top is noise. Status surfaces via
+    // the directory status text + the Info tab's Connection block
+    // anyway. The user can still open this window manually from the
+    // Remote menu if they want the focused view.
     std::strncpy(m_urlBuffer, clean.c_str(), sizeof(m_urlBuffer) - 1);
     m_urlBuffer[sizeof(m_urlBuffer) - 1] = '\0';
     m_pendingUrl = clean;
     m_pending    = PendingAction::ConnectShowStatus;
-    m_visible    = true;
 }
 
 void UIRemoteConnection::render()
 {
-    if (!m_visible || !m_uiManager) return;
+    if (!m_uiManager) return;
+
+    // The state machine must advance every frame regardless of
+    // whether this window is visible — when a Browse-window
+    // 'Connect' arms a ConnectShowStatus / ConnectExecute step,
+    // it needs to progress even with the Connect-to-Remote window
+    // hidden. Drive the state first, then render the window only
+    // if the user actually opened it.
+    advanceStateMachine();
+    if (!m_visible) return;
 
     // Source-aware: getCurrentDevice() returns whatever the active capture
     // path needs as its "device" — for V4L2/DS that's a filesystem path
@@ -100,10 +113,6 @@ void UIRemoteConnection::render()
         renderStatusFooter(connected);
     }
     ImGui::End();
-
-    // Always advance the state machine even if the window is now
-    // covered — connect/disconnect MUST progress once initiated.
-    advanceStateMachine();
 }
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Bundle that closes the three directory-polish issues plus a wave of
UX items that came out of long-soak testing against the production
deployment.

Closes #56 · Closes #57 · Closes #58

## Issues delivered

### #58 — Capped exponential backoff on remote reconnect

`VideoCaptureRemote::decodeLoop` used to retry every 2 s forever
when the host went down. A laptop client left armed overnight would
pile up ~1800 TLS handshakes for nothing. Now table-driven backoff
`[2, 2, 5, 5, 15, 30, 60]` seconds with the 60 s slot held for any
further failures; reset on the first successful frame after a
reconnect. After ~30 consecutive failures (≈15 min in the ceiling
slot) the new
`IVideoCapture::isHostLikelyOffline()` flag flips on and the UI
surfaces "Host appears offline" — but the URL stays armed so a
brief recovery still catches the next slot. No auto-disconnect.

### #57 — Report this stream

Service-side `POST /streams/<id>/report` existed since #49 but had
no UI surface. Now:

- **Explicit Connect / Report buttons** on every row in the Browse
  window (originally a right-click menu — wasn't discoverable).
- **Two-modal flow**: a *Report Stream* input modal with required
  reason + optional contact, then a separate *Report Sent* feedback
  modal with the confirmation message + a copy-pasteable protocol
  number (`R-XXXXXXXX`). Recipient hint up front: "this report
  goes to the directory maintainer, not to the host of the stream
  and not to Cloudflare."
- **Receipt id persisted** in `stream_reports.report_id` via a
  migration (`002_report_id.sql`) + indexed, so the maintainer can
  pivot from a quoted receipt back to the original row.
- **Real client IP behind a reverse proxy**: new
  `DIRECTORY_TRUST_PROXY_HEADERS` env var. When on, the service
  honours `Cf-Connecting-Ip` / `True-Client-Ip` / `X-Real-Ip` /
  `X-Forwarded-For` before the TCP RemoteAddr. Same lookup is used
  by the rate limiter so one proxy IP doesn't burn the whole bucket
  for everyone behind it. Off by default (spoofing-resistant for
  direct-exposure deployments); the FRP+Cloudflare host turns it on
  via the env var.
- **Wire format documented**: `docs/DIRECTORY_PROTOCOL.md` updated
  with the `reportId` field on the response.

### #56 — Validate Custom URL on client + reject malformed at service

Custom endpoint URL field used to accept any string. A typo like
`htts://foo` or `https//foo.com` (missing colon) became a registered
entry that any browser hitting it got `ERR_NAME_NOT_RESOLVED` on,
rotting the listing. Two-sided guard:

- **Client**: `validateCustomEndpoint()` in
  `UIConfigurationStreaming.cpp` — scheme must be `http(s)://`,
  host must contain at least one alphanumeric, optional port
  parses as 1..65535. Inline red warning under the URL field;
  publish toggle gated.
- **Service**: `isValidEndpointURL()` in handlers.go runs the same
  shape via `net/url` + explicit alnum / port-range checks.
  `validateRegister` and `validatePatch` both reject malformed
  endpoints with `400 invalid_request`. **8 new table-driven cases**
  in register_test.go cover scheme typos, missing colon, port out
  of range, hostless URLs etc. All passing.

## Polish that came out of the long-soak

- **Info tab is mode-aware**. Client mode now renders a dedicated
  *Remote Stream* block (host URL, incoming resolution, display
  interpolation) and a *Connection* block (Connected /
  Reconnecting... / Host likely offline) keyed off the new
  isHostLikelyOffline flag. Host mode still gets Capture +
  Streaming sections. Fixed two latent issues while in there:
  hard-coded `RetroCapture v0.1.0` → `RETROCAPTURE_VERSION`,
  Portuguese strings → English (per repo convention).
- **F11 toggles fullscreen** (both SDL2 and GLFW backends),
  edge-triggered alongside the existing F12 = toggle UI.
- **Quick-tunnel DNS propagation hint** under the directory status
  text — "URL can take up to ~2 minutes to resolve from other
  networks". Surfaced after a real publish-then-immediately-connect
  cycle returned `Failed to resolve hostname`.
- **Click on a Browse row's Connect button no longer pops the
  Connect-to-Remote window** on top. The Browse window itself is
  enough context; the manual window stays reachable from the
  Remote menu for users who want the focused view.
- **Always-on-top OSD overlay** in the bottom-right showing
  Connecting / Reconnecting / Disconnecting / Connected
  transitions. Anchored bottom-right with `NoInputs` so it never
  steals clicks. Visible even with F12 hiding the rest of the UI
  (had to fix UIManager::endFrame to always call ImGui::Render
  rather than gating on visibility). Detects stalled streams via a
  `m_lastFrameAtSteadyUs` timestamp (2 s threshold) instead of the
  cached resolution, so a killed host shows up in the overlay
  within seconds rather than waiting on the TCP timeout.
- **`isReceivingFrames()`** as a new virtual on `IVideoCapture` so
  the UI can read "actually decoding right now" instead of
  "captureWidth > 0" (which stays at the last value after the
  stream drops). Mirrored on UIManager every frame by
  Application::syncDirectoryClient.

## Files touched

```
 16 commits ·  ~30 files changed
 Service (Go):
   platform/services/directory/internal/api/handlers.go
   platform/services/directory/internal/api/register_test.go
   platform/services/directory/internal/api/types.go
   platform/services/directory/internal/config/config.go
   platform/services/directory/internal/store/store.go
   platform/services/directory/internal/store/store_test.go
   platform/services/directory/internal/store/migrations/002_report_id.sql  (new)
   platform/services/directory/cmd/directory/main.go
   platform/docker-compose.yml
 Client (C++):
   src/capture/IVideoCapture.h
   src/capture/VideoCaptureRemote.h
   src/capture/VideoCaptureRemote.cpp
   src/core/Application.cpp
   src/ui/UIManager.h
   src/ui/UIManager.cpp
   src/ui/UIInfoPanel.h
   src/ui/UIInfoPanel.cpp
   src/ui/UIRemoteConnection.cpp
   src/ui/UIDirectoryBrowser.h
   src/ui/UIDirectoryBrowser.cpp
   src/ui/UIConfigurationStreaming.cpp
 Docs:
   docs/DIRECTORY_PROTOCOL.md
```

## Test plan

- [x] Linux x86_64 cross-compile (Docker) — green
- [x] Windows x86_64 cross-compile (Docker / MXE) — green
- [x] `go test ./...` on `platform/services/directory` — green,
      including the 8 new URL-validation cases
- [x] Manual: enable Cloudflare Quick Tunnel, publish, browse,
      click Connect — connects with no extra window popping
- [x] Manual: kill the host while a client is connected — overlay
      shows "Reconnecting..." within ~2 s, settles back to
      "Connected" within 3 s of host return
- [x] Manual: report a stream — input modal closes, feedback
      modal opens with the protocol number `R-XXXXXXXX`
- [x] Manual: validate URL field rejects `htts://foo`, accepts
      `https://example.com:8080`
- [ ] Manual: redeploy the directory service with
      `DIRECTORY_TRUST_PROXY_HEADERS=true` and verify reporter_ip
      now records the real client (still on user to verify with
      production deploy)

## Migration note

The new `002_report_id.sql` runs automatically on next service
start — adds `report_id TEXT NOT NULL DEFAULT ''` and an index to
`stream_reports`. Existing rows get the empty default. The
migration runner tracks applied migrations in `_migrations` so
re-running is a no-op.
