### PR TITLE
Quick Actions OSD + Shortcuts widget + OSD layer split (closes #68)

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -13,6 +13,7 @@
   "menu.view":              "View",
   "menu.view.toggleui":     "Toggle UI",
   "menu.view.quickactions": "Quick actions",
+  "menu.view.shortcuts":    "Keyboard shortcuts",
   "menu.view.info":         "Info",
   "menu.view.capturepresets": "Capture Presets",
   "menu.view.recordings":   "Recordings",
@@ -237,6 +238,11 @@
   "quickactions.disconnect": "Disconnect",
   "quickactions.browse":   "Browse directory",
   "quickactions.record_client.tip": "Records what's on screen (post-decode video).\nAudio is captured from the local input device, NOT\nfrom the remote stream — without system loopback\nthe recording will be silent. Configure a loopback\nsource in your OS to capture stream audio too.",
+
+  "shortcuts.title":       "Keyboard shortcuts",
+  "shortcuts.f11":         "Toggle fullscreen",
+  "shortcuts.f12":         "Toggle UI",
+  "shortcuts.dismiss_hint": "Hide via View → Keyboard shortcuts",
 
   "overlay.connecting":    "Connecting...",
   "overlay.reconnecting":  "Reconnecting...",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -12,6 +12,7 @@
   "menu.configurations.audio":      "Audio",
   "menu.view":              "View",
   "menu.view.toggleui":     "Toggle UI",
+  "menu.view.quickactions": "Quick actions",
   "menu.view.info":         "Info",
   "menu.view.capturepresets": "Capture Presets",
   "menu.view.recordings":   "Recordings",
@@ -230,6 +231,12 @@
   "browse.report_sent.quote_hint": "Quote this if you contact the maintainer.",
   "browse.report_sent.no_protocol": "The directory service did not return a protocol number for this report. The report itself was accepted.",
   "browse.report_sent.close": "Close",
+
+  "quickactions.title":    "Quick actions",
+  "quickactions.viewers":  "viewers",
+  "quickactions.disconnect": "Disconnect",
+  "quickactions.browse":   "Browse directory",
+  "quickactions.record_client.tip": "Records what's on screen (post-decode video).\nAudio is captured from the local input device, NOT\nfrom the remote stream — without system loopback\nthe recording will be silent. Configure a loopback\nsource in your OS to capture stream audio too.",
 
   "overlay.connecting":    "Connecting...",
   "overlay.reconnecting":  "Reconnecting...",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -12,6 +12,7 @@
   "menu.configurations.audio":      "Áudio",
   "menu.view":              "Visualizar",
   "menu.view.toggleui":     "Mostrar/Ocultar UI",
+  "menu.view.quickactions": "Ações rápidas",
   "menu.view.info":         "Informações",
   "menu.view.capturepresets": "Presets de Captura",
   "menu.view.recordings":   "Gravações",
@@ -230,6 +231,12 @@
   "browse.report_sent.quote_hint": "Mencione este número se entrar em contato com o mantenedor.",
   "browse.report_sent.no_protocol": "O serviço de diretório não retornou um número de protocolo para este report. O report em si foi aceito.",
   "browse.report_sent.close": "Fechar",
+
+  "quickactions.title":    "Ações rápidas",
+  "quickactions.viewers":  "espectadores",
+  "quickactions.disconnect": "Desconectar",
+  "quickactions.browse":   "Navegar diretório",
+  "quickactions.record_client.tip": "Grava o que está na tela (vídeo pós-decode).\nO áudio vem do dispositivo de entrada local, NÃO\ndo stream remoto — sem loopback do sistema a gravação\nficará muda. Configure uma fonte loopback no OS\npara capturar o áudio do stream também.",
 
   "overlay.connecting":    "Conectando...",
   "overlay.reconnecting":  "Reconectando...",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -13,6 +13,7 @@
   "menu.view":              "Visualizar",
   "menu.view.toggleui":     "Mostrar/Ocultar UI",
   "menu.view.quickactions": "Ações rápidas",
+  "menu.view.shortcuts":    "Atalhos do teclado",
   "menu.view.info":         "Informações",
   "menu.view.capturepresets": "Presets de Captura",
   "menu.view.recordings":   "Gravações",
@@ -237,6 +238,11 @@
   "quickactions.disconnect": "Desconectar",
   "quickactions.browse":   "Navegar diretório",
   "quickactions.record_client.tip": "Grava o que está na tela (vídeo pós-decode).\nO áudio vem do dispositivo de entrada local, NÃO\ndo stream remoto — sem loopback do sistema a gravação\nficará muda. Configure uma fonte loopback no OS\npara capturar o áudio do stream também.",
+
+  "shortcuts.title":       "Atalhos do teclado",
+  "shortcuts.f11":         "Alternar tela cheia",
+  "shortcuts.f12":         "Mostrar/Ocultar UI",
+  "shortcuts.dismiss_hint": "Oculte em Visualizar → Atalhos do teclado",
 
   "overlay.connecting":    "Conectando...",
   "overlay.reconnecting":  "Reconectando...",

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -20,6 +20,7 @@
 #endif
 #include "../shader/ShaderEngine.h"
 #include "../ui/UIManager.h"
+#include "../osd/QuickActionsOverlay.h"
 #include "../ui/UIRemoteConnection.h"
 #include "../ui/UICapturePresets.h"
 #include "../ui/UIRecordings.h"
@@ -189,10 +190,17 @@ bool Application::init()
 
 void Application::updateCursorVisibility()
 {
-    // Simple method to sync cursor visibility with UI visibility
+    // Keep the OS cursor visible whenever ANY interactive surface is on
+    // screen — the full UI OR an interactive OSD (#68). Hiding it while
+    // the quick-actions widget is showing would let the user click the
+    // buttons but with no visible pointer, which feels broken even when
+    // the underlying clicks register.
     if (m_ui && m_window)
     {
-        m_window->setCursorVisible(m_ui->isVisible());
+        const bool osdInteractive =
+            m_ui->getQuickActionsOverlay() &&
+            m_ui->getQuickActionsOverlay()->isVisible();
+        m_window->setCursorVisible(m_ui->isVisible() || osdInteractive);
     }
 }
 
@@ -650,6 +658,12 @@ bool Application::initCapture()
                 // most).
                 if (snap.sourceFps > 0) m_remoteSourceFps = snap.sourceFps;
                 m_hasPendingRemoteMeta.store(true);
+                // Push the host's viewer count straight onto UIManager
+                // (#68) — the OSD quick-actions widget reads it every
+                // frame to render "watching with N others" in client
+                // mode. Bypasses the pending-snapshot apply path
+                // because there's no GL state involved.
+                if (m_ui) m_ui->setRemoteUpstreamClientCount(snap.upstreamClientCount);
             });
     }
 
@@ -2492,6 +2506,12 @@ bool Application::initUI()
                         }
                         if (snap.sourceFps > 0) m_remoteSourceFps = snap.sourceFps;
                         m_hasPendingRemoteMeta.store(true);
+                        // #68 — same upstream-client-count push the
+                        // initCapture-side callback does. Without this
+                        // copy, switching to Remote mid-session via
+                        // Browse leaves the OSD's "watching with N
+                        // others" stuck at 0 forever.
+                        if (m_ui) m_ui->setRemoteUpstreamClientCount(snap.upstreamClientCount);
                     });
             }
             else
@@ -3194,6 +3214,14 @@ void Application::run()
         // transition is needed (just compares two booleans and a few
         // strings).
         syncDirectoryClient();
+        // Cursor visibility tracks BOTH UIManager::isVisible() and the
+        // OSD overlay (#68). The setOnVisibilityChanged callback only
+        // fires on F12 toggles — toggling the quick-actions widget via
+        // View doesn't, and the desktop client mode flip doesn't either.
+        // Running this every frame keeps cursor state in sync; the
+        // window manager's own internal cache makes redundant calls
+        // free.
+        updateCursorVisibility();
 
         m_window->pollEvents();
         

--- a/src/osd/ConnectionStatusOverlay.cpp
+++ b/src/osd/ConnectionStatusOverlay.cpp
@@ -1,0 +1,135 @@
+#include "ConnectionStatusOverlay.h"
+#include "QuickActionsOverlay.h"
+#include "../ui/UIManager.h"
+#include "../utils/TranslationManager.h"
+
+#include <imgui.h>
+
+ConnectionStatusOverlay::ConnectionStatusOverlay(UIManager *uiManager,
+                                                 QuickActionsOverlay *quickActions)
+    : m_uiManager(uiManager)
+    , m_quickActions(quickActions)
+{
+}
+
+ConnectionStatusOverlay::~ConnectionStatusOverlay() = default;
+
+void ConnectionStatusOverlay::render()
+{
+    if (!m_uiManager) return;
+
+    if (m_uiManager->getSourceType() != UIManager::SourceType::Remote)
+    {
+        // Not in client mode — nothing to surface. Reset the
+        // transition tracking so a later mode switch starts fresh.
+        m_lastDevice.clear();
+        m_lastHadFrames      = false;
+        m_connectedSince     = 0.0;
+        m_disconnectingUntil = 0.0;
+        return;
+    }
+
+    const double now      = ImGui::GetTime();
+    const std::string dev = m_uiManager->getCurrentDevice();
+    // 'Has frames' means decoding right NOW — capture dims stick at
+    // the last seen value forever after a drop, so the dedicated
+    // VideoCaptureRemote::isReceivingFrames mirror is the only
+    // honest liveness signal.
+    const bool hasFrames  = m_uiManager->getRemoteReceivingFrames();
+    const bool offline    = m_uiManager->getRemoteHostLikelyOffline();
+
+    // Disconnect tail — when the user clears the device, hold the
+    // "Disconnecting…" label for a short window so the detached
+    // teardown has visible feedback.
+    if (!m_lastDevice.empty() && dev.empty())
+    {
+        m_disconnectingUntil = now + 1.5;
+    }
+
+    // First-frame-arrived edge → arm the "Connected" flash.
+    if (!m_lastHadFrames && hasFrames && !dev.empty())
+    {
+        m_connectedSince = now;
+    }
+    if (!hasFrames)
+    {
+        m_connectedSince = 0.0;
+    }
+
+    std::string label;
+    ImVec4      color    = ImVec4(0.95f, 0.7f, 0.3f, 1.0f); // orange default
+    bool        spinning = false;
+
+    if (now < m_disconnectingUntil)
+    {
+        label    = T("overlay.disconnecting");
+        spinning = true;
+    }
+    else if (dev.empty())
+    {
+        // No URL armed and past the disconnect tail — nothing to say.
+    }
+    else if (offline)
+    {
+        label    = T("overlay.host_offline");
+        spinning = true;
+    }
+    else if (!hasFrames)
+    {
+        label    = m_lastHadFrames ? T("overlay.reconnecting")
+                                   : T("overlay.connecting");
+        spinning = true;
+    }
+    else if (m_connectedSince > 0.0 && now - m_connectedSince < 3.0)
+    {
+        label    = T("overlay.connected");
+        color    = ImVec4(0.40f, 0.80f, 0.40f, 1.0f);
+        spinning = false;
+    }
+
+    // Update tracking before the early-return so transitions
+    // detected this frame land in next frame's state.
+    m_lastDevice    = dev;
+    m_lastHadFrames = hasFrames;
+
+    if (label.empty()) return;
+
+    // Shared bottom-right corner with QuickActionsOverlay (#68). When
+    // the widget is on screen, query its rendered height and push
+    // ourselves up by that + a small gap. No magic numbers — the
+    // overlay grows/shrinks if the widget's content changes.
+    const ImGuiViewport *vp = ImGui::GetMainViewport();
+    float bottomReserved = 16.0f;
+    if (m_quickActions && m_quickActions->isVisible())
+    {
+        const float widgetH = m_quickActions->renderedHeight();
+        if (widgetH > 0.0f) bottomReserved += widgetH + 8.0f;
+    }
+    const ImVec2 anchor(vp->WorkPos.x + vp->WorkSize.x - 16.0f,
+                        vp->WorkPos.y + vp->WorkSize.y - bottomReserved);
+    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+    ImGui::SetNextWindowBgAlpha(0.85f);
+
+    const ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoDecoration       | ImGuiWindowFlags_AlwaysAutoResize |
+        ImGuiWindowFlags_NoSavedSettings    | ImGuiWindowFlags_NoFocusOnAppearing |
+        ImGuiWindowFlags_NoNav              | ImGuiWindowFlags_NoMove;
+
+    if (ImGui::Begin("##connOverlay", nullptr, flags))
+    {
+        if (spinning)
+        {
+            // 4-frame ASCII spinner at ~6 fps. ImGui doesn't ship a
+            // spinner widget; a one-char rotation is enough to signal
+            // "working" without pulling extra primitives.
+            static const char *spin = "|/-\\";
+            const int idx = static_cast<int>(now * 6.0) & 0x3;
+            ImGui::TextColored(color, "%c %s", spin[idx], label.c_str());
+        }
+        else
+        {
+            ImGui::TextColored(color, "%s", label.c_str());
+        }
+    }
+    ImGui::End();
+}

--- a/src/osd/ConnectionStatusOverlay.h
+++ b/src/osd/ConnectionStatusOverlay.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+class UIManager;
+class QuickActionsOverlay;
+
+/**
+ * Remote-stream connection status OSD.
+ *
+ * When the desktop is in client mode (Source = Remote, currentDevice
+ * non-empty), this overlay renders a small spinning label at the
+ * bottom-right of the viewport while we transition between states:
+ *
+ *   Connecting…   — armed device, no frames yet, no prior session
+ *   Reconnecting… — armed device, no frames now, had frames before
+ *   Disconnecting… — device just cleared, short tail
+ *   Connected     — flashed for ~3 s on the first frame
+ *   Host appears offline — extended reconnect failure
+ *
+ * Extracted from UIManager::renderConnectionOverlay during the OSD
+ * layering pass (#68). Reads the live state from UIManager through
+ * a small set of public getters; owns the transition-tracking state
+ * itself so UIManager doesn't have to.
+ *
+ * Stacks above QuickActionsOverlay when both are visible — queries
+ * the widget's renderedHeight() and offsets its anchor upward.
+ */
+class ConnectionStatusOverlay
+{
+public:
+    ConnectionStatusOverlay(UIManager *uiManager,
+                            QuickActionsOverlay *quickActions);
+    ~ConnectionStatusOverlay();
+
+    void render();
+
+private:
+    UIManager           *m_uiManager    = nullptr;
+    QuickActionsOverlay *m_quickActions = nullptr;
+
+    // Per-frame transition tracking. Lives here instead of on
+    // UIManager so the overlay is self-contained.
+    std::string m_lastDevice;
+    bool        m_lastHadFrames        = false;
+    double      m_connectedSince       = 0.0;
+    double      m_disconnectingUntil   = 0.0;
+};

--- a/src/osd/QuickActionsOverlay.cpp
+++ b/src/osd/QuickActionsOverlay.cpp
@@ -107,24 +107,24 @@ void QuickActionsOverlay::render()
         ImGui::Separator();
     }
 
-    // Client-mode controls (#68 follow-up). When we're consuming a
-    // remote /raw, the broadcasting controls don't apply — the user
-    // either wants to disconnect or jump back to the directory to
-    // pick a different stream. Render those as the primary actions
-    // before the recording button (which stays available — see
-    // below).
+    // Browse directory — always available so users can discover other
+    // streams without going through the Remote menu, regardless of
+    // whether they're broadcasting (host) or consuming (client).
+    if (UIDirectoryBrowser *browser = m_uiManager->getDirectoryBrowserWindow())
+    {
+        if (ImGui::Button(T("quickactions.browse").c_str(), ImVec2(-1, 0)))
+        {
+            browser->setVisible(true);
+        }
+    }
+
+    // Disconnect — client mode only (no remote URL armed → nothing to
+    // disconnect from).
     if (clientMode)
     {
         if (ImGui::Button(T("quickactions.disconnect").c_str(), ImVec2(-1, 0)))
         {
             m_uiManager->setCurrentDevice("");
-        }
-        if (UIDirectoryBrowser *browser = m_uiManager->getDirectoryBrowserWindow())
-        {
-            if (ImGui::Button(T("quickactions.browse").c_str(), ImVec2(-1, 0)))
-            {
-                browser->setVisible(true);
-            }
         }
     }
 

--- a/src/osd/QuickActionsOverlay.cpp
+++ b/src/osd/QuickActionsOverlay.cpp
@@ -1,0 +1,208 @@
+#include "QuickActionsOverlay.h"
+#include "../ui/UIManager.h"
+#include "../ui/UIDirectoryBrowser.h"
+#include "../ui/UISectionHeader.h"
+#include "../utils/TranslationManager.h"
+
+#include <imgui.h>
+
+#include <cstdio>
+
+QuickActionsOverlay::QuickActionsOverlay(UIManager *uiManager)
+    : m_uiManager(uiManager)
+{
+}
+
+QuickActionsOverlay::~QuickActionsOverlay() = default;
+
+void QuickActionsOverlay::render()
+{
+    if (!m_visible || !m_uiManager) return;
+
+    // Pinned to the bottom-right of the main viewport every frame.
+    // The connection-status overlay shares this corner — it queries
+    // renderedHeight() and shifts itself up to avoid overlap.
+    const ImGuiViewport *vp = ImGui::GetMainViewport();
+    const ImVec2 anchor(vp->WorkPos.x + vp->WorkSize.x - 16.0f,
+                        vp->WorkPos.y + vp->WorkSize.y - 16.0f);
+    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+    ImGui::SetNextWindowSize(ImVec2(240, 0), ImGuiCond_Always);
+    ImGui::SetNextWindowBgAlpha(0.92f);
+
+    // No decoration. NoSavedSettings keeps imgui.ini clean — the
+    // per-frame anchor is the only source of truth for position.
+    // NoFocusOnAppearing avoids stealing clicks from underlying
+    // capture when the overlay first paints.
+    const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+                                   ImGuiWindowFlags_NoMove |
+                                   ImGuiWindowFlags_NoResize |
+                                   ImGuiWindowFlags_NoCollapse |
+                                   ImGuiWindowFlags_NoSavedSettings |
+                                   ImGuiWindowFlags_NoFocusOnAppearing |
+                                   ImGuiWindowFlags_NoNav |
+                                   ImGuiWindowFlags_AlwaysAutoResize;
+
+    if (!ImGui::Begin("##quickActions", nullptr, flags))
+    {
+        ImGui::End();
+        return;
+    }
+
+    const bool clientMode      = m_uiManager->isRemoteSource() &&
+                                 !m_uiManager->getCurrentDevice().empty();
+    const bool streamingActive = m_uiManager->getStreamingActive();
+    const bool recordingActive = m_uiManager->getRecordingActive();
+
+    // Title — no native title bar, so a coloured label substitutes.
+    ImGui::TextColored(ImVec4(0.4f, 0.7f, 1.0f, 1.0f), "%s",
+                       T("quickactions.title").c_str());
+    ImGui::Separator();
+
+    // Status lines shown only when the matching session is active —
+    // keeps the overlay compact instead of dedicating space to
+    // greyed-out placeholders.
+    if (!clientMode && streamingActive)
+    {
+        ui_status_bullet(ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
+        ImGui::SameLine();
+        ImGui::Text("Streaming");
+        ImGui::SameLine();
+        ImGui::TextDisabled("- %u %s",
+                            m_uiManager->getStreamClientCount(),
+                            T("quickactions.viewers").c_str());
+    }
+    // In client mode, show the host's viewer count instead. Fed by
+    // RemoteMetaSync via Application — 0 means either we just
+    // connected and /meta hasn't been parsed yet, or the host is
+    // running an older build that doesn't emit streaming.clientCount.
+    if (clientMode)
+    {
+        const uint32_t upstream = m_uiManager->getRemoteUpstreamClientCount();
+        ui_status_bullet(ImVec4(0.4f, 0.7f, 1.0f, 1.0f));
+        ImGui::SameLine();
+        ImGui::Text("Watching");
+        ImGui::SameLine();
+        ImGui::TextDisabled("- %u %s", upstream, T("quickactions.viewers").c_str());
+    }
+    if (recordingActive)
+    {
+        const uint64_t durationUs = m_uiManager->getRecordingDurationUs();
+        uint64_t seconds = durationUs / 1000000;
+        uint64_t minutes = seconds / 60;
+        seconds %= 60;
+        const uint64_t hours = minutes / 60;
+        minutes %= 60;
+
+        ui_status_bullet(ImVec4(1.0f, 0.30f, 0.30f, 1.0f));
+        ImGui::SameLine();
+        ImGui::Text("Recording");
+        ImGui::SameLine();
+        ImGui::TextDisabled("- %02llu:%02llu:%02llu",
+                            static_cast<unsigned long long>(hours),
+                            static_cast<unsigned long long>(minutes),
+                            static_cast<unsigned long long>(seconds));
+    }
+    if ((!clientMode && streamingActive) || recordingActive)
+    {
+        ImGui::Separator();
+    }
+
+    // Client-mode controls (#68 follow-up). When we're consuming a
+    // remote /raw, the broadcasting controls don't apply — the user
+    // either wants to disconnect or jump back to the directory to
+    // pick a different stream. Render those as the primary actions
+    // before the recording button (which stays available — see
+    // below).
+    if (clientMode)
+    {
+        if (ImGui::Button(T("quickactions.disconnect").c_str(), ImVec2(-1, 0)))
+        {
+            m_uiManager->setCurrentDevice("");
+        }
+        if (UIDirectoryBrowser *browser = m_uiManager->getDirectoryBrowserWindow())
+        {
+            if (ImGui::Button(T("quickactions.browse").c_str(), ImVec2(-1, 0)))
+            {
+                browser->setVisible(true);
+            }
+        }
+    }
+
+    // Streaming button — mirror of UIConfigurationStreaming's
+    // renderStartStopButton (processing → active → cooldown → idle).
+    // Hidden in client mode (consuming a remote /raw — nothing
+    // local to broadcast).
+    if (!clientMode)
+    {
+        const bool processing = m_uiManager->isStreamingProcessing();
+        const int64_t cooldownMs = m_uiManager->getStreamingCooldownRemainingMs();
+        if (processing)
+        {
+            ImGui::BeginDisabled();
+            ImGui::Button(streamingActive ? "Parando..." : "Iniciando...",
+                          ImVec2(-1, 0));
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Aguarde o processo terminar");
+            }
+        }
+        else if (streamingActive)
+        {
+            if (ImGui::Button(T("streaming.stop").c_str(), ImVec2(-1, 0)))
+            {
+                m_uiManager->setStreamingProcessing(true);
+                m_uiManager->triggerStreamingStartStop(false);
+            }
+        }
+        else if (cooldownMs > 0)
+        {
+            ImGui::BeginDisabled();
+            char label[64];
+            std::snprintf(label, sizeof(label), "Aguardando (%ds)",
+                          static_cast<int>(cooldownMs / 1000));
+            ImGui::Button(label, ImVec2(-1, 0));
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Aguarde o cooldown terminar antes de iniciar o streaming novamente");
+            }
+        }
+        else
+        {
+            if (ImGui::Button(T("streaming.start").c_str(), ImVec2(-1, 0)))
+            {
+                m_uiManager->setStreamingProcessing(true);
+                m_uiManager->triggerStreamingStartStop(true);
+            }
+        }
+    }
+
+    // Recording button — UIConfigurationRecording has no cooldown
+    // wrapper, so the overlay mirrors the simpler shape. Stays
+    // available in client mode (#68) since the video pipeline is
+    // generic and records whatever's in the framebuffer; only audio
+    // has a caveat called out in the tooltip.
+    if (recordingActive)
+    {
+        if (ImGui::Button(T("recording.stop").c_str(), ImVec2(-1, 0)))
+        {
+            m_uiManager->triggerRecordingStartStop(false);
+        }
+    }
+    else
+    {
+        if (ImGui::Button(T("recording.start").c_str(), ImVec2(-1, 0)))
+        {
+            m_uiManager->triggerRecordingStartStop(true);
+        }
+        if (clientMode && ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("%s", T("quickactions.record_client.tip").c_str());
+        }
+    }
+
+    m_lastRenderedHeight = ImGui::GetWindowHeight();
+
+    ImGui::End();
+}

--- a/src/osd/QuickActionsOverlay.h
+++ b/src/osd/QuickActionsOverlay.h
@@ -1,0 +1,55 @@
+#pragma once
+
+class UIManager;
+
+/**
+ * Quick-actions OSD widget (#68).
+ *
+ * Lives in the OSD layer (`src/osd/`) — pinned to the bottom-right
+ * of the main viewport every frame, no title bar, no drag, no resize,
+ * no imgui.ini persistence. Distinguished from the UI layer
+ * (`src/ui/`) which owns interactive windows the user opens / closes /
+ * moves at will.
+ *
+ * What it surfaces:
+ *   - Start / Stop Streaming                  (mirrors UIConfigurationStreaming)
+ *   - Start / Stop Recording                  (mirrors UIConfigurationRecording)
+ *   - Connected viewers count                 (when streaming is active)
+ *   - Recording duration HH:MM:SS             (when recording is active)
+ *
+ * Re-entrancy with the full Configuration windows is guaranteed by
+ * routing every click through the same UIManager::triggerXxxStartStop
+ * paths those windows call. Reading the same processing / cooldown
+ * flags keeps the button label tracking byte-for-byte (Iniciando…,
+ * Aguardando (Ns), etc.).
+ *
+ * In client mode (consuming a remote /raw), the streaming button is
+ * hidden — there's nothing local to broadcast. Recording stays
+ * available since you can record the consumed feed locally.
+ *
+ * Visibility:
+ *   - Default on so first-time users discover it.
+ *   - Toggle via View → "Quick actions"; UIManager persists the
+ *     choice to config.json across runs.
+ */
+class QuickActionsOverlay
+{
+public:
+    QuickActionsOverlay(UIManager *uiManager);
+    ~QuickActionsOverlay();
+
+    void render();
+    void setVisible(bool visible) { m_visible = visible; }
+    bool isVisible() const        { return m_visible; }
+
+    // Height of the overlay on its last frame, used by the
+    // connection-status overlay to push itself above when both are
+    // on screen at once. Returns 0 if the overlay hasn't rendered or
+    // isn't currently visible.
+    float renderedHeight() const  { return m_lastRenderedHeight; }
+
+private:
+    UIManager *m_uiManager = nullptr;
+    bool       m_visible = true;
+    float      m_lastRenderedHeight = 0.0f;
+};

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -1108,8 +1108,13 @@ std::string APIController::buildMetaSnapshotJSON()
          <<   "\"outputHeight\": "   << jsonNumber(m_uiManager->getOutputHeight())
          << "}, "
          << "\"streaming\": {"
-         <<   "\"active\": " << jsonBool(m_uiManager->getStreamingActive()) << ", "
-         <<   "\"url\": "    << jsonString(m_uiManager->getStreamUrl())
+         <<   "\"active\": "      << jsonBool(m_uiManager->getStreamingActive())     << ", "
+         <<   "\"url\": "         << jsonString(m_uiManager->getStreamUrl())         << ", "
+         // #68 — expose the host's viewer count so a remote client
+         // can render "you're watching with N other viewers" in the
+         // OSD quick-actions widget. No security concern since
+         // browsing the directory already exposes per-stream counts.
+         <<   "\"clientCount\": " << jsonNumber(m_uiManager->getStreamClientCount())
          << "}"
          << "}";
 

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -707,7 +707,13 @@ std::string HTTPTSStreamer::getStreamUrl() const
 
 uint32_t HTTPTSStreamer::getClientCount() const
 {
-    return m_clientCount.load();
+    // Combine /stream subscribers (web portal viewers consuming
+    // MPEG-TS) and /raw subscribers (remote RetroCapture desktop
+    // clients consuming the shader-bypassed feed). Both are "people
+    // watching the host's broadcast" — surfacing only one of them
+    // makes the count under-report whenever the audience splits
+    // between the portal and remote-client viewers (#68).
+    return m_clientCount.load() + m_rawClientCount.load();
 }
 
 void HTTPTSStreamer::cleanup()

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -281,6 +281,16 @@ namespace
                 out.imageOutputWidth    = im.value("outputWidth",  0u);
                 out.imageOutputHeight   = im.value("outputHeight", 0u);
             }
+            if (j.contains("streaming") && j["streaming"].is_object())
+            {
+                // Only field we need from the streaming block in client
+                // mode is the host's current viewer count (#68 — fed to
+                // the OSD quick-actions widget). Active / url describe
+                // the host's local state which the client doesn't
+                // surface anywhere.
+                const auto &st = j["streaming"];
+                out.upstreamClientCount = st.value("clientCount", 0u);
+            }
             return true;
         }
         catch (const std::exception &e)
@@ -374,17 +384,24 @@ void RemoteMetaSync::dispatchIfChanged(const Snapshot &snap)
     const bool sourceChanged  = (snap.sourceWidth      != m_lastSourceWidth)  ||
                                 (snap.sourceHeight     != m_lastSourceHeight) ||
                                 (snap.sourceFps        != m_lastSourceFps);
+    // #68 — upstream client count also participates in the delta
+    // check. Without this, a viewer joining or leaving the host's
+    // stream never wakes the callback up (preset/hash/source all
+    // unchanged), so the OSD quick-actions widget stays frozen at
+    // whatever count was active on first connect.
+    const bool viewersChanged = (snap.upstreamClientCount != m_lastUpstreamClientCount);
 
-    if (presetChanged || hashChanged || toggleChanged || paramsChanged || sourceChanged)
+    if (presetChanged || hashChanged || toggleChanged || paramsChanged || sourceChanged || viewersChanged)
     {
         if (m_cb) m_cb(snap);
-        m_lastPreset          = snap.preset;
-        m_lastPresetHash      = snap.presetHash;
-        m_lastPipelineEnabled = snap.pipelineEnabled;
-        m_lastParamValues     = std::move(currentValues);
-        m_lastSourceWidth     = snap.sourceWidth;
-        m_lastSourceHeight    = snap.sourceHeight;
-        m_lastSourceFps       = snap.sourceFps;
+        m_lastPreset                = snap.preset;
+        m_lastPresetHash            = snap.presetHash;
+        m_lastPipelineEnabled       = snap.pipelineEnabled;
+        m_lastParamValues           = std::move(currentValues);
+        m_lastSourceWidth           = snap.sourceWidth;
+        m_lastSourceHeight          = snap.sourceHeight;
+        m_lastSourceFps             = snap.sourceFps;
+        m_lastUpstreamClientCount   = snap.upstreamClientCount;
     }
 }
 

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -55,6 +55,11 @@ public:
         bool                         imageMaintainAspect = true;
         uint32_t                     imageOutputWidth    = 0;
         uint32_t                     imageOutputHeight   = 0;
+        // streaming block — for the OSD quick-actions widget (#68) to
+        // surface "you're watching with N other viewers" in client
+        // mode. Optional; older hosts that don't send this field
+        // leave it at 0.
+        uint32_t                     upstreamClientCount = 0;
     };
 
     using SnapshotCallback = std::function<void(const Snapshot &)>;
@@ -131,4 +136,5 @@ private:
     uint32_t            m_lastSourceWidth  = 0;
     uint32_t            m_lastSourceHeight = 0;
     uint32_t            m_lastSourceFps    = 0;
+    uint32_t            m_lastUpstreamClientCount = 0;
 };

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -10,6 +10,9 @@
 #endif
 #include "UIInfoPanel.h"
 #include "UIPreferences.h"
+#include "UISectionHeader.h"
+#include "../osd/QuickActionsOverlay.h"
+#include "../osd/ConnectionStatusOverlay.h"
 #include "UICredits.h"
 #include "UIRemoteConnection.h"
 #include "UIDirectoryBrowser.h"
@@ -72,6 +75,8 @@ UIManager::~UIManager()
 #endif
     m_infoWindow.reset();
     m_preferencesWindow.reset();
+    m_connectionOverlay.reset();
+    m_quickActionsOverlay.reset();
     m_creditsWindow.reset();
     m_capturePresetsWindow.reset();
     m_recordingsWindow.reset();
@@ -159,6 +164,15 @@ bool UIManager::init(void *window)
         }
     }
 
+    // We previously tried to extend the default font's glyph range
+    // to include geometric shapes (U+25A0..U+25FF) so the `●` / `○`
+    // status bullets would render. That doesn't work: Dear ImGui's
+    // built-in Proggy Clean has no glyph DATA for any of those
+    // codepoints, so ranging them in still gets the missing-glyph
+    // fallback. The bullets are now drawn via ImDrawList primitives
+    // through ui_status_bullet() in UISectionHeader.h — same
+    // technique UIDirectoryBrowser::drawPadlockIcon uses.
+
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
 
@@ -217,6 +231,13 @@ bool UIManager::init(void *window)
 #endif
     m_infoWindow        = std::make_unique<UIInfoPanel>(this);
     m_preferencesWindow = std::make_unique<UIPreferences>(this);
+    // OSD layer (#68). Lives in src/osd/ — visual elements pinned to
+    // viewport corners with no user-movable decoration, distinct from
+    // the UI layer (src/ui/) which owns interactive windows.
+    m_quickActionsOverlay = std::make_unique<QuickActionsOverlay>(this);
+    m_quickActionsOverlay->setVisible(m_quickActionsVisible);
+    m_connectionOverlay   = std::make_unique<ConnectionStatusOverlay>(
+        this, m_quickActionsOverlay.get());
 
     m_creditsWindow = std::make_unique<UICredits>(this);
     m_capturePresetsWindow = std::make_unique<UICapturePresets>(this);
@@ -269,13 +290,20 @@ void UIManager::beginFrame()
         return;
     }
 
-    // Disable ImGui mouse input BEFORE processing events when UI is hidden
-    // This prevents ImGui from processing mouse events and controlling cursor
+    // Mouse-input gating. NoMouse blocks ImGui from interpreting any
+    // pointer activity, used to keep the cursor / clicks from leaking
+    // into a hidden UI. But the OSD layer (#68) lives outside the
+    // m_uiVisible gate — its buttons must respond to clicks even
+    // with F12 hiding the rest of the UI. So gate NoMouse on
+    // (UI hidden AND no interactive OSD on screen) rather than on
+    // UI alone, and skip the mouse-position scrub that would prevent
+    // any widget from seeing hover at all.
+    const bool osdInteractive = m_quickActionsOverlay && m_quickActionsOverlay->isVisible();
+    const bool blockMouse     = !m_uiVisible && !osdInteractive;
     ImGuiIO& io = ImGui::GetIO();
-    if (!m_uiVisible)
+    if (blockMouse)
     {
         io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
-        // Also disable mouse buttons to prevent any mouse interaction
         io.MouseDown[0] = false;
         io.MouseDown[1] = false;
         io.MouseDown[2] = false;
@@ -286,7 +314,7 @@ void UIManager::beginFrame()
     {
         io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
     }
-    
+
     // Always call NewFrame, even when UI is hidden (maintains ImGui state)
     ImGui_ImplOpenGL3_NewFrame();
 #ifdef USE_SDL2
@@ -295,14 +323,13 @@ void UIManager::beginFrame()
     ImGui_ImplGlfw_NewFrame();
 #endif
     ImGui::NewFrame();
-    
-    // CRITICAL: Ensure mouse is disabled after NewFrame
-    // ImGui backends (ImGui_ImplGlfw_NewFrame/ImGui_ImplSDL2_NewFrame) may re-enable mouse input
-    // and restore cursor visibility, so we must disable it again
-    if (!m_uiVisible)
+
+    // ImGui backends (Glfw/SDL2 NewFrame) may flip the mouse flag and
+    // pull a fresh cursor position from the OS — re-apply our gating
+    // and scrub the position only when truly blocking input.
+    if (blockMouse)
     {
         io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
-        // Also clear mouse position to prevent any mouse interaction
         io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
         io.MousePosPrev = ImVec2(-FLT_MAX, -FLT_MAX);
     }
@@ -325,10 +352,16 @@ void UIManager::endFrame()
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     
-    // Keep ImGui mouse disabled when UI is hidden
-    // This prevents ImGui from interfering with cursor visibility
+    // Mouse input gating. NoMouse blocks ImGui from interpreting
+    // clicks, which keeps the cursor from being captured by hidden
+    // windows. But the OSD layer (#68) lives outside the m_uiVisible
+    // gate — when the quick-actions overlay is on screen, its
+    // buttons must respond to clicks even with the rest of the UI
+    // hidden via F12. So gate NoMouse on (UI hidden AND no
+    // interactive OSD visible) rather than UI alone.
+    const bool osdInteractive = m_quickActionsOverlay && m_quickActionsOverlay->isVisible();
     ImGuiIO& io = ImGui::GetIO();
-    if (!m_uiVisible)
+    if (!m_uiVisible && !osdInteractive)
     {
         io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
     }
@@ -354,11 +387,14 @@ void UIManager::render()
 {
     if (!m_initialized) return;
 
-    // Connection overlay runs before the visibility gate so the user
-    // sees Connecting / Reconnecting / Disconnecting / Connected
-    // feedback even with the full UI hidden via F12. Otherwise the
-    // screen looks frozen during a reconnect with no hint that the
-    // client is still working in the background.
+    // OSD layer renders BEFORE the m_uiVisible gate (#68). By
+    // definition an OSD shows up regardless of whether the rest of
+    // the UI is hidden — the user pressing F12 to clear the screen
+    // shouldn't make the quick-actions widget or the connection
+    // status indicator vanish too. Quick actions renders first so
+    // its rendered-height is up-to-date when the connection overlay
+    // queries it for anti-collision math.
+    if (m_quickActionsOverlay) m_quickActionsOverlay->render();
     renderConnectionOverlay();
 
     if (!m_uiVisible)
@@ -411,12 +447,17 @@ void UIManager::render()
             // sense for a viewer to override.
             toggleItem(T("menu.configurations.shaders"),  m_shaderWindow.get());
             toggleItem(T("menu.configurations.image"),    m_imageWindow.get());
+            // Recording is allowed in client mode (#68) — the
+            // pipeline is generic and captures whatever the
+            // framebuffer holds, which in client mode is the
+            // decoded remote /raw. Audio has a caveat (no local
+            // loopback by default) that the OSD tooltip surfaces.
+            toggleItem(T("menu.configurations.recording"),  m_recordingWindow.get());
             if (!clientMode)
             {
                 ImGui::Separator();
                 toggleItem(T("menu.configurations.source"),     m_sourceWindow.get());
                 toggleItem(T("menu.configurations.streaming"),  m_streamingWindow.get());
-                toggleItem(T("menu.configurations.recording"),  m_recordingWindow.get());
                 toggleItem(T("menu.configurations.webportal"),  m_webPortalWindow.get());
 #ifdef __linux__
                 toggleItem(T("menu.configurations.audio"),      m_audioWindow.get());
@@ -432,6 +473,14 @@ void UIManager::render()
                 setVisible(!m_uiVisible);
             }
             ImGui::Separator();
+            if (m_quickActionsOverlay)
+            {
+                bool visible = m_quickActionsOverlay->isVisible();
+                if (ImGui::MenuItem(T("menu.view.quickactions").c_str(), nullptr, visible))
+                {
+                    m_quickActionsOverlay->setVisible(!visible);
+                }
+            }
             if (m_infoWindow)
             {
                 bool visible = m_infoWindow->isVisible();
@@ -528,7 +577,7 @@ void UIManager::render()
         // we're a remote viewer.
         if (m_sourceWindow)    m_sourceWindow->setVisible(false);
         if (m_streamingWindow) m_streamingWindow->setVisible(false);
-        if (m_recordingWindow) m_recordingWindow->setVisible(false);
+        // Recording window stays openable in client mode (#68).
         if (m_webPortalWindow) m_webPortalWindow->setVisible(false);
 #ifdef __linux__
         if (m_audioWindow)     m_audioWindow->setVisible(false);
@@ -548,6 +597,7 @@ void UIManager::render()
 #endif
     if (m_infoWindow)        m_infoWindow->render();
     if (m_preferencesWindow) m_preferencesWindow->render();
+    // m_quickActionsOverlay rendered earlier, above the m_uiVisible gate.
 
     // Renderizar janela de créditos
     if (m_creditsWindow)
@@ -1405,18 +1455,11 @@ void UIManager::renderStreamingPanel()
     ImGui::Text("HTTP MPEG-TS Streaming (audio + video)");
     ImGui::Separator();
 
-    // Status
-    ImGui::Text("Status: %s", m_streamingActive ? "Active" : "Inactive");
-    if (m_streamingActive)
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "●");
-    }
-    else
-    {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
-    }
+    // Status — bullet drawn via ui_status_indicator() in
+    // UISectionHeader.h so it goes through ImDrawList primitives
+    // instead of an untyped Unicode glyph the default font can't
+    // render.
+    ui_status_indicator(m_streamingActive, "Active", "Inactive");
 
     if (m_streamingActive && !m_streamUrl.empty())
     {
@@ -2464,6 +2507,12 @@ void UIManager::loadConfig()
             auto &prefs = config["preferences"];
             if (prefs.contains("language"))        m_language        = prefs["language"].get<std::string>();
             if (prefs.contains("startFullscreen")) m_startFullscreen = prefs["startFullscreen"].get<bool>();
+            // #68 — Quick actions widget visibility persists. Default
+            // true so users discover the widget on first launch; once
+            // they toggle it off via View, the choice survives across
+            // runs.
+            if (prefs.contains("quickActionsVisible"))
+                m_quickActionsVisible = prefs["quickActionsVisible"].get<bool>();
         }
 
         // Carregar configurações de captura
@@ -2851,6 +2900,9 @@ void UIManager::saveConfig()
         config["preferences"] = {
             {"language",        m_language},
             {"startFullscreen", m_startFullscreen},
+            {"quickActionsVisible",
+             m_quickActionsOverlay ? m_quickActionsOverlay->isVisible()
+                                  : m_quickActionsVisible},
         };
 
         // Salvar configurações de imagem
@@ -3758,117 +3810,9 @@ bool UIManager::loadStreamingProfile(const std::string &name)
 // ─────────────────────────────────────────────────────────────────────
 void UIManager::renderConnectionOverlay()
 {
-    if (m_sourceType != SourceType::Remote)
-    {
-        // Not in client mode — nothing to surface. Also clear the
-        // tracking state so a later mode switch starts fresh.
-        m_overlayLastDevice.clear();
-        m_overlayLastHadFrames = false;
-        m_overlayConnectedSince     = 0.0;
-        m_overlayDisconnectingUntil = 0.0;
-        return;
-    }
-
-    const double now      = ImGui::GetTime();
-    const std::string dev = m_currentDevice;
-    // 'Has frames' means decoding right NOW — not 'has ever had
-    // frames'. captureWidth/Height stay at the last seen value
-    // forever after the stream drops, so they're a "we know the
-    // resolution" signal, not a liveness one. Use the mirrored
-    // VideoCaptureRemote::isReceivingFrames() flag instead, which
-    // flips back to false the moment the decode loop loses the
-    // connection.
-    const bool hasFrames  = m_remoteReceivingFrames;
-    const bool offline    = m_remoteHostLikelyOffline;
-
-    // Detect 'device just became empty' — that's the disconnect
-    // transition. We arm a short window so the overlay can render
-    // "Disconnecting..." while the detached teardown runs.
-    if (!m_overlayLastDevice.empty() && dev.empty())
-    {
-        m_overlayDisconnectingUntil = now + 1.5;
-    }
-
-    // Track first-frame-arrived to drive the "Connected" flash.
-    if (!m_overlayLastHadFrames && hasFrames && !dev.empty())
-    {
-        m_overlayConnectedSince = now;
-    }
-    if (!hasFrames)
-    {
-        m_overlayConnectedSince = 0.0;
-    }
-
-    // Decide what to render.
-    std::string label;
-    ImVec4      color    = ImVec4(0.95f, 0.7f, 0.3f, 1.0f); // orange default
-    bool        spinning = false;
-
-    if (now < m_overlayDisconnectingUntil)
-    {
-        label    = T("overlay.disconnecting");
-        spinning = true;
-    }
-    else if (dev.empty())
-    {
-        // No URL armed and we're past the disconnect tail — nothing
-        // to say.
-    }
-    else if (offline)
-    {
-        label    = T("overlay.host_offline");
-        spinning = true;
-    }
-    else if (!hasFrames)
-    {
-        label    = m_overlayLastHadFrames ? T("overlay.reconnecting")
-                                          : T("overlay.connecting");
-        spinning = true;
-    }
-    else if (m_overlayConnectedSince > 0.0 && now - m_overlayConnectedSince < 3.0)
-    {
-        label    = T("overlay.connected");
-        color    = ImVec4(0.40f, 0.80f, 0.40f, 1.0f);
-        spinning = false;
-    }
-
-    // Always update the tracking BEFORE the early-return so transitions
-    // we detect this frame land in next frame's state.
-    m_overlayLastDevice    = dev;
-    m_overlayLastHadFrames = hasFrames;
-
-    if (label.empty()) return;
-
-    // Bottom-right anchor. SetNextWindowPos with pivot (1,1) puts
-    // the window's bottom-right corner at the screen point we pass.
-    // Padding of 16 px so it doesn't kiss the screen edges.
-    const ImGuiViewport *vp = ImGui::GetMainViewport();
-    const ImVec2 anchor(vp->WorkPos.x + vp->WorkSize.x - 16.0f,
-                        vp->WorkPos.y + vp->WorkSize.y - 16.0f);
-    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 1.0f));
-    ImGui::SetNextWindowBgAlpha(0.85f);
-
-    const ImGuiWindowFlags flags =
-        ImGuiWindowFlags_NoDecoration       | ImGuiWindowFlags_AlwaysAutoResize |
-        ImGuiWindowFlags_NoSavedSettings    | ImGuiWindowFlags_NoFocusOnAppearing |
-        ImGuiWindowFlags_NoNav              | ImGuiWindowFlags_NoMove;
-
-    if (ImGui::Begin("##connOverlay", nullptr, flags))
-    {
-        if (spinning)
-        {
-            // Simple ASCII spinner — 4-frame cycle, ~6 fps. ImGui
-            // doesn't ship a spinner widget but a one-char rotation
-            // is enough to signal "working" without pulling extra
-            // primitives.
-            static const char *spin = "|/-\\";
-            const int idx = static_cast<int>(now * 6.0) & 0x3;
-            ImGui::TextColored(color, "%c %s", spin[idx], label.c_str());
-        }
-        else
-        {
-            ImGui::TextColored(color, "%s", label.c_str());
-        }
-    }
-    ImGui::End();
+    // Delegates to osd::ConnectionStatusOverlay since the OSD layer
+    // pass in #68. UIManager keeps this thin entry point so existing
+    // callers (Application's render path) don't need to learn about
+    // the new location.
+    if (m_connectionOverlay) m_connectionOverlay->render();
 }

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -11,6 +11,7 @@
 #include "UIInfoPanel.h"
 #include "UIPreferences.h"
 #include "UISectionHeader.h"
+#include "UIShortcutsHelp.h"
 #include "../osd/QuickActionsOverlay.h"
 #include "../osd/ConnectionStatusOverlay.h"
 #include "UICredits.h"
@@ -75,6 +76,7 @@ UIManager::~UIManager()
 #endif
     m_infoWindow.reset();
     m_preferencesWindow.reset();
+    m_shortcutsHelpWindow.reset();
     m_connectionOverlay.reset();
     m_quickActionsOverlay.reset();
     m_creditsWindow.reset();
@@ -238,6 +240,10 @@ bool UIManager::init(void *window)
     m_quickActionsOverlay->setVisible(m_quickActionsVisible);
     m_connectionOverlay   = std::make_unique<ConnectionStatusOverlay>(
         this, m_quickActionsOverlay.get());
+    // Shortcuts orientation widget — UI layer, top-right corner,
+    // F12-gated unlike the OSD.
+    m_shortcutsHelpWindow = std::make_unique<UIShortcutsHelp>(this);
+    m_shortcutsHelpWindow->setVisible(m_shortcutsHelpVisible);
 
     m_creditsWindow = std::make_unique<UICredits>(this);
     m_capturePresetsWindow = std::make_unique<UICapturePresets>(this);
@@ -481,6 +487,14 @@ void UIManager::render()
                     m_quickActionsOverlay->setVisible(!visible);
                 }
             }
+            if (m_shortcutsHelpWindow)
+            {
+                bool visible = m_shortcutsHelpWindow->isVisible();
+                if (ImGui::MenuItem(T("menu.view.shortcuts").c_str(), nullptr, visible))
+                {
+                    m_shortcutsHelpWindow->setVisible(!visible);
+                }
+            }
             if (m_infoWindow)
             {
                 bool visible = m_infoWindow->isVisible();
@@ -597,6 +611,7 @@ void UIManager::render()
 #endif
     if (m_infoWindow)        m_infoWindow->render();
     if (m_preferencesWindow) m_preferencesWindow->render();
+    if (m_shortcutsHelpWindow) m_shortcutsHelpWindow->render();
     // m_quickActionsOverlay rendered earlier, above the m_uiVisible gate.
 
     // Renderizar janela de créditos
@@ -2513,6 +2528,8 @@ void UIManager::loadConfig()
             // runs.
             if (prefs.contains("quickActionsVisible"))
                 m_quickActionsVisible = prefs["quickActionsVisible"].get<bool>();
+            if (prefs.contains("shortcutsHelpVisible"))
+                m_shortcutsHelpVisible = prefs["shortcutsHelpVisible"].get<bool>();
         }
 
         // Carregar configurações de captura
@@ -2903,6 +2920,9 @@ void UIManager::saveConfig()
             {"quickActionsVisible",
              m_quickActionsOverlay ? m_quickActionsOverlay->isVisible()
                                   : m_quickActionsVisible},
+            {"shortcutsHelpVisible",
+             m_shortcutsHelpWindow ? m_shortcutsHelpWindow->isVisible()
+                                   : m_shortcutsHelpVisible},
         };
 
         // Salvar configurações de imagem

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -27,6 +27,7 @@ class UIConfigurationRecording;
 class UIConfigurationWebPortal;
 class UIConfigurationAudio;
 class UIInfoPanel;
+class QuickActionsOverlay;
 class UIPreferences;
 class UICredits;
 class UIRemoteConnection;
@@ -54,7 +55,8 @@ public:
     /// state transitions (Connecting / Reconnecting / Disconnecting
     /// / Connected). Rendered before render()'s F12-visibility gate
     /// so the user sees connection feedback even with the rest of
-    /// the IMGUI surface hidden.
+    /// the IMGUI surface hidden. Delegates to
+    /// osd::ConnectionStatusOverlay since #68.
     void renderConnectionOverlay();
 
     // Callbacks para interação
@@ -452,6 +454,13 @@ public:
     // VideoCaptureRemote::isReceivingFrames() every frame.
     bool getRemoteReceivingFrames() const { return m_remoteReceivingFrames; }
     void setRemoteReceivingFrames(bool v) { m_remoteReceivingFrames = v; }
+
+    // Host's current viewer count, parsed from /meta when we're in
+    // client mode (#68). Application piggybacks the
+    // RemoteMetaSync::Snapshot callback to keep this fresh. 0 when
+    // we're not a client or the host's /meta predates this field.
+    uint32_t getRemoteUpstreamClientCount() const { return m_remoteUpstreamClientCount; }
+    void setRemoteUpstreamClientCount(uint32_t v) { m_remoteUpstreamClientCount = v; }
     float getSourceOverscanPercentX() const { return m_sourceOverscanPercentX; }
     float getSourceOverscanPercentY() const { return m_sourceOverscanPercentY; }
     bool getSourceOverscanLocked() const { return m_sourceOverscanLocked; }
@@ -522,6 +531,9 @@ public:
     // decide whether to show Connect or Disconnect.
     UIRemoteConnection *getRemoteConnectionWindow() const { return m_remoteConnectionWindow.get(); }
     UIDirectoryBrowser *getDirectoryBrowserWindow() const { return m_directoryBrowserWindow.get(); }
+    // OSD layer accessor — Application needs it to gate cursor
+    // visibility on whether an interactive overlay is on screen (#68).
+    QuickActionsOverlay *getQuickActionsOverlay() const { return m_quickActionsOverlay.get(); }
     void setOnStreamingMaxVideoBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxVideoBufferSizeChanged = callback; }
     void setOnStreamingMaxAudioBufferSizeChanged(std::function<void(size_t)> callback) { m_onStreamingMaxAudioBufferSizeChanged = callback; }
     void setOnStreamingMaxBufferTimeSecondsChanged(std::function<void(int64_t)> callback) { m_onStreamingMaxBufferTimeSecondsChanged = callback; }
@@ -837,6 +849,16 @@ private:
 #endif
     std::unique_ptr<class UIInfoPanel>              m_infoWindow;
     std::unique_ptr<class UIPreferences>            m_preferencesWindow;
+    // OSD layer (#68) — lives in src/osd/, owned by UIManager since
+    // it has the only natural place to hand them lifetime + state
+    // accessors.
+    std::unique_ptr<class QuickActionsOverlay>      m_quickActionsOverlay;
+    std::unique_ptr<class ConnectionStatusOverlay>  m_connectionOverlay;
+    // Loaded from config.json before m_quickActionsOverlay exists,
+    // applied via setVisible() right after construction. Defaults to
+    // true so first-time users see the overlay; subsequent toggles
+    // round-trip through saveConfig().
+    bool m_quickActionsVisible = true;
 
     std::unique_ptr<class UICredits> m_creditsWindow;
     std::unique_ptr<class UICapturePresets> m_capturePresetsWindow;
@@ -922,15 +944,10 @@ private:
     uint32_t m_captureFps = 0;
     bool     m_remoteHostLikelyOffline = false;
     bool     m_remoteReceivingFrames   = false;
+    uint32_t m_remoteUpstreamClientCount = 0;
     // Connection-overlay frame-to-frame tracking. We detect
-    // transitions (e.g. currentDevice just became empty -> show
-    // "Disconnecting...") by comparing this frame's state with last
-    // frame's. Held in member fields rather than statics so the data
-    // is reset alongside UIManager.
-    std::string m_overlayLastDevice;
-    bool        m_overlayLastHadFrames = false;
-    double      m_overlayConnectedSince = 0.0;     // ImGui::GetTime()
-    double      m_overlayDisconnectingUntil = 0.0; // disconnect feedback decays at this time
+    // Connection-overlay transition tracking moved to
+    // osd::ConnectionStatusOverlay during the OSD layer pass (#68).
     // Overscan: crop % das bordas do source antes do downscale.
     // X horizontal, Y vertical. Locked espelha um no outro.
     float m_sourceOverscanPercentX = 0.0f;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -849,6 +849,7 @@ private:
 #endif
     std::unique_ptr<class UIInfoPanel>              m_infoWindow;
     std::unique_ptr<class UIPreferences>            m_preferencesWindow;
+    std::unique_ptr<class UIShortcutsHelp>          m_shortcutsHelpWindow;
     // OSD layer (#68) — lives in src/osd/, owned by UIManager since
     // it has the only natural place to hand them lifetime + state
     // accessors.
@@ -859,6 +860,10 @@ private:
     // true so first-time users see the overlay; subsequent toggles
     // round-trip through saveConfig().
     bool m_quickActionsVisible = true;
+    // Same persistence pattern for the shortcuts-help orientation
+    // widget (#68 follow-up). Default true so new users see the
+    // keyboard hints on first launch.
+    bool m_shortcutsHelpVisible = true;
 
     std::unique_ptr<class UICredits> m_creditsWindow;
     std::unique_ptr<class UICapturePresets> m_capturePresetsWindow;

--- a/src/ui/UISectionHeader.h
+++ b/src/ui/UISectionHeader.h
@@ -48,10 +48,41 @@ inline void ui_section_header(const char *title, const char *blurb = nullptr)
 }
 
 /**
- * Inline status indicator used inside renderXxxStatus() blocks. A
- * coloured filled bullet next to a "Status: ..." line at the top of
- * the window. Same colour conventions everywhere: green = active /
- * healthy, red = stopped / inactive, grey = unavailable / disabled.
+ * Coloured status bullet drawn via ImDrawList primitives.
+ *
+ * Why not a text glyph: Dear ImGui's built-in Proggy Clean font
+ * ships only ASCII + Latin-1 glyph data, so `●` (U+25CF) renders
+ * as the missing-glyph fallback ('?') even if we extend the font's
+ * glyph range. Drawing a filled circle directly through the
+ * window draw list sidesteps the font question entirely and gives
+ * us colour control besides.
+ *
+ * Reserves layout space equal to one text line tall, so callers
+ * can `SameLine()` after it just like they would after a real
+ * `ImGui::Text("●")`.
+ */
+inline void ui_status_bullet(const ImVec4 &color)
+{
+    const float lineH  = ImGui::GetTextLineHeight();
+    const float radius = lineH * 0.32f;
+    const ImVec2 cursor = ImGui::GetCursorScreenPos();
+    const ImVec2 center(cursor.x + radius, cursor.y + lineH * 0.5f);
+
+    ImDrawList *dl = ImGui::GetWindowDrawList();
+    dl->AddCircleFilled(center, radius,
+                        ImGui::ColorConvertFloat4ToU32(color), 16);
+
+    // Reserve layout space — diameter wide, one line tall. The
+    // tiny extra padding on the right (4 px) prevents the next
+    // SameLine'd widget from touching the circle.
+    ImGui::Dummy(ImVec2(radius * 2.0f + 4.0f, lineH));
+}
+
+/**
+ * Inline status indicator used inside renderXxxStatus() blocks.
+ * Renders as `Status: <label> <bullet>` where the bullet's colour
+ * follows the active flag. Green = active / healthy, red = stopped
+ * / inactive — same convention as the connection-status overlay.
  *
  * Usage:
  *   ui_section_header("Video Recording");
@@ -61,12 +92,6 @@ inline void ui_status_indicator(bool active, const char *activeLabel, const char
 {
     ImGui::Text("Status: %s", active ? activeLabel : inactiveLabel);
     ImGui::SameLine();
-    if (active)
-    {
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "●");
-    }
-    else
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "●");
-    }
+    ui_status_bullet(active ? ImVec4(0.0f, 1.0f, 0.0f, 1.0f)
+                            : ImVec4(1.0f, 0.0f, 0.0f, 1.0f));
 }

--- a/src/ui/UIShortcutsHelp.cpp
+++ b/src/ui/UIShortcutsHelp.cpp
@@ -1,0 +1,63 @@
+#include "UIShortcutsHelp.h"
+#include "UIManager.h"
+#include "../utils/TranslationManager.h"
+
+#include <imgui.h>
+
+UIShortcutsHelp::UIShortcutsHelp(UIManager *uiManager)
+    : m_uiManager(uiManager)
+{
+}
+
+UIShortcutsHelp::~UIShortcutsHelp() = default;
+
+void UIShortcutsHelp::render()
+{
+    if (!m_visible || !m_uiManager) return;
+
+    // Pinned to top-right every frame. ImGuiCond_Always + pivot (1,0)
+    // anchors the top-right corner of the window to the viewport's
+    // top-right padded by 16 px.
+    const ImGuiViewport *vp = ImGui::GetMainViewport();
+    const ImVec2 anchor(vp->WorkPos.x + vp->WorkSize.x - 16.0f,
+                        vp->WorkPos.y + 16.0f);
+    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowBgAlpha(0.85f);
+
+    const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+                                   ImGuiWindowFlags_NoMove |
+                                   ImGuiWindowFlags_NoResize |
+                                   ImGuiWindowFlags_NoCollapse |
+                                   ImGuiWindowFlags_NoSavedSettings |
+                                   ImGuiWindowFlags_NoFocusOnAppearing |
+                                   ImGuiWindowFlags_NoNav |
+                                   ImGuiWindowFlags_AlwaysAutoResize;
+
+    if (!ImGui::Begin("##shortcutsHelp", nullptr, flags))
+    {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::TextColored(ImVec4(0.4f, 0.7f, 1.0f, 1.0f), "%s",
+                       T("shortcuts.title").c_str());
+    ImGui::Separator();
+
+    // Two-column layout: shortcut key on the left, description on
+    // the right. Using ImGui::Text + SameLine instead of a Table
+    // because the table widget pulls in scroll/sort scaffolding we
+    // don't need for a five-item card.
+    auto row = [](const char *key, const char *desc) {
+        ImGui::TextColored(ImVec4(0.95f, 0.85f, 0.4f, 1.0f), "%s", key);
+        ImGui::SameLine(80.0f);
+        ImGui::TextDisabled("%s", desc);
+    };
+
+    row("F11", T("shortcuts.f11").c_str());
+    row("F12", T("shortcuts.f12").c_str());
+
+    ImGui::Spacing();
+    ImGui::TextDisabled("%s", T("shortcuts.dismiss_hint").c_str());
+
+    ImGui::End();
+}

--- a/src/ui/UIShortcutsHelp.h
+++ b/src/ui/UIShortcutsHelp.h
@@ -1,0 +1,36 @@
+#pragma once
+
+class UIManager;
+
+/**
+ * Keyboard-shortcuts orientation widget (#68 follow-up).
+ *
+ * Lives in the UI layer (`src/ui/`) — visibility tracks F12 like
+ * every other interactive window, NOT the OSD layer. The intent is
+ * a discoverability nudge for new users, not a permanent HUD:
+ * when the user presses F12 to clear the screen, the shortcuts
+ * hint goes away with the rest of the UI.
+ *
+ * Pinned to the top-right corner of the viewport every frame so it
+ * doesn't compete with the bottom-right OSD overlays
+ * (QuickActionsOverlay + ConnectionStatusOverlay). No drag, no
+ * resize, no decoration — close it via View → Shortcuts when
+ * you've memorised the list.
+ *
+ * Visibility persists across runs via UIManager + config.json so the
+ * user only has to dismiss it once.
+ */
+class UIShortcutsHelp
+{
+public:
+    UIShortcutsHelp(UIManager *uiManager);
+    ~UIShortcutsHelp();
+
+    void render();
+    void setVisible(bool visible) { m_visible = visible; }
+    bool isVisible() const        { return m_visible; }
+
+private:
+    UIManager *m_uiManager = nullptr;
+    bool       m_visible = true;
+};


### PR DESCRIPTION
Closes #68 — persistent quick-action widget for stream/record + client count.

The PR grew along the way to also pull a clean **OSD layer split** out of `UIManager`, fix several user-visible bugs the new widget surfaced (combined viewer count, missing glyphs, hover unresponsive when UI hidden), and add a small **keyboard-shortcuts orientation widget** on the opposite corner.

## What's in the box

### `src/osd/` — new OSD layer
Two distinct visual layers now live in separate directories:

- **`src/ui/`** — interactive windows the user opens, closes, moves, and resizes at will. Title bars, decoration, `imgui.ini` persistence.
- **`src/osd/`** — overlays pinned to viewport corners every frame. No title bar, no drag, no resize, no `imgui.ini` entries. Position is decided by the app, not the user.

Two OSD members today:
- **`QuickActionsOverlay`** (bottom-right): the widget #68 actually asked for.
- **`ConnectionStatusOverlay`** (bottom-right, stacks above the widget when both visible): extracted from `UIManager::renderConnectionOverlay` — ~130 lines + 4 tracking fields moved out of `UIManager` into its own class.

### `QuickActionsOverlay` — the actual widget
Pinned bottom-right, always-on by default. Surfaces:

- **Host mode**: Start/Stop Streaming (mirrors the full `renderStartStopButton` state machine — processing → active → cooldown → idle, with the same `Iniciando…` / `Aguardando (Ns)` labels), Start/Stop Recording, **Browse directory** (always available so users can discover other streams while broadcasting), `● Streaming · N viewers`, `● Recording HH:MM:SS`.
- **Client mode**: hides the Streaming button (nothing local to broadcast), surfaces **Disconnect** + **Browse directory**, keeps Recording with a tooltip explaining the audio-loopback caveat, shows `● Watching · N viewers` fed from the host's `/meta`.

Re-entrancy with `Configurations → Streaming` / `Recording` guaranteed: every click routes through the same `UIManager::triggerXxxStartStop` paths those windows call.

### Recording unblocked in client mode
The video pipeline records whatever's in the framebuffer regardless of source, and recording a remote stream is a legitimate use case. `Configurations → Recording` is now reachable while a Remote source is active. Audio caveat (no local loopback by default → silent recording) surfaces as a tooltip on the OSD's Record button.

### Combined viewer count (`/stream` + `/raw`)
`HTTPTSStreamer::getClientCount()` now returns `m_clientCount + m_rawClientCount`. /raw listeners (remote desktop clients consuming the shader-bypassed feed) are equally "people watching this host's broadcast" — the old behaviour under-reported whenever the audience split between the web portal and remote clients. Propagates automatically to the Configuration → Streaming label, the OSD widget, `/api/v1/status`, and the directory ad.

### Upstream viewer count via `/meta`
`/meta` now emits `streaming.clientCount`, `RemoteMetaSync::parseSnapshotJSON` parses it and stores it on the `Snapshot`, the snapshot delta dedup considers a viewers-changed delta alongside preset/source changes (so a join/leave wakes the callback up — previously the count froze on first connect), and `Application` pushes the value to `UIManager` from both the `initCapture`-time `RemoteMetaSync` AND the mid-session `RemoteMetaSync` that's spawned when the user picks a stream via Browse. Older hosts that don't emit the field degrade silently to 0.

### Cursor + input gating fix
NoMouse / cursor visibility were previously gated on `m_uiVisible` alone, so when F12 hid the UI the OSD widget rendered but hover/clicks were dead. Now gated on `(UI hidden AND no interactive OSD on screen)`. `updateCursorVisibility()` runs per-frame so OSD-visibility changes propagate even when the F12 callback didn't fire. Mouse-position scrub only happens when truly blocking input, not when only the UI is hidden.

### Status bullets via `ImDrawList`
Dear ImGui's built-in Proggy Clean font ships glyph data only for ASCII + Latin-1. Status indicators using `●` (U+25CF) were rendering as the missing-glyph fallback `?` across the app. New `ui_status_bullet(ImVec4)` helper in `UISectionHeader.h` paints a filled circle through `ImDrawList::AddCircleFilled` and reserves layout space equal to one text line — same technique `UIDirectoryBrowser` already used for its padlock icon. `ui_status_indicator()` and all in-app `●` call sites swapped over.

### `UIShortcutsHelp` — keyboard-shortcuts orientation card
Small fixed card at the top-right of the viewport listing F11 / F12 so new users discover the keys without trawling menus. Lives in the UI layer — F12-gated like every other interactive surface, distinct from the bottom-right OSD overlays.

Toggle via **View → Keyboard shortcuts**; visibility persists across runs in `preferences.shortcutsHelpVisible`. Default on so first-time users see the hints.

## Build status
Cross-compiled clean on both:
- `./tools/build-linux-x86_64-docker.sh`
- `./tools/build-windows-x86_64-docker.sh`

## Test plan
- [x] Launch app, confirm Quick Actions widget appears bottom-right and Keyboard shortcuts card appears top-right
- [x] Press F12 — both visible elements stay on screen (UI menu / Configuration windows hide); cursor remains visible over the OSD; hover effect works on the OSD buttons; Start/Stop Streaming / Recording fire from the OSD with UI hidden
- [x] Toggle View → Quick actions off; press F12; confirm cursor hides this time (no interactive OSD on screen)
- [x] Start streaming; connect a remote desktop client via Browse on a second machine — host's "Streaming · N viewers" count goes up, the remote client's "Watching · N viewers" count matches
- [x] Connect from a portal browser too — count adds /stream and /raw subscribers together
- [x] Have the second machine disconnect — counts go back down on both sides (dedup fix)
- [x] Start recording in client mode — tooltip on the OSD Record button explains audio caveat; video file plays back; audio is silent unless a loopback is configured
- [x] Toggle View → Keyboard shortcuts off, restart app, confirm the card stays hidden
- [x] Restart the app, confirm Quick Actions visibility also persists

## Follow-ups (separate issues)

Opened during this PR's development:
- **#69** — TLS in `HttpClient` (HTTPS for directory + remote /raw). Default flip to `https://directory.retrocapture.com` parked behind it.
- **#70** — Named Cloudflare Tunnel management: pick existing, delete, no DNS sprawl.
- **#71** — Interface picker for Direct endpoint mode (multi-homed host chooses which IPv4 to advertise).

Out of scope intentionally on this PR.