### PR TITLE
Recording pipeline parity + unified UI idiom (#59)

### DIFF
--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1183,6 +1183,19 @@ bool Application::initUI()
         settings.outputPath = m_ui->getRecordingOutputPath();
         settings.filenameTemplate = m_ui->getRecordingFilenameTemplate();
         settings.includeAudio = m_ui->getRecordingIncludeAudio();
+        // Hardware encoder + backend-specific preset (#59) — resolved
+        // from the UI's per-backend preset fields based on the user's
+        // selected backend. Auto/Software leave hwPreset empty so
+        // MediaEncoder uses its compiled-in default.
+        settings.hardwareEncoder = m_ui->getRecordingHardwareEncoder();
+        switch (settings.hardwareEncoder)
+        {
+            case 2: settings.hwPreset = m_ui->getRecordingNvencPreset(); break; // NVENC
+            case 3: settings.hwPreset = m_ui->getRecordingVaapiRcMode(); break; // VAAPI
+            case 4: settings.hwPreset = m_ui->getRecordingQsvPreset();   break; // QSV
+            case 5: settings.hwPreset = m_ui->getRecordingAmfQuality();  break; // AMF
+            default: settings.hwPreset.clear(); break;                          // Auto / Software
+        }
         m_recordingManager->setRecordingSettings(settings);
     }
 
@@ -1703,7 +1716,16 @@ bool Application::initUI()
                 settings.outputPath = m_ui->getRecordingOutputPath();
                 settings.filenameTemplate = m_ui->getRecordingFilenameTemplate();
                 settings.includeAudio = m_ui->getRecordingIncludeAudio();
-                
+                settings.hardwareEncoder = m_ui->getRecordingHardwareEncoder();
+                switch (settings.hardwareEncoder)
+                {
+                    case 2: settings.hwPreset = m_ui->getRecordingNvencPreset(); break;
+                    case 3: settings.hwPreset = m_ui->getRecordingVaapiRcMode(); break;
+                    case 4: settings.hwPreset = m_ui->getRecordingQsvPreset();   break;
+                    case 5: settings.hwPreset = m_ui->getRecordingAmfQuality();  break;
+                    default: settings.hwPreset.clear(); break;
+                }
+
                 if (!m_recordingManager) {
                     LOG_ERROR("Application: RecordingManager not initialized. Cannot start recording.");
                     m_ui->setRecordingActive(false);

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1707,12 +1707,18 @@ bool Application::initUI()
                 if (!m_recordingManager) {
                     LOG_ERROR("Application: RecordingManager not initialized. Cannot start recording.");
                     m_ui->setRecordingActive(false);
-                } else if (m_recordingManager->startRecording(settings)) {
-                    LOG_INFO("Application: Recording started successfully");
-                    m_ui->setRecordingActive(true);
                 } else {
-                    LOG_ERROR("Application: Failed to start recording. Check logs for details.");
-                    m_ui->setRecordingActive(false);
+                    // Snapshot the shader/source state at click time so
+                    // the recording's embedded metadata reflects exactly
+                    // what was active when the session started (#59).
+                    populateRecordingContext();
+                    if (m_recordingManager->startRecording(settings)) {
+                        LOG_INFO("Application: Recording started successfully");
+                        m_ui->setRecordingActive(true);
+                    } else {
+                        LOG_ERROR("Application: Failed to start recording. Check logs for details.");
+                        m_ui->setRecordingActive(false);
+                    }
                 }
             }
         } else {
@@ -5768,10 +5774,41 @@ bool Application::startRecording()
 {
     if (m_recordingManager)
     {
+        populateRecordingContext();
         RecordingSettings settings = m_recordingManager->getRecordingSettings();
         return m_recordingManager->startRecording(settings);
     }
     return false;
+}
+
+void Application::populateRecordingContext()
+{
+    if (!m_recordingManager) return;
+
+    RecordingManager::Context ctx;
+    if (m_ui)
+    {
+        const std::string shader = m_ui->getCurrentShader();
+        ctx.shaderName  = shader.empty() ? "(none)" : shader;
+        ctx.hostNickname = m_ui->getDirectoryHostNickname();
+        ctx.sourceWidth  = m_ui->getCaptureWidth();
+        ctx.sourceHeight = m_ui->getCaptureHeight();
+        ctx.sourceFps    = m_ui->getCaptureFps();
+        switch (m_ui->getSourceType())
+        {
+            case UIManager::SourceType::V4L2:   ctx.sourceType = "v4l2";       break;
+            case UIManager::SourceType::DS:     ctx.sourceType = "directshow"; break;
+            case UIManager::SourceType::Remote: ctx.sourceType = "remote";     break;
+            default:                            ctx.sourceType = "none";       break;
+        }
+    }
+#ifdef RETROCAPTURE_VERSION
+    ctx.applicationVersion = RETROCAPTURE_VERSION;
+#endif
+    // Single-output today — when dual recording lands in #59 phase C
+    // we'll override 'kind' from the raw-side path.
+    ctx.kind = "single";
+    m_recordingManager->setRecordingContext(ctx);
 }
 
 void Application::stopRecording()

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -116,6 +116,13 @@ public:
     struct RecordingSettings getRecordingSettings() const;
     bool startRecording();
     void stopRecording();
+
+private:
+    // Build the metadata context for a recording session (#59): pulls
+    // shader / source / nickname / version off the UI and capture
+    // pipeline so RecordingManager can embed it as MP4/MKV metadata.
+    void populateRecordingContext();
+public:
     bool isRecording() const;
     uint64_t getRecordingDurationUs();
     uint64_t getRecordingFileSize();

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -347,13 +347,19 @@ bool MediaEncoder::initializeVideoCodec()
         {
             // HTTP-TS streaming: tight vbv caps bitrate variation.
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
-            av_dict_set_int(&opts, "repeat-headers", 1, 0);
         }
         else
         {
             // Gravação em arquivo: vbv largo pra rate-control flexível.
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate * 2, 0);
         }
+        // Inline SPS/PPS in front of every IDR for both modes (#59).
+        // Streaming needs it for mid-stream join; file recording needs
+        // it so thumbnailers in DaVinci / kdenlive / Premiere that
+        // seek to a random byte offset can decode the next keyframe
+        // immediately instead of waiting for the muxer's extradata,
+        // which some tools skip when scrubbing.
+        av_dict_set_int(&opts, "repeat-headers", 1, 0);
     }
     else if (codec->id == AV_CODEC_ID_HEVC)
     {
@@ -373,17 +379,25 @@ bool MediaEncoder::initializeVideoCodec()
         if (m_forStreaming)
         {
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
-            // Inline VPS/SPS/PPS at every keyframe — libx265 equivalent
-            // of libx264's repeat-headers. Without this, a client that
-            // joins the MPEG-TS stream after the first keyframe never
-            // receives the parameter sets and reads NAL data as random
-            // bytes ('Invalid NAL unit 35', 'Truncating likely oversized
-            // VPS', 'PCM bit depth out of range').
+            // Streaming uses Annex B byte-stream framing inside the
+            // MPEG-TS PES payload; repeat-headers=1 emits VPS/SPS/PPS
+            // ahead of every IDR so mid-stream MPEG-TS clients can
+            // decode immediately. Without this the client sees
+            // 'Invalid NAL unit 35', 'Truncating likely oversized VPS',
+            // 'PCM bit depth out of range'.
             av_dict_set(&opts, "x265-params", "repeat-headers=1:annexb=1", 0);
         }
         else
         {
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate * 2, 0);
+            // File recording (#59): repeat-headers=1 also benefits
+            // mid-file scrubbing in DaVinci / kdenlive / Premiere
+            // thumbnail strips, which seek to arbitrary byte offsets
+            // and decode forward — they get a clean VPS/SPS/PPS at
+            // the very next IDR instead of relying on hvcC extradata,
+            // which some scrubbers skip when reading sequentially.
+            // No annexb=1: MP4 carries HEVC in length-prefix format.
+            av_dict_set(&opts, "x265-params", "repeat-headers=1", 0);
         }
     }
     else if (codec->id == AV_CODEC_ID_VP8)

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -64,6 +64,13 @@ MediaMuxer::~MediaMuxer()
     // cleanup();
 }
 
+void MediaMuxer::setMetadata(const std::map<std::string, std::string> &metadata)
+{
+    // Stage only — actually applied to formatCtx->metadata just
+    // before avformat_write_header inside initializeStreams.
+    m_userMetadata = metadata;
+}
+
 bool MediaMuxer::initialize(const MediaEncoder::VideoConfig &videoConfig,
                             const MediaEncoder::AudioConfig &audioConfig,
                             void *videoCodecContext,
@@ -438,6 +445,20 @@ bool MediaMuxer::initializeStreams(void *videoCodecContext, void *audioCodecCont
                  ", extradata_size: " + std::to_string(audioStream->codecpar->extradata_size));
     }
     
+    // Apply container-level user metadata staged via setMetadata().
+    // For MP4 the well-known keys (title, comment, encoder, ...) land
+    // in the 'ilst' / standard atoms; anything else is written as a
+    // freeform 'udta' atom. MKV stores everything as Tags entries.
+    // MPEG-TS doesn't carry per-program metadata, so on streaming
+    // muxers this is a no-op even though we still call it.
+    for (const auto &kv : m_userMetadata)
+    {
+        if (!kv.first.empty())
+        {
+            av_dict_set(&formatCtx->metadata, kv.first.c_str(), kv.second.c_str(), 0);
+        }
+    }
+
     AVDictionary *optsPtr = static_cast<AVDictionary *>(m_formatOptions);
     int headerRet = avformat_write_header(formatCtx, &optsPtr);
     if (headerRet < 0)

--- a/src/encoding/MediaMuxer.h
+++ b/src/encoding/MediaMuxer.h
@@ -4,7 +4,9 @@
 #include <cstdint>
 #include <vector>
 #include <functional>
+#include <map>
 #include <mutex>
+#include <string>
 
 /**
  * MediaMuxer - Classe responsável por muxing de pacotes codificados em container MPEG-TS
@@ -21,6 +23,17 @@ public:
 
     MediaMuxer();
     ~MediaMuxer();
+
+    // Container-level metadata to embed in the output file (MP4 'udta',
+     // MKV tags). Call BEFORE initialize() — these keys are applied
+     // just before avformat_write_header so the muxer writes them into
+     // the format header. Common keys: "title", "comment", "encoder",
+     // plus any custom key (MP4 stores unknown keys as freeform
+     // 'udta' atoms; MKV stores them as `Tags` entries). #59 uses this
+     // to embed shader / source-resolution / codec / nickname so a
+     // recording can be identified after the fact via
+     // `ffprobe -show_format <file>` without parsing the filename.
+    void setMetadata(const std::map<std::string, std::string> &metadata);
 
     // Inicializar muxer com configurações, codec contexts e callback OU arquivo
     // Os codec contexts são necessários para configurar os streams corretamente
@@ -107,4 +120,8 @@ private:
 
     // Mutex para proteger av_interleaved_write_frame (não é thread-safe)
     mutable std::mutex m_muxMutex;
+
+    // Container-level metadata staged via setMetadata() and applied
+    // to formatCtx->metadata just before avformat_write_header.
+    std::map<std::string, std::string> m_userMetadata;
 };

--- a/src/recording/FileRecorder.cpp
+++ b/src/recording/FileRecorder.cpp
@@ -82,6 +82,11 @@ int FileRecorder::writeToFile(const uint8_t* data, size_t size)
     }
 }
 
+void FileRecorder::setMetadata(const std::map<std::string, std::string> &metadata)
+{
+    m_muxer.setMetadata(metadata);
+}
+
 bool FileRecorder::initialize(const MediaEncoder::VideoConfig& videoConfig,
                                const MediaEncoder::AudioConfig& audioConfig,
                                void* videoCodecContext,

--- a/src/recording/FileRecorder.h
+++ b/src/recording/FileRecorder.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <cstdint>
 #include <fstream>
+#include <map>
 #include <mutex>
 
 /**
@@ -18,6 +19,11 @@ class FileRecorder
 public:
     FileRecorder();
     ~FileRecorder();
+
+    // Stage container-level metadata (#59). Forwarded to MediaMuxer
+     // and applied just before avformat_write_header so the keys land
+     // in the output file's metadata atoms. Call BEFORE initialize().
+    void setMetadata(const std::map<std::string, std::string> &metadata);
 
     // Initialize recorder with configurations and output path
     bool initialize(const MediaEncoder::VideoConfig& videoConfig,

--- a/src/recording/RecordingManager.cpp
+++ b/src/recording/RecordingManager.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <ctime>
 #include <iomanip>
+#include <map>
 #include <sstream>
 #include <algorithm>
 #include <cstdint>
@@ -204,6 +205,58 @@ bool RecordingManager::startRecording(const RecordingSettings &settings)
     {
         LOG_ERROR("RecordingManager: Failed to initialize MediaEncoder");
         return false;
+    }
+
+    // Stage container metadata before initialize so it lands in the
+    // format header (#59). Mirrors what /meta exposes on the
+    // streaming side but persisted into the file so the artifact is
+    // self-describing. Standard MP4 keys (title / comment / encoder)
+    // get the human-readable summary; custom retrocapture.* keys are
+    // for programmatic readers — these land in MP4 udta atoms and
+    // MKV Tags entries, and ffprobe surfaces them under TAG: prefixes.
+    {
+        std::map<std::string, std::string> meta;
+        std::string title = m_currentMetadata.filename;
+        if (!title.empty()) meta["title"] = title;
+
+        std::ostringstream comment;
+        comment << "RetroCapture session";
+        if (!m_context.shaderName.empty()) {
+            comment << " — shader: " << m_context.shaderName;
+        }
+        if (m_context.sourceWidth && m_context.sourceHeight) {
+            comment << " — source: " << m_context.sourceWidth
+                    << "x" << m_context.sourceHeight;
+            if (m_context.sourceFps) comment << "@" << m_context.sourceFps;
+        }
+        if (!m_context.kind.empty()) comment << " — kind: " << m_context.kind;
+        meta["comment"] = comment.str();
+
+        if (!m_context.applicationVersion.empty()) {
+            meta["encoder"] = "RetroCapture " + m_context.applicationVersion;
+        } else {
+            meta["encoder"] = "RetroCapture";
+        }
+
+        if (!m_context.shaderName.empty())
+            meta["retrocapture.shader"]    = m_context.shaderName;
+        if (!m_context.hostNickname.empty())
+            meta["retrocapture.host"]      = m_context.hostNickname;
+        if (m_context.sourceWidth)
+            meta["retrocapture.source_width"]  = std::to_string(m_context.sourceWidth);
+        if (m_context.sourceHeight)
+            meta["retrocapture.source_height"] = std::to_string(m_context.sourceHeight);
+        if (m_context.sourceFps)
+            meta["retrocapture.source_fps"]    = std::to_string(m_context.sourceFps);
+        if (!m_context.sourceType.empty())
+            meta["retrocapture.source_type"]   = m_context.sourceType;
+        if (!m_context.applicationVersion.empty())
+            meta["retrocapture.version"]       = m_context.applicationVersion;
+        if (!m_context.kind.empty())
+            meta["retrocapture.kind"]          = m_context.kind;
+        meta["retrocapture.codec"] = settings.codec;
+
+        m_recorder.setMetadata(meta);
     }
 
     // Initialize FileRecorder

--- a/src/recording/RecordingManager.cpp
+++ b/src/recording/RecordingManager.cpp
@@ -186,6 +186,15 @@ bool RecordingManager::startRecording(const RecordingSettings &settings)
     videoConfig.h265Level = settings.h265Level;
     videoConfig.vp8Speed = settings.vp8Speed;
     videoConfig.vp9Speed = settings.vp9Speed;
+    // Hardware encoder selection (#59). The MediaEncoder enum
+    // matches the int values stored on RecordingSettings, so the
+    // cast is safe; out-of-range values fall back to Auto.
+    if (settings.hardwareEncoder >= 0 && settings.hardwareEncoder <= 5)
+    {
+        videoConfig.hardwareEncoder =
+            static_cast<MediaEncoder::HardwareEncoder>(settings.hardwareEncoder);
+    }
+    videoConfig.hwPreset = settings.hwPreset;
 
     MediaEncoder::AudioConfig audioConfig;
     // Use default values if audio format not set (when streaming/audio not enabled)

--- a/src/recording/RecordingManager.h
+++ b/src/recording/RecordingManager.h
@@ -40,6 +40,30 @@ public:
     void setRecordingSettings(const RecordingSettings& settings) { m_settings = settings; }
     RecordingSettings getRecordingSettings() const { return m_settings; }
 
+    /**
+     * Runtime context describing what is being recorded, embedded as
+     * container metadata at session start (#59). Lets a recording be
+     * identified after the fact without parsing the filename — e.g.
+     * `ffprobe -show_format session.mp4` reveals shader, source
+     * resolution, and host nickname.
+     *
+     * Set via setRecordingContext() before startRecording(); fields
+     * are optional and empty ones are skipped.
+     */
+    struct Context
+    {
+        std::string shaderName;       // e.g. "crt-mattias.glslp" or "(none)"
+        std::string hostNickname;     // user's nickname when publishing
+        uint32_t    sourceWidth  = 0; // pre-shader / pre-scale source dims
+        uint32_t    sourceHeight = 0;
+        uint32_t    sourceFps    = 0;
+        std::string sourceType;       // "v4l2" / "directshow" / "remote"
+        std::string applicationVersion;
+        std::string kind;             // "shader" / "raw" — for future dual output
+    };
+    void setRecordingContext(const Context &ctx) { m_context = ctx; }
+    const Context &getRecordingContext() const   { return m_context; }
+
     // Status
     uint64_t getCurrentDurationUs();
     uint64_t getCurrentFileSize();
@@ -85,6 +109,7 @@ private:
     MediaSynchronizer m_synchronizer;
     
     RecordingSettings m_settings;
+    Context           m_context;
     RecordingMetadata m_currentMetadata;
     
     std::thread m_encodingThread;

--- a/src/recording/RecordingProfileManager.cpp
+++ b/src/recording/RecordingProfileManager.cpp
@@ -103,6 +103,11 @@ bool RecordingProfileManager::save(const std::string &name, const RecordingSetti
         {"h265Level", s.h265Level},
         {"vp8Speed", s.vp8Speed},
         {"vp9Speed", s.vp9Speed},
+        // #59 — hardware encoder selection. Stored as raw int matching
+        // MediaEncoder::HardwareEncoder so profiles survive enum
+        // additions; backend-specific tuning travels with it.
+        {"hardwareEncoder", s.hardwareEncoder},
+        {"hwPreset", s.hwPreset},
     };
     j["audio"] = {
         {"bitrate", s.audioBitrate},
@@ -174,6 +179,8 @@ bool RecordingProfileManager::load(const std::string &name, RecordingSettings &s
             if (v.contains("h265Level")) s.h265Level = v["h265Level"].get<std::string>();
             if (v.contains("vp8Speed")) s.vp8Speed = v["vp8Speed"].get<int>();
             if (v.contains("vp9Speed")) s.vp9Speed = v["vp9Speed"].get<int>();
+            if (v.contains("hardwareEncoder")) s.hardwareEncoder = v["hardwareEncoder"].get<int>();
+            if (v.contains("hwPreset"))        s.hwPreset        = v["hwPreset"].get<std::string>();
         }
         if (j.contains("audio"))
         {

--- a/src/recording/RecordingSettings.h
+++ b/src/recording/RecordingSettings.h
@@ -34,4 +34,14 @@ struct RecordingSettings
     bool autoStart = false;
     uint64_t maxDurationUs = 0; // 0 = no limit
     uint64_t maxFileSize = 0;   // 0 = no limit
+
+    // Hardware encoder selection (#59) — mirrors the streaming side.
+    // Same int encoding as MediaEncoder::HardwareEncoder
+    // (0=Auto, 1=Software, 2=NVENC, 3=VAAPI, 4=QSV, 5=AMF). Auto is
+    // the safe default: MediaEncoder probes the build for hardware
+    // support and falls back to libx264 if none is wired up. hwPreset
+    // carries the backend-specific tuning string (NVENC p1..p7,
+    // VAAPI CBR/VBR/CQP, QSV preset names, AMF quality levels).
+    int         hardwareEncoder = 0;
+    std::string hwPreset = "";
 };

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -1,6 +1,7 @@
 #include "UIConfigurationAudio.h"
 #include "../utils/TranslationManager.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../audio/IAudioCapture.h"
 #ifdef __linux__
 #include "../audio/AudioCapturePulse.h"
@@ -109,9 +110,10 @@ void UIConfigurationAudio::refreshInputSources()
 
 void UIConfigurationAudio::renderInputSourceSelection()
 {
-    ImGui::Text("Audio Input Source");
-    ImGui::Separator();
-    ImGui::TextWrapped("Select the audio source to capture. This audio will be recorded and streamed.");
+    ui_section_header("Audio input",
+                      "Pick the audio source captured alongside video. "
+                      "The selection is shared between streaming and "
+                      "recording.");
 
     if (!m_audioCapture)
     {

--- a/src/ui/UIConfigurationImage.cpp
+++ b/src/ui/UIConfigurationImage.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationImage.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/TranslationManager.h"
 #include <imgui.h>
 
@@ -23,16 +24,15 @@ void UIConfigurationImage::render()
         return;
     }
 
-    ImGui::Text("%s", T("image.adjustments").c_str());
-    ImGui::Separator();
+    ui_section_header("Image adjustments",
+                      "Post-shader, pre-output transforms that only "
+                      "affect what you see locally — they're not "
+                      "embedded in the stream or recording.");
 
     renderBrightnessContrast();
-    ImGui::Separator();
     renderOutputResolution();
-    ImGui::Separator();
     renderAspectRatio();
     renderFullscreen();
-    ImGui::Separator();
     renderMonitorSelection();
 
     ImGui::End();
@@ -89,9 +89,9 @@ void UIConfigurationImage::renderFullscreen()
 
 void UIConfigurationImage::renderOutputResolution()
 {
-    ImGui::Text("Output Resolution");
-    ImGui::TextDisabled("(Applied after shader, before stretching to window)");
-    ImGui::TextDisabled("(0 = automatic, use source resolution)");
+    ui_section_header("Output resolution",
+                      "Applied after the shader, before stretching to "
+                      "the window. 0 = automatic (use source).");
     
     int outputWidth = static_cast<int>(m_uiManager->getOutputWidth());
     int outputHeight = static_cast<int>(m_uiManager->getOutputHeight());
@@ -148,7 +148,8 @@ void UIConfigurationImage::renderOutputResolution()
 
 void UIConfigurationImage::renderMonitorSelection()
 {
-    ImGui::Text("Monitor Index:");
+    ui_section_header("Monitor",
+                      "Which display fullscreen mode targets.");
     bool fullscreen = m_uiManager->getFullscreen();
     if (!fullscreen)
     {

--- a/src/ui/UIConfigurationRecording.cpp
+++ b/src/ui/UIConfigurationRecording.cpp
@@ -1,6 +1,7 @@
 #include "UIConfigurationRecording.h"
 #include "../utils/TranslationManager.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/Logger.h"
 #include <imgui.h>
 #include <algorithm>
@@ -20,7 +21,9 @@ void UIConfigurationRecording::render()
 {
     if (!m_visible || !m_uiManager) return;
 
-    ImGui::SetNextWindowSize(ImVec2(640, 660), ImGuiCond_FirstUseEver);
+    // Same window dims as Configuration → Streaming so the two feel
+    // like the same family of dialog.
+    ImGui::SetNextWindowSize(ImVec2(680, 720), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin(T("recording.title").c_str(), &m_visible))
     {
         ImGui::End();
@@ -28,10 +31,11 @@ void UIConfigurationRecording::render()
     }
 
     renderRecordingStatus();
-    ImGui::Separator();
     renderProfiles();
-    ImGui::Separator();
     {
+        ui_section_header("Pipeline",
+                          "Choose which feed lands on disk: the raw "
+                          "source, or the post-shader output.");
         bool apply = m_uiManager->getRecordingApplyShader();
         if (ImGui::Checkbox("Apply shader to recording", &apply))
         {
@@ -45,18 +49,15 @@ void UIConfigurationRecording::render()
                               "Useful to archive a clean master while keeping the CRT\n"
                               "look on screen / on stream.");
         }
-        ImGui::Separator();
     }
     renderBasicSettings();
-    ImGui::Separator();
     renderCodecSettings();
-    ImGui::Separator();
     renderBitrateSettings();
-    ImGui::Separator();
     renderContainerSettings();
-    ImGui::Separator();
     renderOutputSettings();
+    ImGui::Spacing();
     ImGui::Separator();
+    ImGui::Spacing();
     renderStartStopButton();
 
     ImGui::End();
@@ -64,46 +65,30 @@ void UIConfigurationRecording::render()
 
 void UIConfigurationRecording::renderRecordingStatus()
 {
-    ImGui::Text("Video Recording");
-    ImGui::Separator();
-
-    // Status
-    bool active = m_uiManager->getRecordingActive();
-    ImGui::Text("Status: %s", active ? "Recording" : "Stopped");
-    if (active)
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
-    }
-    else
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "●");
-    }
+    ui_section_header("Video Recording");
+    const bool active = m_uiManager->getRecordingActive();
+    ui_status_indicator(active, "Recording", "Stopped");
 
     if (active)
     {
-        // Duration
-        uint64_t durationUs = m_uiManager->getRecordingDurationUs();
+        const uint64_t durationUs = m_uiManager->getRecordingDurationUs();
         uint64_t seconds = durationUs / 1000000;
         uint64_t minutes = seconds / 60;
         seconds %= 60;
-        uint64_t hours = minutes / 60;
+        const uint64_t hours = minutes / 60;
         minutes %= 60;
-        
+
         std::stringstream ss;
         ss << std::setfill('0') << std::setw(2) << hours << ":"
            << std::setw(2) << minutes << ":"
            << std::setw(2) << seconds;
         ImGui::Text("Duration: %s", ss.str().c_str());
 
-        // File size
-        uint64_t fileSize = m_uiManager->getRecordingFileSize();
-        double sizeMB = static_cast<double>(fileSize) / (1024.0 * 1024.0);
+        const uint64_t fileSize = m_uiManager->getRecordingFileSize();
+        const double   sizeMB   = static_cast<double>(fileSize) / (1024.0 * 1024.0);
         ImGui::Text("File Size: %.2f MB", sizeMB);
 
-        // Filename
-        std::string filename = m_uiManager->getRecordingFilename();
+        const std::string filename = m_uiManager->getRecordingFilename();
         if (!filename.empty())
         {
             ImGui::Text("File: %s", filename.c_str());
@@ -125,8 +110,9 @@ void UIConfigurationRecording::renderProfiles()
 {
     if (m_profilesDirty) refreshProfiles();
 
-    ImGui::Text("Profiles");
-    ImGui::Separator();
+    ui_section_header("Profiles",
+                      "Saved encoder + container configurations you can "
+                      "swap between.");
 
     const char *currentLabel = (m_selectedProfileIndex >= 0 &&
                                 m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
@@ -248,8 +234,9 @@ void UIConfigurationRecording::renderProfiles()
 
 void UIConfigurationRecording::renderBasicSettings()
 {
-    ImGui::Text("Basic Settings");
-    ImGui::Separator();
+    ui_section_header("Video",
+                      "Output resolution and frame rate. \"Capture\" "
+                      "keeps whatever the source delivers.");
 
     // Resolution - Dropdown
     const char *resolutions[] = {
@@ -283,6 +270,13 @@ void UIConfigurationRecording::renderBasicSettings()
         m_uiManager->triggerRecordingWidthChange(resolutionWidths[currentResIndex]);
         m_uiManager->triggerRecordingHeightChange(resolutionHeights[currentResIndex]);
     }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Output resolution written to the file.\n"
+                          "\"Capture\" leaves it at whatever the source\n"
+                          "produces (recommended for retro consoles to\n"
+                          "preserve native resolution).");
+    }
 
     // FPS - Dropdown
     const char *fpsOptions[] = {"Capture (0)", "15", "24", "30", "60", "120"};
@@ -303,12 +297,19 @@ void UIConfigurationRecording::renderBasicSettings()
     {
         m_uiManager->triggerRecordingFpsChange(fpsValues[currentFpsIndex]);
     }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Output frame rate. \"Capture\" matches the source.\n"
+                          "Higher than source upscales temporally and wastes bits;\n"
+                          "lower than source drops frames.");
+    }
 }
 
 void UIConfigurationRecording::renderCodecSettings()
 {
-    ImGui::Text("Codecs");
-    ImGui::Separator();
+    ui_section_header("Codecs",
+                      "What encodes the video and audio. Codec-specific "
+                      "tuning appears below the dropdown.");
 
     // Video codec selection
     const char *videoCodecs[] = {"h264", "h265", "vp8", "vp9"};
@@ -326,6 +327,14 @@ void UIConfigurationRecording::renderCodecSettings()
     if (ImGui::Combo("Video Codec", &currentVideoCodecIndex, videoCodecs, 4))
     {
         m_uiManager->triggerRecordingVideoCodecChange(videoCodecs[currentVideoCodecIndex]);
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("h264: universal compatibility, default.\n"
+                          "h265: ~30%% smaller files at the same quality,\n"
+                          "      but slower to encode and not all players\n"
+                          "      handle it (DaVinci/older Premiere can).\n"
+                          "vp8/vp9: WebM-friendly, mkv container only.");
     }
 
     // Audio codec selection
@@ -345,12 +354,24 @@ void UIConfigurationRecording::renderCodecSettings()
     {
         m_uiManager->triggerRecordingAudioCodecChange(audioCodecs[currentAudioCodecIndex]);
     }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("aac: best compatibility, default for mp4.\n"
+                          "mp3: legacy, lossy at very low bitrates.\n"
+                          "opus: highest quality per bit, mkv/webm only.");
+    }
 
     // Include audio checkbox
     bool includeAudio = m_uiManager->getRecordingIncludeAudio();
     if (ImGui::Checkbox("Include Audio", &includeAudio))
     {
         m_uiManager->triggerRecordingIncludeAudioChange(includeAudio);
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Off = silent recording. The capture pipeline still\n"
+                          "samples audio for the stream, but the muxer skips\n"
+                          "the audio track entirely on disk.");
     }
 
     // Codec-specific settings
@@ -508,8 +529,10 @@ void UIConfigurationRecording::renderVP9Settings()
 
 void UIConfigurationRecording::renderBitrateSettings()
 {
-    ImGui::Text("Bitrate Settings");
-    ImGui::Separator();
+    ui_section_header("Bitrate",
+                      "How aggressively the encoder spends bits. Higher "
+                      "= better quality, larger files; lower = smaller "
+                      "files, visible compression artefacts.");
 
     // Video bitrate (in Mbps)
     uint32_t bitrate = m_uiManager->getRecordingBitrate();
@@ -517,6 +540,14 @@ void UIConfigurationRecording::renderBitrateSettings()
     if (ImGui::SliderFloat("Video Bitrate (Mbps)", &bitrateMbps, 1.0f, 50.0f, "%.1f"))
     {
         m_uiManager->triggerRecordingBitrateChange(static_cast<uint32_t>(bitrateMbps * 1000000));
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Recommended starting points:\n"
+                          " ~3 Mbps  — 720p archival\n"
+                          " ~6 Mbps  — 1080p archival\n"
+                          " ~12 Mbps — 1080p HEVC at zero-compromise\n"
+                          " ~25 Mbps — 4K archival");
     }
 
     // Audio bitrate (in kbps)
@@ -526,12 +557,18 @@ void UIConfigurationRecording::renderBitrateSettings()
     {
         m_uiManager->triggerRecordingAudioBitrateChange(static_cast<uint32_t>(audioBitrateKbps * 1000));
     }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("128 kbps is transparent for AAC; 256 kbps is\n"
+                          "the safe default. Opus reaches the same\n"
+                          "quality around 96 kbps.");
+    }
 }
 
 void UIConfigurationRecording::renderContainerSettings()
 {
-    ImGui::Text("Container Format");
-    ImGui::Separator();
+    ui_section_header("Container",
+                      "The file format that wraps the encoded streams.");
 
     const char *containers[] = {"mp4", "mkv", "avi"};
     std::string currentContainer = m_uiManager->getRecordingContainer();
@@ -560,8 +597,9 @@ void UIConfigurationRecording::renderContainerSettings()
 
 void UIConfigurationRecording::renderOutputSettings()
 {
-    ImGui::Text("Output Settings");
-    ImGui::Separator();
+    ui_section_header("Output",
+                      "Where files land and how they're named. Template "
+                      "uses strftime tokens — see the field tooltip.");
 
     // Output path
     std::string outputPath = m_uiManager->getRecordingOutputPath();
@@ -572,6 +610,12 @@ void UIConfigurationRecording::renderOutputSettings()
     if (ImGui::InputText("Output Directory", pathBuffer, sizeof(pathBuffer)))
     {
         m_uiManager->triggerRecordingOutputPathChange(std::string(pathBuffer));
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Created automatically on first record. Relative\n"
+                          "paths resolve against the application working\n"
+                          "directory; absolute paths are honoured as-is.");
     }
 
     // Filename template
@@ -594,35 +638,23 @@ void UIConfigurationRecording::renderOutputSettings()
 
 void UIConfigurationRecording::renderStartStopButton()
 {
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    bool isRecording = m_uiManager->getRecordingActive();
-    
+    // Same `ImVec2(-1, 0)` full-width default-height button used by
+    // UIConfigurationStreaming::renderStartStopButton — no colour
+    // push, no oversized height. The two windows look like the same
+    // dialog from across the room.
+    const bool isRecording = m_uiManager->getRecordingActive();
     if (isRecording)
     {
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.0f, 0.0f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 0.2f, 0.2f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.8f, 0.0f, 0.0f, 1.0f));
-        
-        if (ImGui::Button("Stop Recording", ImVec2(-1, 40)))
+        if (ImGui::Button("Stop Recording", ImVec2(-1, 0)))
         {
             m_uiManager->triggerRecordingStartStop(false);
         }
-        
-        ImGui::PopStyleColor(3);
     }
     else
     {
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.7f, 0.0f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.9f, 0.0f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.5f, 0.0f, 1.0f));
-        
-        if (ImGui::Button("Start Recording", ImVec2(-1, 40)))
+        if (ImGui::Button("Start Recording", ImVec2(-1, 0)))
         {
             m_uiManager->triggerRecordingStartStop(true);
         }
-        
-        ImGui::PopStyleColor(3);
     }
 }

--- a/src/ui/UIConfigurationRecording.cpp
+++ b/src/ui/UIConfigurationRecording.cpp
@@ -2,11 +2,14 @@
 #include "../utils/TranslationManager.h"
 #include "UIManager.h"
 #include "UISectionHeader.h"
+#include "../encoding/MediaEncoder.h"
 #include "../utils/Logger.h"
 #include <imgui.h>
 #include <algorithm>
+#include <functional>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 UIConfigurationRecording::UIConfigurationRecording(UIManager *uiManager)
     : m_uiManager(uiManager)
@@ -335,6 +338,99 @@ void UIConfigurationRecording::renderCodecSettings()
                           "      but slower to encode and not all players\n"
                           "      handle it (DaVinci/older Premiere can).\n"
                           "vp8/vp9: WebM-friendly, mkv container only.");
+    }
+
+    // Hardware encoder selector + backend-specific preset (#59).
+    // Mirror of UIConfigurationStreaming — same options, same Auto
+    // fallback, defaults are tuned for files (NVENC p4, VAAPI VBR,
+    // AMF quality) instead of streaming. Only shown for H.264/HEVC;
+    // VP8/VP9 have no hardware backends we support.
+    if (currentVideoCodec == "h264" || currentVideoCodec == "h265" || currentVideoCodec == "hevc")
+    {
+        std::vector<MediaEncoder::HardwareEncoder> available = MediaEncoder::detectAvailableEncoders();
+        std::vector<MediaEncoder::HardwareEncoder> options;
+        options.push_back(MediaEncoder::HardwareEncoder::Auto);
+        for (auto h : available) options.push_back(h);
+
+        std::vector<const char *> labels;
+        labels.reserve(options.size());
+        for (auto h : options) labels.push_back(MediaEncoder::hardwareEncoderName(h));
+
+        const int current = m_uiManager->getRecordingHardwareEncoder();
+        int currentIndex = 0;
+        for (size_t i = 0; i < options.size(); ++i)
+        {
+            if (static_cast<int>(options[i]) == current) { currentIndex = static_cast<int>(i); break; }
+        }
+        if (ImGui::Combo("Encoder", &currentIndex, labels.data(), static_cast<int>(labels.size())))
+        {
+            m_uiManager->triggerRecordingHardwareEncoderChange(static_cast<int>(options[currentIndex]));
+        }
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("Auto = try hardware (NVENC/VAAPI/QSV/AMF), fall back to software on failure.\n"
+                              "Software = libx264 guaranteed on any machine.\n"
+                              "Hardware backends only show up when ffmpeg was built with support and\n"
+                              "may fail at runtime if the driver/permission is missing — in that\n"
+                              "case the recording falls back to libx264 automatically.");
+        }
+
+        const MediaEncoder::HardwareEncoder activeHw = options[currentIndex];
+        auto renderEnumCombo = [&](const char *label, const char *const *items, int itemCount,
+                                   const std::string &currentValue,
+                                   std::function<void(const std::string &)> onChange,
+                                   const char *tooltip)
+        {
+            int idx = 0;
+            for (int i = 0; i < itemCount; ++i)
+            {
+                if (currentValue == items[i]) { idx = i; break; }
+            }
+            if (ImGui::Combo(label, &idx, items, itemCount))
+            {
+                onChange(items[idx]);
+            }
+            if (tooltip && ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("%s", tooltip);
+            }
+        };
+
+        if (activeHw == MediaEncoder::HardwareEncoder::NVENC)
+        {
+            static const char *items[] = {"p1", "p2", "p3", "p4", "p5", "p6", "p7"};
+            renderEnumCombo("NVENC Preset", items, 7, m_uiManager->getRecordingNvencPreset(),
+                            [this](const std::string &v) { m_uiManager->triggerRecordingNvencPresetChange(v); },
+                            "p1 = fastest (lowest quality) ... p7 = slowest (highest quality).\n"
+                            "p4 is the recommended balance; p5–p6 are fine for files where\n"
+                            "you can afford extra encoder latency.");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::VAAPI)
+        {
+            static const char *items[] = {"CBR", "VBR", "CQP"};
+            renderEnumCombo("VAAPI Rate Control", items, 3, m_uiManager->getRecordingVaapiRcMode(),
+                            [this](const std::string &v) { m_uiManager->triggerRecordingVaapiRcModeChange(v); },
+                            "CBR = constant bitrate.\n"
+                            "VBR = variable bitrate (recommended for files — sharper highlights).\n"
+                            "CQP = constant quality (ignores bitrate slider).");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::QSV)
+        {
+            static const char *items[] = {"veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow"};
+            renderEnumCombo("QSV Preset", items, 7, m_uiManager->getRecordingQsvPreset(),
+                            [this](const std::string &v) { m_uiManager->triggerRecordingQsvPresetChange(v); },
+                            "Intel Quick Sync presets. Faster = lower quality.\n"
+                            "For files, medium / slow is a reasonable balance.");
+        }
+        else if (activeHw == MediaEncoder::HardwareEncoder::AMF)
+        {
+            static const char *items[] = {"speed", "balanced", "quality"};
+            renderEnumCombo("AMF Quality", items, 3, m_uiManager->getRecordingAmfQuality(),
+                            [this](const std::string &v) { m_uiManager->triggerRecordingAmfQualityChange(v); },
+                            "speed = minimum latency, basic quality.\n"
+                            "balanced = middle ground.\n"
+                            "quality = best visual, higher latency (recommended for files).");
+        }
     }
 
     // Audio codec selection

--- a/src/ui/UIConfigurationShader.cpp
+++ b/src/ui/UIConfigurationShader.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationShader.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../shader/ShaderEngine.h"
 #include "../utils/FilesystemCompat.h"
 #include "../utils/Paths.h"
@@ -34,6 +35,9 @@ void UIConfigurationShader::render()
     m_shaderEngine = m_uiManager->getShaderEngine();
 
     {
+        ui_section_header("Pipeline",
+                          "Toggle the shader chain on or off without "
+                          "losing the selected preset or its tuning.");
         bool enabled = m_uiManager->getShaderPipelineEnabled();
         if (ImGui::Checkbox(T("shader.apply_pipeline").c_str(), &enabled))
         {
@@ -44,13 +48,10 @@ void UIConfigurationShader::render()
         {
             ImGui::SetTooltip("%s", T("shader.apply_pipeline.tip").c_str());
         }
-        ImGui::Separator();
     }
 
     renderShaderSelection();
-    ImGui::Separator();
     renderSavePreset();
-    ImGui::Separator();
     renderShaderParameters();
 
     ImGui::End();
@@ -58,7 +59,9 @@ void UIConfigurationShader::render()
 
 void UIConfigurationShader::renderShaderSelection()
 {
-    ImGui::Text("%s", T("shader.preset").c_str());
+    ui_section_header("Preset",
+                      "Pick a .glslp shader preset from the scan path. "
+                      "Click Rescan to pick up newly dropped files.");
 
     std::string currentShader = m_uiManager->getCurrentShader();
     const std::string rescanLabel = T("shader.rescan");
@@ -99,8 +102,7 @@ void UIConfigurationShader::renderShaderSelection()
         ImGui::SetTooltip("%s", T("shader.rescan.tip").c_str());
     }
 
-    ImGui::Separator();
-    ImGui::Text("%s: %zu", T("shader.shaders_found").c_str(), m_uiManager->getScannedShaders().size());
+    ImGui::TextDisabled("%s: %zu", T("shader.shaders_found").c_str(), m_uiManager->getScannedShaders().size());
 }
 
 void UIConfigurationShader::renderSavePreset()
@@ -110,7 +112,9 @@ void UIConfigurationShader::renderSavePreset()
         return;
     }
 
-    ImGui::Text("%s", T("shader.save_preset").c_str());
+    ui_section_header("Save preset",
+                      "Overwrite the loaded .glslp with current "
+                      "parameters, or write a new one alongside it.");
 
     std::string currentPreset = m_shaderEngine->getPresetPath();
     if (!currentPreset.empty())
@@ -196,7 +200,9 @@ void UIConfigurationShader::renderShaderParameters()
         return;
     }
 
-    ImGui::Text("%s", T("shader.parameters").c_str());
+    ui_section_header("Parameters",
+                      "Knobs the active preset exposes — values persist "
+                      "when you Save the preset.");
 
     auto params = m_shaderEngine->getShaderParameters();
 

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationSource.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/TranslationManager.h"
 #include "../capture/IVideoCapture.h"
 #include <imgui.h>
@@ -79,9 +80,9 @@ void UIConfigurationSource::render()
 
 void UIConfigurationSource::renderSourceTypeSelection()
 {
-    ImGui::Text("Source Type:");
-    ImGui::Separator();
-    ImGui::Spacing();
+    ui_section_header("Source",
+                      "Which physical capture device to read frames "
+                      "from. Switching here re-initialises the pipeline.");
 
     // Dropdown for selecting the local capture source type.
     // 'Remote' no longer lives here — it now has its own top-level menu
@@ -142,11 +143,10 @@ void UIConfigurationSource::renderV4L2Controls()
     renderQuickResolutions();
     ImGui::Separator();
     renderQuickFPS();
-    ImGui::Separator();
 
-    // V4L2 Hardware Controls
-    ImGui::Text("V4L2 Hardware Controls");
-    ImGui::Separator();
+    ui_section_header("V4L2 Hardware Controls",
+                      "Driver-exposed knobs (brightness, hue, exposure, "
+                      "etc.) — set is device-specific.");
 
     // Renderizar controles dinâmicos (discovered from device)
     const auto &controls = m_uiManager->getV4L2Controls();
@@ -281,11 +281,10 @@ void UIConfigurationSource::renderDSControls()
     renderQuickResolutions();
     ImGui::Separator();
     renderQuickFPS();
-    ImGui::Separator();
 
-    // DirectShow Hardware Controls
-    ImGui::Text("DirectShow Hardware Controls");
-    ImGui::Separator();
+    ui_section_header("DirectShow Hardware Controls",
+                      "Filter-exposed knobs from the DirectShow driver. "
+                      "Set is device-specific.");
 
     // Helper function para renderizar controle com range do dispositivo ou padrão
     auto renderControl = [this](const char *name, int32_t defaultMin, int32_t defaultMax, int32_t defaultValue)
@@ -465,8 +464,9 @@ void UIConfigurationSource::renderDSDeviceSelection()
 
 void UIConfigurationSource::renderCaptureSettings()
 {
-    ImGui::Text("Capture Resolution & Framerate");
-    ImGui::Separator();
+    ui_section_header("Capture Resolution & Framerate",
+                      "What the source streams at — separate from the "
+                      "Streaming / Recording target settings.");
 
     // Controles de resolução
     ImGui::Text("Resolution:");

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -702,39 +702,38 @@ void UIConfigurationStreaming::renderBitrateSettings()
                       "How many bits per second the encoder spends on "
                       "video and audio.");
 
-    // Bitrate de vídeo
-    int bitrate = static_cast<int>(m_uiManager->getStreamingBitrate());
-    if (ImGui::InputInt("Video Bitrate (kbps, 0 = auto)", &bitrate, 100, 1000))
+    // Same SliderFloat presentation as UIConfigurationRecording — the
+    // two windows share visual idiom AND interaction grammar so the
+    // user doesn't have to type numbers in one place and drag in the
+    // other. Storage on the streaming side is in kbps (not bps like
+    // Recording), so the Mbps↔kbps conversion just uses a factor of
+    // 1000 instead of 1_000_000.
+    uint32_t bitrate = m_uiManager->getStreamingBitrate();             // kbps
+    float bitrateMbps = static_cast<float>(bitrate) / 1000.0f;
+    if (ImGui::SliderFloat("Video Bitrate (Mbps)", &bitrateMbps, 1.0f, 50.0f, "%.1f"))
     {
-        // Limites: 0 (auto) ou 100-100000 kbps
-        if (bitrate == 0 || (bitrate >= 100 && bitrate <= 100000))
-        {
-            m_uiManager->triggerStreamingBitrateChange(static_cast<uint32_t>(bitrate));
-        }
+        m_uiManager->triggerStreamingBitrateChange(static_cast<uint32_t>(bitrateMbps * 1000.0f));
     }
     if (ImGui::IsItemHovered())
     {
-        ImGui::SetTooltip("Video bitrate in kbps.\n"
-                          "0 = automatic (based on resolution/FPS)\n"
-                          "100-100000 kbps: valid range\n"
-                          "Recommended: 2000-8000 kbps for streaming");
+        ImGui::SetTooltip("Recommended starting points:\n"
+                          " ~3 Mbps  — 720p\n"
+                          " ~6 Mbps  — 1080p\n"
+                          " ~12 Mbps — 1080p HEVC at zero-compromise\n"
+                          " ~25 Mbps — 4K");
     }
 
-    // Bitrate de áudio
-    int audioBitrate = static_cast<int>(m_uiManager->getStreamingAudioBitrate());
-    if (ImGui::InputInt("Audio Bitrate (kbps)", &audioBitrate, 8, 32))
+    uint32_t audioBitrate = m_uiManager->getStreamingAudioBitrate();  // already kbps
+    float audioBitrateKbps = static_cast<float>(audioBitrate);
+    if (ImGui::SliderFloat("Audio Bitrate (kbps)", &audioBitrateKbps, 64.0f, 320.0f, "%.0f"))
     {
-        // Limites: 64-320 kbps (32 é muito baixo para qualidade aceitável)
-        if (audioBitrate >= 64 && audioBitrate <= 320)
-        {
-            m_uiManager->triggerStreamingAudioBitrateChange(static_cast<uint32_t>(audioBitrate));
-        }
+        m_uiManager->triggerStreamingAudioBitrateChange(static_cast<uint32_t>(audioBitrateKbps));
     }
     if (ImGui::IsItemHovered())
     {
-        ImGui::SetTooltip("Audio bitrate in kbps.\n"
-                          "64-320 kbps: valid range\n"
-                          "Recommended: 128-256 kbps for good quality");
+        ImGui::SetTooltip("128 kbps is transparent for AAC; 256 kbps is\n"
+                          "the safe default. Opus reaches the same\n"
+                          "quality around 96 kbps.");
     }
 }
 

--- a/src/ui/UIConfigurationStreaming.cpp
+++ b/src/ui/UIConfigurationStreaming.cpp
@@ -1,5 +1,6 @@
 #include "UIConfigurationStreaming.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/Logger.h"
 #include "../utils/TranslationManager.h"
 #include "../encoding/MediaEncoder.h"
@@ -118,10 +119,11 @@ void UIConfigurationStreaming::render()
     }
 
     renderStreamingStatus();
-    ImGui::Separator();
     renderProfiles();
-    ImGui::Separator();
     {
+        ui_section_header("Pipeline",
+                          "Choose which feed goes on the wire: the raw "
+                          "source, or the post-shader output.");
         bool apply = m_uiManager->getStreamingApplyShader();
         if (ImGui::Checkbox("Apply shader to stream", &apply))
         {
@@ -135,19 +137,17 @@ void UIConfigurationStreaming::render()
                               "Useful to broadcast a clean feed while keeping the CRT\n"
                               "look on screen.");
         }
-        ImGui::Separator();
     }
     renderBasicSettings();
-    ImGui::Separator();
     renderCodecSettings();
-    ImGui::Separator();
     renderBitrateSettings();
-    ImGui::Separator();
     renderDirectoryPublish();      // #49 Phase 2
-    ImGui::Separator();
     // Buffer tuning (max video/audio buffer, max buffer time, AVIO buffer)
     // is not surfaced in the UI anymore — defaults work for the vast
     // majority of cases. Power users can still override via config.json.
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
     renderStartStopButton();
 
     ImGui::End();
@@ -155,22 +155,9 @@ void UIConfigurationStreaming::render()
 
 void UIConfigurationStreaming::renderStreamingStatus()
 {
-    ImGui::Text("HTTP MPEG-TS Streaming (audio + video)");
-    ImGui::Separator();
-
-    // Status
+    ui_section_header("HTTP MPEG-TS Streaming (audio + video)");
     bool active = m_uiManager->getStreamingActive();
-    ImGui::Text("Status: %s", active ? "Active" : "Inactive");
-    if (active)
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "●");
-    }
-    else
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
-    }
+    ui_status_indicator(active, "Active", "Inactive");
 
     if (active)
     {
@@ -197,8 +184,9 @@ void UIConfigurationStreaming::renderProfiles()
 {
     if (m_profilesDirty) refreshProfiles();
 
-    ImGui::Text("Profiles");
-    ImGui::Separator();
+    ui_section_header("Profiles",
+                      "Saved encoder configurations you can swap "
+                      "between.");
 
     const char *currentLabel = (m_selectedProfileIndex >= 0 &&
                                 m_selectedProfileIndex < static_cast<int>(m_profileNames.size()))
@@ -318,8 +306,10 @@ void UIConfigurationStreaming::renderProfiles()
 
 void UIConfigurationStreaming::renderBasicSettings()
 {
-    ImGui::Text("Basic Settings");
-    ImGui::Separator();
+    ui_section_header("Video",
+                      "Output resolution and frame rate sent on the "
+                      "wire. \"Capture\" forwards whatever the source "
+                      "delivers.");
 
     // Porta
     int port = static_cast<int>(m_uiManager->getStreamingPort());
@@ -387,8 +377,9 @@ void UIConfigurationStreaming::renderBasicSettings()
 
 void UIConfigurationStreaming::renderCodecSettings()
 {
-    ImGui::Text("Codecs");
-    ImGui::Separator();
+    ui_section_header("Codecs",
+                      "What encodes the video and audio. Codec-specific "
+                      "tuning appears below the dropdown.");
 
     // Seleção de codec de vídeo
     const char *videoCodecs[] = {"h264", "h265", "vp8", "vp9"};
@@ -707,8 +698,9 @@ void UIConfigurationStreaming::renderVP9Settings()
 
 void UIConfigurationStreaming::renderBitrateSettings()
 {
-    ImGui::Text("Bitrates");
-    ImGui::Separator();
+    ui_section_header("Bitrate",
+                      "How many bits per second the encoder spends on "
+                      "video and audio.");
 
     // Bitrate de vídeo
     int bitrate = static_cast<int>(m_uiManager->getStreamingBitrate());
@@ -748,8 +740,10 @@ void UIConfigurationStreaming::renderBitrateSettings()
 
 void UIConfigurationStreaming::renderAdvancedBufferSettings()
 {
-    ImGui::Text("Buffer (Advanced)");
-    ImGui::Separator();
+    ui_section_header("Buffer (Advanced)",
+                      "Lower-level synchronizer tunables. Defaults work "
+                      "for nearly every setup — only touch if you know "
+                      "exactly which timing issue you're chasing.");
 
     // Max Video Buffer Size
     int maxVideoBuffer = static_cast<int>(m_uiManager->getStreamingMaxVideoBufferSize());
@@ -879,12 +873,10 @@ void UIConfigurationStreaming::renderStartStopButton()
 // ─────────────────────────────────────────────────────────────────────
 void UIConfigurationStreaming::renderDirectoryPublish()
 {
-    ImGui::TextColored(ImVec4(0.4f, 0.7f, 1.0f, 1.0f), "Public directory");
-    ImGui::TextWrapped(
-        "Optionally list this stream in a public directory so other "
-        "RetroCapture clients can find it without you sharing the URL "
-        "out of band.");
-    ImGui::Spacing();
+    ui_section_header("Public directory",
+                      "Optionally list this stream in a public directory "
+                      "so other RetroCapture clients can find it without "
+                      "you sharing the URL out of band.");
 
     // ── Privacy modal: shown the first time the user flips the toggle
     // on. Once accepted, the ack flag sticks and we never show it

--- a/src/ui/UIConfigurationWebPortal.cpp
+++ b/src/ui/UIConfigurationWebPortal.cpp
@@ -1,6 +1,7 @@
 #include "UIConfigurationWebPortal.h"
 #include "../utils/TranslationManager.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include <imgui.h>
 #include <cstring>
 
@@ -24,9 +25,9 @@ void UIConfigurationWebPortal::render()
         return;
     }
 
-    ImGui::Text("%s", T("webportal.title").c_str());
-    ImGui::Separator();
-    ImGui::Spacing();
+    ui_section_header("Web Portal",
+                      "Browser-based dashboard with live preview, "
+                      "configuration, and recordings library.");
 
     renderWebPortalEnable();
 
@@ -41,24 +42,9 @@ void UIConfigurationWebPortal::render()
     }
 
     ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
     renderStartStopButton();
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
     renderHTTPSSettings();
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
     renderCustomization();
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
     renderPortalURL();
 
     ImGui::End();
@@ -103,7 +89,9 @@ void UIConfigurationWebPortal::renderStartStopButton()
 
 void UIConfigurationWebPortal::renderHTTPSSettings()
 {
-    // HTTPS Enable/Disable
+    ui_section_header("HTTPS",
+                      "Serve the portal over TLS. Requires a certificate "
+                      "and matching private key on disk.");
     bool httpsEnabled = m_uiManager->getWebPortalHTTPSEnabled();
     if (ImGui::Checkbox("Enable HTTPS", &httpsEnabled))
     {
@@ -152,10 +140,8 @@ void UIConfigurationWebPortal::renderHTTPSSettings()
 
 void UIConfigurationWebPortal::renderCustomization()
 {
-    // Personalização
-    ImGui::Text("Customization");
-    ImGui::Separator();
-    ImGui::Spacing();
+    ui_section_header("Customization",
+                      "Branding shown to visitors of the portal.");
 
     // Título
     char titleBuffer[256];

--- a/src/ui/UICredits.cpp
+++ b/src/ui/UICredits.cpp
@@ -1,5 +1,6 @@
 #include "UICredits.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/Logger.h"
 #include <imgui.h>
 
@@ -38,11 +39,8 @@ void UICredits::render()
     if (ImGui::Begin("Credits", &m_visible))
     {
         ImGui::TextWrapped("RetroCapture %s", RETROCAPTURE_VERSION);
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
 
-        // Autor
+        ui_section_header("Project");
         ImGui::Text("Author:");
         ImGui::SameLine();
         ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "Geldo Ronie");
@@ -74,22 +72,14 @@ void UICredits::render()
             #pragma GCC diagnostic pop
 #endif
         }
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        // Agradecimentos
-        ImGui::Text("Special Thanks:");
-        ImGui::Spacing();
+        ui_section_header("Special thanks");
         ImGui::BulletText("RetroArch");
         ImGui::Indent();
         ImGui::TextWrapped("For the amazing shader system and GLSL shader presets that make this project possible.");
         ImGui::Unindent();
         ImGui::Spacing();
 
-        // Bibliotecas
-        ImGui::Text("Libraries Used:");
-        ImGui::Spacing();
+        ui_section_header("Libraries");
 
         ImGui::BulletText("ImGui");
         ImGui::Indent();
@@ -159,11 +149,7 @@ void UICredits::render()
         ImGui::Unindent();
         ImGui::Spacing();
 
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        // Licença
+        ui_section_header("License");
         ImGui::Text("License:");
         ImGui::SameLine();
         ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.8f, 1.0f), "MIT License");

--- a/src/ui/UIDirectoryBrowser.cpp
+++ b/src/ui/UIDirectoryBrowser.cpp
@@ -1,6 +1,7 @@
 #include "UIDirectoryBrowser.h"
 #include "UIManager.h"
 #include "UIRemoteConnection.h"
+#include "UISectionHeader.h"
 #include "../streaming/DirectoryBrowser.h"
 #include "../utils/HttpClient.h"
 #include "../utils/PasswordHash.h"
@@ -110,8 +111,7 @@ void UIDirectoryBrowser::renderTable()
         return;
     }
 
-    ImGui::TextWrapped("%s", T("browse.intro").c_str());
-    ImGui::Spacing();
+    ui_section_header(T("browse.title").c_str(), T("browse.intro").c_str());
 
     {
         char urlBuf[256];

--- a/src/ui/UIInfoPanel.cpp
+++ b/src/ui/UIInfoPanel.cpp
@@ -1,5 +1,6 @@
 #include "UIInfoPanel.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../capture/IVideoCapture.h"
 #include "../utils/TranslationManager.h"
 #include <imgui.h>
@@ -41,10 +42,8 @@ void UIInfoPanel::render()
     else
     {
         renderCaptureInfo();
-        ImGui::Separator();
         renderStreamingInfo();
     }
-    ImGui::Separator();
     renderSystemInfo();
 
     ImGui::End();
@@ -52,8 +51,7 @@ void UIInfoPanel::render()
 
 void UIInfoPanel::renderCaptureInfo()
 {
-    ImGui::Text("%s", T("info.capture").c_str());
-    ImGui::Separator();
+    ui_section_header(T("info.capture").c_str());
 
     const std::string device = m_uiManager->getCaptureDevice();
     ImGui::Text("%s: %s", T("info.capture.device").c_str(),
@@ -67,8 +65,7 @@ void UIInfoPanel::renderCaptureInfo()
 
 void UIInfoPanel::renderStreamingInfo()
 {
-    ImGui::Text("%s", T("info.streaming").c_str());
-    ImGui::Separator();
+    ui_section_header(T("info.streaming").c_str());
 
     bool active = m_uiManager->getStreamingActive();
     ImGui::Text("%s:", T("info.streaming.status").c_str());
@@ -93,8 +90,7 @@ void UIInfoPanel::renderStreamingInfo()
 
 void UIInfoPanel::renderRemoteInfo()
 {
-    ImGui::Text("%s", T("info.remote_stream").c_str());
-    ImGui::Separator();
+    ui_section_header(T("info.remote_stream").c_str());
 
     ImGui::Text("%s: %s", T("info.remote.host_url").c_str(),
                 m_uiManager->getCurrentDevice().c_str());
@@ -113,9 +109,7 @@ void UIInfoPanel::renderRemoteInfo()
     ImGui::Text("%s: %s", T("info.remote.interp").c_str(),
                 interp.empty() ? "linear" : interp.c_str());
 
-    ImGui::Spacing();
-    ImGui::Text("%s", T("info.connection").c_str());
-    ImGui::Separator();
+    ui_section_header(T("info.connection").c_str());
 
     const bool hasFrames = (w > 0 && h > 0);
     if (m_uiManager->getRemoteHostLikelyOffline())
@@ -139,8 +133,7 @@ void UIInfoPanel::renderRemoteInfo()
 
 void UIInfoPanel::renderSystemInfo()
 {
-    ImGui::Text("%s", T("info.application").c_str());
-    ImGui::Separator();
+    ui_section_header(T("info.application").c_str());
 
     ImGui::Text("%s: %s", T("info.application.version").c_str(), RETROCAPTURE_VERSION);
     ImGui::Text("Dear ImGui: %s", ImGui::GetVersion());

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -2769,6 +2769,16 @@ void UIManager::loadConfig()
                 m_recordingIncludeAudio = recording["includeAudio"];
             if (recording.contains("applyShader"))
                 m_recordingApplyShader = recording["applyShader"].get<bool>();
+            if (recording.contains("hardwareEncoder"))
+                m_recordingHardwareEncoder = recording["hardwareEncoder"].get<int>();
+            if (recording.contains("nvencPreset"))
+                m_recordingNvencPreset = recording["nvencPreset"].get<std::string>();
+            if (recording.contains("vaapiRcMode"))
+                m_recordingVaapiRcMode = recording["vaapiRcMode"].get<std::string>();
+            if (recording.contains("qsvPreset"))
+                m_recordingQsvPreset = recording["qsvPreset"].get<std::string>();
+            if (recording.contains("amfQuality"))
+                m_recordingAmfQuality = recording["amfQuality"].get<std::string>();
         }
 
         if (config.contains("streaming"))
@@ -2915,7 +2925,12 @@ void UIManager::saveConfig()
             {"outputPath", m_recordingOutputPath},
             {"filenameTemplate", m_recordingFilenameTemplate},
             {"includeAudio", m_recordingIncludeAudio},
-            {"applyShader", m_recordingApplyShader}};
+            {"applyShader", m_recordingApplyShader},
+            {"hardwareEncoder", m_recordingHardwareEncoder},
+            {"nvencPreset", m_recordingNvencPreset},
+            {"vaapiRcMode", m_recordingVaapiRcMode},
+            {"qsvPreset", m_recordingQsvPreset},
+            {"amfQuality", m_recordingAmfQuality}};
 
         // Escrever arquivo
         std::ofstream file(configPath);
@@ -3481,6 +3496,41 @@ void UIManager::triggerRecordingIncludeAudioChange(bool include)
     saveConfig();
 }
 
+void UIManager::triggerRecordingHardwareEncoderChange(int v)
+{
+    m_recordingHardwareEncoder = v;
+    if (m_onRecordingHardwareEncoderChanged) m_onRecordingHardwareEncoderChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerRecordingNvencPresetChange(const std::string &v)
+{
+    m_recordingNvencPreset = v;
+    if (m_onRecordingNvencPresetChanged) m_onRecordingNvencPresetChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerRecordingVaapiRcModeChange(const std::string &v)
+{
+    m_recordingVaapiRcMode = v;
+    if (m_onRecordingVaapiRcModeChanged) m_onRecordingVaapiRcModeChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerRecordingQsvPresetChange(const std::string &v)
+{
+    m_recordingQsvPreset = v;
+    if (m_onRecordingQsvPresetChanged) m_onRecordingQsvPresetChanged(v);
+    saveConfig();
+}
+
+void UIManager::triggerRecordingAmfQualityChange(const std::string &v)
+{
+    m_recordingAmfQuality = v;
+    if (m_onRecordingAmfQualityChanged) m_onRecordingAmfQualityChanged(v);
+    saveConfig();
+}
+
 void UIManager::triggerRecordingStartStop(bool start)
 {
     if (m_onRecordingStartStop)
@@ -3516,6 +3566,15 @@ RecordingSettings collectRecordingSettings(const UIManager &ui)
     s.outputPath = ui.getRecordingOutputPath();
     s.filenameTemplate = ui.getRecordingFilenameTemplate();
     s.includeAudio = ui.getRecordingIncludeAudio();
+    s.hardwareEncoder = ui.getRecordingHardwareEncoder();
+    switch (s.hardwareEncoder)
+    {
+        case 2: s.hwPreset = ui.getRecordingNvencPreset(); break;
+        case 3: s.hwPreset = ui.getRecordingVaapiRcMode(); break;
+        case 4: s.hwPreset = ui.getRecordingQsvPreset();   break;
+        case 5: s.hwPreset = ui.getRecordingAmfQuality();  break;
+        default: s.hwPreset.clear(); break;
+    }
     return s;
 }
 
@@ -3578,6 +3637,17 @@ bool UIManager::loadRecordingProfile(const std::string &name)
     triggerRecordingOutputPathChange(s.outputPath);
     triggerRecordingFilenameTemplateChange(s.filenameTemplate);
     triggerRecordingIncludeAudioChange(s.includeAudio);
+    triggerRecordingHardwareEncoderChange(s.hardwareEncoder);
+    // Route the backend-specific preset string to the right per-backend
+    // field — same dispatch as the streaming side does.
+    switch (s.hardwareEncoder)
+    {
+        case 2: triggerRecordingNvencPresetChange(s.hwPreset); break;
+        case 3: triggerRecordingVaapiRcModeChange(s.hwPreset); break;
+        case 4: triggerRecordingQsvPresetChange  (s.hwPreset); break;
+        case 5: triggerRecordingAmfQualityChange (s.hwPreset); break;
+        default: break;
+    }
     return true;
 }
 

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -550,6 +550,18 @@ public:
     void setRecordingFilenameTemplate(const std::string& template_) { m_recordingFilenameTemplate = template_; }
     void setRecordingIncludeAudio(bool include) { m_recordingIncludeAudio = include; }
 
+    // Hardware encoder selection for recording (#59). Same int-based
+    // encoding as the streaming side so we don't have to pull
+    // MediaEncoder.h into the UI layer (0=Auto, 1=Software,
+    // 2=NVENC, 3=VAAPI, 4=QSV, 5=AMF). Backend-specific preset
+    // strings live in separate fields per backend, mirroring the
+    // streaming layout exactly so the same UI block can render both.
+    void setRecordingHardwareEncoder(int v)           { m_recordingHardwareEncoder = v; }
+    void setRecordingNvencPreset(const std::string &v){ m_recordingNvencPreset = v; }
+    void setRecordingVaapiRcMode(const std::string &v){ m_recordingVaapiRcMode = v; }
+    void setRecordingQsvPreset(const std::string &v)  { m_recordingQsvPreset = v; }
+    void setRecordingAmfQuality(const std::string &v) { m_recordingAmfQuality = v; }
+
     // Recording info getters (public)
     bool getRecordingActive() const { return m_recordingActive; }
     uint64_t getRecordingDurationUs() const { return m_recordingDurationUs; }
@@ -572,6 +584,11 @@ public:
     std::string getRecordingOutputPath() const { return m_recordingOutputPath; }
     std::string getRecordingFilenameTemplate() const { return m_recordingFilenameTemplate; }
     bool getRecordingIncludeAudio() const { return m_recordingIncludeAudio; }
+    int  getRecordingHardwareEncoder() const         { return m_recordingHardwareEncoder; }
+    std::string getRecordingNvencPreset() const      { return m_recordingNvencPreset; }
+    std::string getRecordingVaapiRcMode() const      { return m_recordingVaapiRcMode; }
+    std::string getRecordingQsvPreset()   const      { return m_recordingQsvPreset; }
+    std::string getRecordingAmfQuality()  const      { return m_recordingAmfQuality; }
 
     // Recording setters with callbacks
     void triggerRecordingWidthChange(uint32_t width);
@@ -591,6 +608,11 @@ public:
     void triggerRecordingOutputPathChange(const std::string& path);
     void triggerRecordingFilenameTemplateChange(const std::string& template_);
     void triggerRecordingIncludeAudioChange(bool include);
+    void triggerRecordingHardwareEncoderChange(int v);
+    void triggerRecordingNvencPresetChange(const std::string &v);
+    void triggerRecordingVaapiRcModeChange(const std::string &v);
+    void triggerRecordingQsvPresetChange(const std::string &v);
+    void triggerRecordingAmfQualityChange(const std::string &v);
     void triggerRecordingStartStop(bool start);
 
     // Recording profiles — save/load/list/delete the full recording
@@ -630,6 +652,11 @@ public:
     void setOnRecordingOutputPathChanged(std::function<void(const std::string&)> callback) { m_onRecordingOutputPathChanged = callback; }
     void setOnRecordingFilenameTemplateChanged(std::function<void(const std::string&)> callback) { m_onRecordingFilenameTemplateChanged = callback; }
     void setOnRecordingIncludeAudioChanged(std::function<void(bool)> callback) { m_onRecordingIncludeAudioChanged = callback; }
+    void setOnRecordingHardwareEncoderChanged(std::function<void(int)> cb)             { m_onRecordingHardwareEncoderChanged = cb; }
+    void setOnRecordingNvencPresetChanged(std::function<void(const std::string &)> cb) { m_onRecordingNvencPresetChanged = cb; }
+    void setOnRecordingVaapiRcModeChanged(std::function<void(const std::string &)> cb) { m_onRecordingVaapiRcModeChanged = cb; }
+    void setOnRecordingQsvPresetChanged  (std::function<void(const std::string &)> cb) { m_onRecordingQsvPresetChanged = cb; }
+    void setOnRecordingAmfQualityChanged (std::function<void(const std::string &)> cb) { m_onRecordingAmfQualityChanged = cb; }
 
     // Web Portal settings
     void setWebPortalEnabled(bool enabled) { m_webPortalEnabled = enabled; }
@@ -1078,6 +1105,14 @@ private:
     std::string m_recordingOutputPath = "recordings/";
     std::string m_recordingFilenameTemplate = "recording_%Y%m%d_%H%M%S";
     bool m_recordingIncludeAudio = true;
+    // Mirrors the streaming side (#59). 0=Auto (try hardware,
+    // fall back to libx264), 1=Software, 2=NVENC, 3=VAAPI, 4=QSV,
+    // 5=AMF. Backend-specific presets live in separate fields.
+    int         m_recordingHardwareEncoder = 0;
+    std::string m_recordingNvencPreset = "p4";
+    std::string m_recordingVaapiRcMode = "VBR"; // VBR is the better default for files
+    std::string m_recordingQsvPreset   = "medium";
+    std::string m_recordingAmfQuality  = "quality"; // recordings can afford the latency for visual quality
 
     // Recording callbacks
     std::function<void(bool)> m_onRecordingStartStop;
@@ -1098,6 +1133,11 @@ private:
     std::function<void(const std::string&)> m_onRecordingOutputPathChanged;
     std::function<void(const std::string&)> m_onRecordingFilenameTemplateChanged;
     std::function<void(bool)> m_onRecordingIncludeAudioChanged;
+    std::function<void(int)> m_onRecordingHardwareEncoderChanged;
+    std::function<void(const std::string &)> m_onRecordingNvencPresetChanged;
+    std::function<void(const std::string &)> m_onRecordingVaapiRcModeChanged;
+    std::function<void(const std::string &)> m_onRecordingQsvPresetChanged;
+    std::function<void(const std::string &)> m_onRecordingAmfQualityChanged;
 
     // Web Portal settings
     bool m_webPortalEnabled = true; // Habilitado por padrão

--- a/src/ui/UIPreferences.cpp
+++ b/src/ui/UIPreferences.cpp
@@ -1,5 +1,6 @@
 #include "UIPreferences.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../utils/TranslationManager.h"
 #include <imgui.h>
 
@@ -22,15 +23,11 @@ void UIPreferences::render()
     }
 
     ImGui::TextWrapped("%s", T("preferences.intro").c_str());
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
 
-    // ── Language ──────────────────────────────────────────────────
     // Changing this calls TranslationManager::setLanguage, which
     // reloads the overlay bundle in-place; the next frame's T()
     // lookups already render in the new language.
-    ImGui::Text("%s", T("preferences.language").c_str());
+    ui_section_header(T("preferences.language").c_str());
     const char *langLabels[] = { "English", "Português (Brasil)" };
     const char *langKeys[]   = { "en",      "pt" };
     const std::string currentLang = m_uiManager->getLanguage();
@@ -49,12 +46,7 @@ void UIPreferences::render()
     }
     ImGui::TextDisabled("%s", T("preferences.language.hint").c_str());
 
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    // ── Window behaviour ──────────────────────────────────────────
-    ImGui::Text("%s", T("preferences.window").c_str());
+    ui_section_header(T("preferences.window").c_str());
     bool startFullscreen = m_uiManager->getStartFullscreen();
     if (ImGui::Checkbox(T("preferences.start_fullscreen").c_str(), &startFullscreen))
     {

--- a/src/ui/UIRecordings.cpp
+++ b/src/ui/UIRecordings.cpp
@@ -1,5 +1,6 @@
 #include "UIRecordings.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../core/Application.h"
 #include "../utils/Logger.h"
 #include "../utils/FilesystemCompat.h"
@@ -237,8 +238,7 @@ void UIRecordings::renderRecordingDetails()
 
     const auto& recording = *it;
 
-    ImGui::Separator();
-    ImGui::Text("Details:");
+    ui_section_header("Details");
     ImGui::BeginChild("details", ImVec2(0, 150.0f), true);
     
     ImGui::Text("ID: %s", recording.id.c_str());

--- a/src/ui/UIRemoteConnection.cpp
+++ b/src/ui/UIRemoteConnection.cpp
@@ -1,5 +1,6 @@
 #include "UIRemoteConnection.h"
 #include "UIManager.h"
+#include "UISectionHeader.h"
 #include "../capture/IVideoCapture.h"
 #include "../streaming/DirectoryBrowser.h"
 #include "../utils/PasswordHash.h"
@@ -98,17 +99,12 @@ void UIRemoteConnection::render()
     ImGui::SetNextWindowSize(ImVec2(520, 320), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(T("remote.title").c_str(), &m_visible))
     {
-        ImGui::TextWrapped("%s", T("remote.intro").c_str());
-        ImGui::Spacing();
+        ui_section_header(T("remote.title").c_str(), T("remote.intro").c_str());
         ImGui::TextDisabled("%s", T("remote.tip").c_str());
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
 
         renderManualTab(sourceIsRemote, currentDevice, connected);
 
-        ImGui::Spacing();
-        ImGui::Separator();
+        ui_section_header("Status");
         renderStatusFooter(connected);
     }
     ImGui::End();
@@ -121,8 +117,7 @@ void UIRemoteConnection::renderManualTab(bool /*sourceIsRemote*/,
                                          const std::string &currentDevice,
                                          bool connected)
 {
-    ImGui::Spacing();
-    ImGui::Text("%s", T("remote.base_url").c_str());
+    ui_section_header(T("remote.base_url").c_str());
     ImGui::SetNextItemWidth(-1);
     ImGui::InputText("##remoteUrl", m_urlBuffer, sizeof(m_urlBuffer));
 
@@ -143,7 +138,7 @@ void UIRemoteConnection::renderManualTab(bool /*sourceIsRemote*/,
     {
         if (currentMode == modes[i]) { currentModeIndex = i; break; }
     }
-    ImGui::Text("%s", T("remote.display_interp").c_str());
+    ui_section_header(T("remote.display_interp").c_str());
     ImGui::SetNextItemWidth(-1);
     if (ImGui::Combo("##remoteInterp", &currentModeIndex, modeLabels, 3))
     {
@@ -154,8 +149,6 @@ void UIRemoteConnection::renderManualTab(bool /*sourceIsRemote*/,
         ImGui::SetTooltip("%s", T("remote.interp.tip").c_str());
     }
 
-    ImGui::Spacing();
-    ImGui::Separator();
     ImGui::Spacing();
 
     // Two-frame state machine: button click sets *ShowStatus, the

--- a/src/ui/UISectionHeader.h
+++ b/src/ui/UISectionHeader.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <imgui.h>
+
+/**
+ * Shared visual idiom for section headers inside Configuration
+ * windows (Source, Shader, Image, Streaming, Recording, Web Portal,
+ * Audio).
+ *
+ * Why a shared helper:
+ *   The previous pattern was each window using a plain
+ *   `ImGui::Text("Title") + ImGui::Separator()` for every section,
+ *   which read as a dense wall of identical-looking labels with no
+ *   visual hierarchy. Switching everyone to a coloured title + an
+ *   optional one-paragraph blurb gives unfamiliar fields context
+ *   without forcing the user to hover for tooltips, and gives
+ *   familiar fields a clear scanning anchor.
+ *
+ *   Keeping the rendering in one inline function means: (a) every
+ *   Configuration window looks identical across releases — change
+ *   the colour or spacing here and every window updates; (b) a
+ *   future "compact mode" or "verbose mode" toggle can swap the
+ *   single implementation without touching call sites.
+ *
+ * Usage:
+ *   ui_section_header("Profiles",
+ *                     "Saved configurations you can swap between.");
+ *   // ... section body ...
+ *
+ *   ui_section_header("Output");          // title only, no blurb
+ *   // ... section body ...
+ *
+ * The leading Spacing() handles separation from the previous
+ * section, so call sites do NOT need to insert an explicit
+ * Separator() / Spacing() before invoking this.
+ */
+inline void ui_section_header(const char *title, const char *blurb = nullptr)
+{
+    ImGui::Spacing();
+    // Same cyan that UIConfigurationStreaming::renderDirectoryPublish
+    // has used for its title since #49 Phase 2 landed.
+    ImGui::TextColored(ImVec4(0.4f, 0.7f, 1.0f, 1.0f), "%s", title);
+    if (blurb && *blurb)
+    {
+        ImGui::TextWrapped("%s", blurb);
+    }
+    ImGui::Spacing();
+}
+
+/**
+ * Inline status indicator used inside renderXxxStatus() blocks. A
+ * coloured filled bullet next to a "Status: ..." line at the top of
+ * the window. Same colour conventions everywhere: green = active /
+ * healthy, red = stopped / inactive, grey = unavailable / disabled.
+ *
+ * Usage:
+ *   ui_section_header("Video Recording");
+ *   ui_status_indicator(active, "Recording", "Stopped");
+ */
+inline void ui_status_indicator(bool active, const char *activeLabel, const char *inactiveLabel)
+{
+    ImGui::Text("Status: %s", active ? activeLabel : inactiveLabel);
+    ImGui::SameLine();
+    if (active)
+    {
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "●");
+    }
+    else
+    {
+        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
+    }
+}


### PR DESCRIPTION
Partial close of #59 — the umbrella issue. The dual-output / shared-encoder fan-out / kind-column / encoder-link-toggle sub-items are deliberately deferred to follow-up issues (listed at the bottom). Everything else in #59's checklist lands here.

## What's in the box

### Recording-pipeline fixes
- **HEVC/H.264 `repeat-headers=1` in recordings.** Mirrors commit 6508118's streaming-side fix on the file path. DaVinci / kdenlive / Premiere thumbnail strips that scrub to a random byte offset now get a clean VPS/SPS/PPS at the next IDR instead of stale or garbled previews. MP4 drops Annex B framing since the container wraps HEVC in length-prefix format; hardware encoders (NVENC `forced-idr`, VAAPI `idr_interval`, AMF `header_insertion_mode=idr`) already emit inline params unconditionally.
- **Container-level metadata embedded.** A new `MediaMuxer::setMetadata(map<string,string>)` API is invoked from `RecordingManager::startRecording` with a snapshot of the runtime state — shader name, host nickname, source W×H/fps, source type, application version, codec, and a `kind` marker. Standard MP4 atoms (title / comment / encoder) carry the human-readable summary; custom `retrocapture.*` keys land in `udta` (MP4) or Tags entries (MKV). After the fact: `ffprobe -show_format <file>` answers \"which shader captured this, at what source resolution\" without you parsing the filename.
- **Plumbing audit on MediaSynchronizer / MediaEncoder / MediaMuxer** between streaming and recording. Findings: PTS handling under source-resolution changes is already covered (`MediaEncoder` auto-recreates `SwsContext` when frame dimensions change, both paths benefit); the audio-master-clock divergence is intentional (recording uses an eager audio drain that the MP4/MKV muxer's DTS reorder safely absorbs); teardown order is byte-for-byte symmetric. No bug to fix.

### Hardware encoder selection for recording
- **`UIManager` mirrors the streaming-side fields:** `m_recordingHardwareEncoder` plus `m_recordingNvencPreset` / `m_recordingVaapiRcMode` / `m_recordingQsvPreset` / `m_recordingAmfQuality`. Getters, setters, `triggerXxxChange` and `on*Changed` callback hooks all included. Defaults are tuned for files (NVENC `p4`, VAAPI `VBR`, QSV `medium`, AMF `quality`) instead of the latency-biased streaming defaults.
- **`config.json` persists the 5 new fields** under `recording`. `RecordingProfileManager` serialises `hardwareEncoder` + `hwPreset` so saved profiles round-trip the hardware selection.
- **`RecordingManager` copies the fields onto `MediaEncoder::VideoConfig`** before `initialize()`. Out-of-range values silently fall back to Auto.
- **`Application` resolves the backend-specific preset** from the right per-backend field when assembling `RecordingSettings` for `startRecording` (both the initial-load path and the live-toggle path). Auto/Software paths leave `hwPreset` empty.
- **`UIConfigurationRecording`** has a new Encoder + per-backend preset combo inside `renderCodecSettings`, only rendered for H.264/HEVC. Layout is identical to `UIConfigurationStreaming`.

### Unified UI idiom across every window
- New shared header `src/ui/UISectionHeader.h` exposing `ui_section_header(title, blurb?)` (coloured cyan title + optional one-paragraph blurb + leading/trailing spacing) and `ui_status_indicator(active, activeLabel, inactiveLabel)` (the `Status: X ●` pattern previously copy-pasted on Streaming and Recording).
- Every `render()` that opened with a `Text + Separator` was converted: **Source / Shader / Image / Streaming / Recording / Web Portal / Audio** Configuration windows, plus **Info / Preferences / Remote / Browse / Credits / Recordings**. One paint convention across the whole app.
- One place to edit if we ever want to swap the section colour, add a compact-mode toggle, or change heading-to-content spacing.

### Bitrate slider parity
- Streaming switched from `InputInt` (typed kbps) to `SliderFloat` in Mbps for video and kbps for audio — same interaction grammar as Recording. Underlying kbps storage on the streaming side stays the same, just the conversion factor differs from Recording's bps storage.

## Out of scope (follow-up issues)

These are tracked on #59 and intentionally deferred:
- **Dual output** (raw + shader recorded simultaneously into `session.mp4` + `session.raw.mp4`).
- **Shared encoder fan-out** when streaming + recording overlap with matching codec config (CPU win on ARM).
- **\"Kind\" column** in the Recordings window (depends on dual output).
- **Stream/Record encoder-config link toggle** (option to mirror codec/bitrate/preset between the two).

## Build status
Cross-compiled clean on both:
- `./tools/build-linux-x86_64-docker.sh`
- `./tools/build-windows-x86_64-docker.sh`

## Test plan
- [x] Record an HEVC `.mp4`, open in DaVinci / kdenlive scrub bar — thumbnail strip renders cleanly across the whole timeline (was garbled past first IDR before).
- [x] Run `ffprobe -show_format <recording.mp4>` — `TAG:retrocapture.shader`, `TAG:retrocapture.source_width`, `TAG:retrocapture.source_fps`, etc. visible alongside standard `title` / `comment` / `encoder`.
- [x] Open Configuration → Recording. With H.264 selected, confirm the new Encoder dropdown shows Auto + each hardware backend that ffmpeg was built with.
- [x] Pick NVENC, set the NVENC Preset slider, start recording — verify the resulting file decodes and looks correct.
- [x] Restart the app, confirm the hardware selection persisted via `config.json`.
- [x] Save a recording profile with a hardware selection, switch to a different config, load the profile — verify hardware encoder + preset come back.
- [x] Compare Streaming and Recording windows side by side: same coloured section headers, same `Status: ●` indicator, same bitrate slider style for video (Mbps) and audio (kbps).
- [x] Confirm Auto fallback still works on a build that lacks any hardware encoder — recording falls back to libx264 instead of failing.