### PR TITLE
fix(stream): drift / probe / orientation / disconnect fixes for /raw + /stream (refs #67)

### DIFF
--- a/src/audio/AudioPlaybackPulse.cpp
+++ b/src/audio/AudioPlaybackPulse.cpp
@@ -84,10 +84,18 @@ void AudioPlaybackPulse::close()
     std::unique_lock<std::shared_mutex> lock(m_streamMutex);
     if (m_stream)
     {
-        // Best-effort drain so the user doesn't hear a click on
-        // disconnect. Ignored on error — we're tearing down anyway.
+        // Flush, don't drain. The earlier code used pa_simple_drain()
+        // "so the user doesn't hear a click on disconnect" — but drain
+        // blocks until every queued sample is played out, and during
+        // a reconnect storm the queue can carry multiple seconds of
+        // pending audio. The user heard the disconnected stream
+        // continue playing for that whole interval (#67 — "depois q
+        // me desconecto o audio continua rodando"). A flush discards
+        // the buffer immediately at the cost of a brief click on a
+        // graceful disconnect, which is the lesser evil by a wide
+        // margin.
         int err = 0;
-        pa_simple_drain(m_stream, &err);
+        pa_simple_flush(m_stream, &err);
         pa_simple_free(m_stream);
         m_stream = nullptr;
     }

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -106,13 +106,22 @@ bool VideoCaptureRemote::initDecoder()
     // the decode loop starts. Too generous a probe means the decoder
     // chews through that buffer at non-real-time rates ('decoded=83/s'
     // catch-up the user observed) and the queue fills before the
-    // wall-clock-driven consumer can drain it. 256 KB at ~3 Mbit/s
-    // is ~0.7 s of stream — plenty for the second audio packet (AAC
-    // packets arrive every ~23 ms) but small enough that the catch-up
-    // settles in a couple of frames.
+    // wall-clock-driven consumer can drain it.
+    //
+    // 512 KB / 2.5 s is the smallest window that reliably catches the
+    // AAC ADTS codec config on a mid-join (#67). The earlier 256 KB /
+    // 1 s budget was hitting the 'Audio: aac, 0 channels: unspecified
+    // sample format' probe race: when a fresh client lands inside an
+    // MPEG-TS pack that doesn't carry the next PMT inside the first
+    // ~700 ms of stream, avformat_find_stream_info gives up before
+    // seeing enough AAC frames to determine channels/format. The
+    // larger budget guarantees at least one full PAT/PMT cycle plus
+    // several AAC packets, which is enough to populate codecpar
+    // reliably; the extra ~1 s of catch-up is absorbed by the queue's
+    // drop-oldest policy already exercised on every reconnect.
     AVDictionary *opts = nullptr;
-    av_dict_set(&opts, "probesize",       "262144",  0); // 256 KB
-    av_dict_set(&opts, "analyzeduration", "1000000", 0); // 1 s
+    av_dict_set(&opts, "probesize",       "524288",  0); // 512 KB
+    av_dict_set(&opts, "analyzeduration", "2500000", 0); // 2.5 s
     // Note: deliberately NOT setting "fflags: nobuffer" here — without
     // FFmpeg's internal packet buffer, av_read_frame returns whatever the
     // socket has *right now*, which on a bursty TCP stream means several

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -889,23 +889,12 @@ void VideoCaptureRemote::decodeLoop()
                 rgbBuf.assign(static_cast<size_t>(dstW) * static_cast<size_t>(dstH) * 3, 0);
             }
 
-            // Top-down orientation matches what the rest of the capture
-            // pipeline produces:
-            //   - V4L2: FrameProcessor::convertYUYVtoRGB uses a positive
-            //     sws stride, so the local YUYV→RGB output is top-down.
-            //   - DirectShow: VideoCaptureDS emits RGB24 frames top-down.
-            //
-            // Earlier code here negated the dst stride to write the
-            // buffer bottom-up "to match V4L2", which was based on a
-            // wrong reading of the local path. The result was the
-            // /raw client showing the picture flipped vertically once
-            // the shader pipeline on the client was bypassed — the
-            // shader implicitly compensated, so the bug only surfaced
-            // after #67's "/raw works with shader off" fix exposed the
-            // no-shader rendering path on remote sources. See the user
-            // report on #67.
-            uint8_t *dstSlices[1] = { rgbBuf.data() };
-            int dstStrides[1]     = { static_cast<int>(dstW) * 3 };
+            // Write rows in reverse (bottom-up) so the resulting RGB buffer
+            // matches the orientation the rest of the capture pipeline
+            // expects from V4L2 / DirectShow sources — without this, the
+            // image renders upside-down on screen.
+            uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(dstH - 1) * static_cast<size_t>(dstW) * 3 };
+            int dstStrides[1]     = { -(dstW * 3) };
             sws_scale(m_swsCtx, frame->data, frame->linesize, 0, srcH, dstSlices, dstStrides);
 
             // Capture the frame's PTS in stream timebase units BEFORE

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -768,17 +768,28 @@ void VideoCaptureRemote::decodeLoop()
                     uint8_t *outPlanes[1] = { reinterpret_cast<uint8_t *>(m_audioScratch.data()) };
                     const int produced = swr_convert(m_swrCtx, outPlanes, static_cast<int>(maxOut),
                                                      const_cast<const uint8_t **>(aFrame->data), nbIn);
-                    if (produced > 0)
+                    if (produced > 0 && aFrame->pts != AV_NOPTS_VALUE)
                     {
                         // Convert the frame's PTS (stream-tb units)
-                        // to stream-origin-relative microseconds the
-                        // same way the video path does it — see the
-                        // anchor logic below. We can reuse the anchor
-                        // because both streams share the same /raw
-                        // demuxer.
-                        const int64_t aPts = (aFrame->pts != AV_NOPTS_VALUE) ? aFrame->pts : 0;
+                        // to absolute stream microseconds. The drift
+                        // check below subtracts the video anchor
+                        // (m_firstPtsUs) to bring this into the same
+                        // coordinate system the video frame
+                        // targetWallUs uses, so we keep it absolute
+                        // here and let the consumer rebase.
+                        //
+                        // IMPORTANT: skip submit when aFrame->pts is
+                        // AV_NOPTS_VALUE. Earlier code substituted 0,
+                        // which on a mid-join anchored the audio
+                        // clock at "stream-time 0" while video
+                        // anchored at the server's current uptime —
+                        // producing the multi-hundred-second drift
+                        // documented in #67. A few dropped frames
+                        // (~20 ms each at AAC 1024-sample boundaries)
+                        // is a much better failure mode than a
+                        // corrupted A/V clock.
                         const AVRational tb = m_formatCtx->streams[m_audioStreamIdx]->time_base;
-                        const int64_t ptsUs = static_cast<int64_t>(static_cast<double>(aPts) * av_q2d(tb) * 1e6);
+                        const int64_t ptsUs = static_cast<int64_t>(static_cast<double>(aFrame->pts) * av_q2d(tb) * 1e6);
                         m_audioPlayback->submit(m_audioScratch.data(),
                                                 static_cast<size_t>(produced),
                                                 ptsUs);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -175,6 +175,26 @@ bool VideoCaptureRemote::initDecoder()
     }
 
     AVCodecParameters *codecPar = m_formatCtx->streams[m_videoStreamIdx]->codecpar;
+    // Reject the open when probe didn't resolve video dimensions. The
+    // demuxer is allowed to surface a stream that's still being
+    // analyzed (the FFmpeg log line is 'Could not find codec
+    // parameters ... none: unspecified size'). If we proceed with
+    // width/height = 0, m_width/m_height are stuck at zero for the
+    // whole session and the consumer dead-locks at
+    //   decoded=N/s consumed=0/s drops=N queueDepth=20
+    // because nothing downstream can route 0x0 frames. Better to fail
+    // initDecoder and let the outer reconnect loop try again — by the
+    // time the next attempt fires, the upstream MPEG-TS is usually
+    // past the partial-PMT region that caused the first probe to
+    // give up.
+    if (codecPar->width <= 0 || codecPar->height <= 0)
+    {
+        LOG_WARN("VideoCaptureRemote: probe returned " +
+                 std::to_string(codecPar->width) + "x" +
+                 std::to_string(codecPar->height) +
+                 " for video stream — rejecting and forcing reconnect");
+        return false;
+    }
     const AVCodec *codec = avcodec_find_decoder(codecPar->codec_id);
     if (!codec)
     {

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -889,12 +889,23 @@ void VideoCaptureRemote::decodeLoop()
                 rgbBuf.assign(static_cast<size_t>(dstW) * static_cast<size_t>(dstH) * 3, 0);
             }
 
-            // Write rows in reverse (bottom-up) so the resulting RGB buffer
-            // matches the orientation the rest of the capture pipeline
-            // expects from V4L2 / DirectShow sources — without this, the
-            // image renders upside-down on screen.
-            uint8_t *dstSlices[1] = { rgbBuf.data() + static_cast<size_t>(dstH - 1) * static_cast<size_t>(dstW) * 3 };
-            int dstStrides[1]     = { -(dstW * 3) };
+            // Top-down orientation matches what the rest of the capture
+            // pipeline produces:
+            //   - V4L2: FrameProcessor::convertYUYVtoRGB uses a positive
+            //     sws stride, so the local YUYV→RGB output is top-down.
+            //   - DirectShow: VideoCaptureDS emits RGB24 frames top-down.
+            //
+            // Earlier code here negated the dst stride to write the
+            // buffer bottom-up "to match V4L2", which was based on a
+            // wrong reading of the local path. The result was the
+            // /raw client showing the picture flipped vertically once
+            // the shader pipeline on the client was bypassed — the
+            // shader implicitly compensated, so the bug only surfaced
+            // after #67's "/raw works with shader off" fix exposed the
+            // no-shader rendering path on remote sources. See the user
+            // report on #67.
+            uint8_t *dstSlices[1] = { rgbBuf.data() };
+            int dstStrides[1]     = { static_cast<int>(dstW) * 3 };
             sws_scale(m_swsCtx, frame->data, frame->linesize, 0, srcH, dstSlices, dstStrides);
 
             // Capture the frame's PTS in stream timebase units BEFORE

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4371,8 +4371,27 @@ void Application::run()
                                 // /raw client also triggers the source-frame capture below.
                                 const bool rawWantsSource = m_streamManager && m_streamManager->isActive() &&
                                                             m_streamManager->hasRawClients();
-                                const bool needSourceCapture = masterOn && shaderActive &&
-                                                               (streamWantsSource || recordWantsSource || rawWantsSource);
+                                // Always capture source pixels when /raw has clients,
+                                // even with the shader pipeline off. /raw is by
+                                // contract pre-shader and must produce frames in a
+                                // single, stable orientation on the wire (top-down,
+                                // matching what the for-loop below converts to from
+                                // glReadPixels' bottom-up output). Without this, the
+                                // shader-off branch fed `frameData` directly — which
+                                // is bottom-up — and a remote viewer saw the image
+                                // upside-down whenever their own client-side shader
+                                // was also off, while the shader-on case stayed
+                                // correct because the shader was implicitly the
+                                // missing flip (#67 — user follow-up "com shader e
+                                // sem shader no client tem q esta no sentido
+                                // correto"). /stream and /recording still gate on
+                                // masterOn && shaderActive — they're consumers, not
+                                // wire-format producers, and they only need the
+                                // source when the user explicitly opts in.
+                                const bool needSourceCapture =
+                                    rawWantsSource ||
+                                    (masterOn && shaderActive &&
+                                     (streamWantsSource || recordWantsSource));
 
                                 bool sourceFrameReady = false;
                                 uint32_t sourceFrameW = 0, sourceFrameH = 0;
@@ -4451,27 +4470,14 @@ void Application::run()
                                     // is listening — the CPU cost only shows up when a remote
                                     // client is actually consuming the raw feed.
                                     //
-                                    // Two code paths because the pre-shader pixels live in
-                                    // different buffers depending on whether the shader chain
-                                    // is running this frame:
-                                    //   - shader active → m_captureSourceFrameData (an extra
-                                    //     readback from the FrameProcessor texture).
-                                    //   - shader off (master toggle disabled or no preset
-                                    //     loaded) → frameData IS already the pre-shader pixels,
-                                    //     so we feed /raw from there. Without this branch,
-                                    //     disabling the shader from the UI silently kills
-                                    //     /raw transmission (#67 — client log showed video
-                                    //     stop while audio kept flowing).
-                                    if (m_streamManager->hasRawClients())
+                                    // needSourceCapture was widened above to fire whenever /raw
+                                    // has clients, regardless of shader state, so the buffer is
+                                    // always present and always top-down (the for-loop above
+                                    // does the flip). One push site, one orientation on the
+                                    // wire.
+                                    if (sourceFrameReady && m_streamManager->hasRawClients())
                                     {
-                                        if (sourceFrameReady)
-                                        {
-                                            m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
-                                        }
-                                        else if (!masterOn || !shaderActive)
-                                        {
-                                            m_streamManager->pushRawFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
-                                        }
+                                        m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
                                     }
                                 }
                                 if (frameDataReady && m_recordingManager && m_recordingManager->isRecording())

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4450,9 +4450,28 @@ void Application::run()
                                     // hasRawClients() gates this so the encoder idles when nothing
                                     // is listening — the CPU cost only shows up when a remote
                                     // client is actually consuming the raw feed.
-                                    if (sourceFrameReady && m_streamManager->hasRawClients())
+                                    //
+                                    // Two code paths because the pre-shader pixels live in
+                                    // different buffers depending on whether the shader chain
+                                    // is running this frame:
+                                    //   - shader active → m_captureSourceFrameData (an extra
+                                    //     readback from the FrameProcessor texture).
+                                    //   - shader off (master toggle disabled or no preset
+                                    //     loaded) → frameData IS already the pre-shader pixels,
+                                    //     so we feed /raw from there. Without this branch,
+                                    //     disabling the shader from the UI silently kills
+                                    //     /raw transmission (#67 — client log showed video
+                                    //     stop while audio kept flowing).
+                                    if (m_streamManager->hasRawClients())
                                     {
-                                        m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
+                                        if (sourceFrameReady)
+                                        {
+                                            m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
+                                        }
+                                        else if (!masterOn || !shaderActive)
+                                        {
+                                            m_streamManager->pushRawFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        }
                                     }
                                 }
                                 if (frameDataReady && m_recordingManager && m_recordingManager->isRecording())

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3901,10 +3901,21 @@ void Application::run()
                          ", finalRenderHeight: " + std::to_string(finalRenderHeight));
             }
 
-            // IMPORTANT: Camera image comes inverted (Y inverted)
-            // Shaders also render inverted, so both need Y inversion
-            // flipY: true for both (camera and shader need to invert)
-            bool shouldFlipY = true;
+            // Camera image and shader output both need Y inversion in
+            // the general case — that's why flipY defaults to true.
+            //
+            // Exception: remote source consumed without a client-side
+            // shader. The /raw wire data goes through one fewer Y
+            // inversion than a locally-captured frame (no FrameProcessor
+            // upload→shader→sample chain on the client), so the
+            // renderer's implicit flip overshoots and the image lands
+            // upside-down. When the user disables the client-side
+            // shader pipeline on a Remote source, drop the flip so the
+            // picture stays right-side-up (#67).
+            const bool remoteWithoutShader =
+                (m_ui && m_ui->getSourceType() == UIManager::SourceType::Remote &&
+                 !isShaderTexture);
+            bool shouldFlipY = !remoteWithoutShader;
 
             // Calculate viewport where capture will be rendered (may be smaller than window if maintainAspect is active)
             uint32_t windowWidth = m_window->getWidth();

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4371,27 +4371,8 @@ void Application::run()
                                 // /raw client also triggers the source-frame capture below.
                                 const bool rawWantsSource = m_streamManager && m_streamManager->isActive() &&
                                                             m_streamManager->hasRawClients();
-                                // Always capture source pixels when /raw has clients,
-                                // even with the shader pipeline off. /raw is by
-                                // contract pre-shader and must produce frames in a
-                                // single, stable orientation on the wire (top-down,
-                                // matching what the for-loop below converts to from
-                                // glReadPixels' bottom-up output). Without this, the
-                                // shader-off branch fed `frameData` directly — which
-                                // is bottom-up — and a remote viewer saw the image
-                                // upside-down whenever their own client-side shader
-                                // was also off, while the shader-on case stayed
-                                // correct because the shader was implicitly the
-                                // missing flip (#67 — user follow-up "com shader e
-                                // sem shader no client tem q esta no sentido
-                                // correto"). /stream and /recording still gate on
-                                // masterOn && shaderActive — they're consumers, not
-                                // wire-format producers, and they only need the
-                                // source when the user explicitly opts in.
-                                const bool needSourceCapture =
-                                    rawWantsSource ||
-                                    (masterOn && shaderActive &&
-                                     (streamWantsSource || recordWantsSource));
+                                const bool needSourceCapture = masterOn && shaderActive &&
+                                                               (streamWantsSource || recordWantsSource || rawWantsSource);
 
                                 bool sourceFrameReady = false;
                                 uint32_t sourceFrameW = 0, sourceFrameH = 0;
@@ -4470,14 +4451,27 @@ void Application::run()
                                     // is listening — the CPU cost only shows up when a remote
                                     // client is actually consuming the raw feed.
                                     //
-                                    // needSourceCapture was widened above to fire whenever /raw
-                                    // has clients, regardless of shader state, so the buffer is
-                                    // always present and always top-down (the for-loop above
-                                    // does the flip). One push site, one orientation on the
-                                    // wire.
-                                    if (sourceFrameReady && m_streamManager->hasRawClients())
+                                    // Two code paths because the pre-shader pixels live in
+                                    // different buffers depending on whether the shader chain
+                                    // is running this frame:
+                                    //   - shader active → m_captureSourceFrameData (an extra
+                                    //     readback from the FrameProcessor texture).
+                                    //   - shader off (master toggle disabled or no preset
+                                    //     loaded) → frameData IS already the pre-shader pixels,
+                                    //     so we feed /raw from there. Without this branch,
+                                    //     disabling the shader from the UI silently kills
+                                    //     /raw transmission (#67 — client log showed video
+                                    //     stop while audio kept flowing).
+                                    if (m_streamManager->hasRawClients())
                                     {
-                                        m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
+                                        if (sourceFrameReady)
+                                        {
+                                            m_streamManager->pushRawFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
+                                        }
+                                        else if (!masterOn || !shaderActive)
+                                        {
+                                            m_streamManager->pushRawFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        }
                                     }
                                 }
                                 if (frameDataReady && m_recordingManager && m_recordingManager->isRecording())


### PR DESCRIPTION
## Summary

Field-testing #67 (the long-session A/V drift bug) on both `/stream` (web portal / VLC / ffplay) and the desktop client over `/raw` surfaced a stack of related failure modes — catastrophic A/V clock corruption on mid-join, AAC probe races, broken state when video probe gave up, `/raw` going silent when the host toggled the shader off, ghost audio after disconnect, and an orientation mismatch when the client disabled its own shader. This PR rolls up the targeted fixes for all of those.

The deeper "gradual A/V skew over hours" angle of #67 is **not** closed by this PR — the catastrophic case is gone and the user reports the brutal desync stopped, but the 30 min / 4 h offset targets in the original acceptance still need a long-session validation pass. If drift recurs, we'll open a follow-up issue.

## Commits

| Commit | Fix |
|--------|-----|
| `72c03cc` | `VideoCaptureRemote`: skip audio submit on `AV_NOPTS_VALUE` — earlier code substituted `0`, anchoring the audio clock to "stream-time 0" while video sat at the server's current uptime → multi-hundred-second drift on every mid-join. |
| `755ab23` | Bump probe budget to 512 KB / 2.5 s. The earlier 256 KB / 1 s window let `avformat_find_stream_info` give up before seeing enough AAC packets, producing the `Audio: aac, 0 channels: unspecified sample format` symptom and a failed `AudioPlaybackPulse::open`. |
| `321745f` | Reject `0x0` probe results and force a reconnect; also stop killing `/raw` transmission when the host disables the shader pipeline. |
| `9c88238` | `AudioPlaybackPulse::close()` swaps `pa_simple_drain` for `pa_simple_flush` — drain blocks until queued samples actually play, so the user heard the just-dropped stream continue playing for the full disconnect interval. |
| `5ea5a5c` + `9f78033` | Reverts of two intermediate orientation attempts that moved the bug rather than fixing it. |
| `7b6a572` | Final orientation fix on the client: when source is Remote and there's no client-side shader, drop the renderer's default `flipY=true`. The shader pipeline implicitly compensates for one flip in the local-capture path that doesn't exist for `/raw`, so leaving the flip on overshoots and lands upside-down. Wire format stays untouched; the decision is taken on the client where shader state is known.

## Test plan

- [x] Cross-compile Linux x86_64 / ARM64 / ARMv7 / Windows x86_64.
- [x] Client connecting mid-stream over `/raw` no longer logs `audio clock drift=-NNN_NNN_NNNus` then collapses to wall-clock master.
- [x] `Audio: aac, 0 channels` probe failure no longer occurs on routine reconnects.
- [x] Host toggling the shader pipeline off keeps `/raw` clients alive (video keeps flowing alongside audio).
- [x] Disconnect kills audio immediately instead of letting the queue drain out.
- [x] Client with no client-side shader displays remote `/raw` right-side up; same client with a shader applied keeps the existing correct orientation.
- [x] 30-minute / 4-hour long-session A/V offset measurement — deferred to a follow-up if it recurs.