### PR TITLE
feat(audio): coherent RetroCapture source/sink pair on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.0-alpha] - unreleased
+
+Linux audio pipeline refactor: the host-side capture path no longer
+hides behind PulseAudio's `module-null-sink` + `module-loopback`
+loopback trick. RetroCapture now records directly from the user-picked
+input device and exposes a symmetric `RetroCapture` source/sink pair
+to the OS audio graph — same shape as the client side has always
+had via `AudioPlaybackPulse`.
+
+### Changed
+
+- **Linux audio: drop null-sink loopback for a coherent `RetroCapture`
+  source/sink pair** (#78) — the host pipeline used to load a
+  `module-null-sink sink_name=RetroCapture` and route the capture-card
+  audio into it via `module-loopback` so we could record the sink's
+  `.monitor`. The user had to understand the PulseAudio sink/source
+  distinction and route an app via `pavucontrol`. Replaced by:
+  - A direct `PA_STREAM_RECORD` against the user-picked capture
+    device. No more null-sink.
+  - A new in-process `AudioBus` fan-out so multiple consumers
+    (encoder/recorder, the published source, the local monitor) all
+    pull from the same owned audio pipeline — opens the door for a
+    DSP chain follow-up without rearchitecting.
+  - A `module-pipe-source source_name=RetroCapture` that publishes
+    what RetroCapture is currently capturing to the OS audio graph,
+    so other apps (DAW, monitoring chain) can record from it — the
+    "input" half of the symmetric pair.
+  - A host-side `MonitorPlayback` (`pa_simple` PLAYBACK stream named
+    `RetroCapture` to the default sink) — the "output" half of the
+    pair, mirror of the client's `AudioPlaybackPulse`. Picking a
+    device under the Audio tab is now audible immediately, with no
+    `pavucontrol` routing. Kept in-process (no module-loopback) so
+    a future DSP chain can sit between the bus and the playback.
+  - A **"Resync monitor" button** in the Audio tab (native + web
+    portal) that drains the monitor backlog and flushes PulseAudio's
+    playback buffer, snapping the monitor back to ~50 ms latency.
+    Useful when a stall accumulates a delay between the captured
+    audio and what the user hears.
+  - Audio tab copy across native UI and the web portal updated to
+    "Input device" / "Start capture" / "Stop capture" and shows a
+    live status line with the current sample rate / channels.
+  - A one-shot migration GC that unloads any leftover pre-0.8
+    `module-null-sink sink_name=RetroCapture` + matching
+    `module-loopback` modules at startup, so upgrades from 0.7.x
+    don't leave stale modules behind.
+- Removed ~700 lines of dead `module-null-sink` / `module-loopback`
+  scaffolding from `AudioCapturePulse`, plus the `restoreAudio-
+  DeviceConnections` two-step (the saved input source is now passed
+  directly to `AudioCapturePulse::open()` during init).
+
+### Scope
+
+- Linux only. WASAPI loopback already works differently on Windows;
+  the host audio path on Windows is untouched in this release.
+
+---
+
 ## [0.7.0-alpha] - 2026-05-21
 
 Twelfth alpha release. Two large product surfaces (shader-preserving

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,9 @@ elseif(PLATFORM_WINDOWS)
     # No Windows, excluir implementações Linux
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureV4L2\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCapturePulse\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*PipeSourcePublisher\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*MonitorPlayback\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioBus\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
 
     # Excluir arquivos Linux genéricos que não têm versão Windows

--- a/src/audio/AudioBus.cpp
+++ b/src/audio/AudioBus.cpp
@@ -1,0 +1,89 @@
+#include "AudioBus.h"
+
+#include <algorithm>
+#include <cstring>
+
+AudioBus::AudioBus(uint32_t sampleRate, uint32_t channels)
+    : m_sampleRate(sampleRate), m_channels(channels)
+{
+}
+
+std::shared_ptr<AudioBus::Tap> AudioBus::createTap(size_t capacitySamples)
+{
+    auto tap = std::shared_ptr<Tap>(new Tap(capacitySamples));
+    std::lock_guard<std::mutex> lock(m_tapsMutex);
+    m_taps.push_back(tap);
+    return tap;
+}
+
+void AudioBus::push(const int16_t *interleaved, size_t sampleCount)
+{
+    if (!interleaved || sampleCount == 0)
+    {
+        return;
+    }
+
+    std::vector<std::shared_ptr<Tap>> live;
+    {
+        std::lock_guard<std::mutex> lock(m_tapsMutex);
+        live.reserve(m_taps.size());
+        auto it = m_taps.begin();
+        while (it != m_taps.end())
+        {
+            if (auto sp = it->lock())
+            {
+                live.push_back(std::move(sp));
+                ++it;
+            }
+            else
+            {
+                it = m_taps.erase(it);
+            }
+        }
+    }
+
+    for (auto &tap : live)
+    {
+        tap->push(interleaved, sampleCount);
+    }
+}
+
+void AudioBus::Tap::push(const int16_t *src, size_t sampleCount)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_buffer.insert(m_buffer.end(), src, src + sampleCount);
+    if (m_capacity > 0 && m_buffer.size() > m_capacity)
+    {
+        const size_t drop = m_buffer.size() - m_capacity;
+        m_buffer.erase(m_buffer.begin(), m_buffer.begin() + drop);
+    }
+}
+
+size_t AudioBus::Tap::pull(int16_t *dst, size_t maxSamples)
+{
+    if (!dst || maxSamples == 0)
+    {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const size_t n = std::min(maxSamples, m_buffer.size());
+    if (n == 0)
+    {
+        return 0;
+    }
+    // deque iterators don't guarantee contiguous storage, so element-by-
+    // element copy. Sizes here are <= a few thousand samples per pull,
+    // so this is not a hot-path concern.
+    for (size_t i = 0; i < n; ++i)
+    {
+        dst[i] = m_buffer[i];
+    }
+    m_buffer.erase(m_buffer.begin(), m_buffer.begin() + n);
+    return n;
+}
+
+size_t AudioBus::Tap::available() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_buffer.size();
+}

--- a/src/audio/AudioBus.h
+++ b/src/audio/AudioBus.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+/**
+ * In-process fan-out for captured S16LE interleaved audio.
+ *
+ * One producer (the platform audio capture, currently AudioCapturePulse)
+ * calls push(); multiple consumers each hold an independent Tap and pull
+ * at their own pace. Day-one consumers are the encoder/recorder drain
+ * (existing IAudioCapture::getSamples path) and the future
+ * module-pipe-source publisher that exposes the `RetroCapture` virtual
+ * source to the rest of the OS audio graph.
+ *
+ * The seam exists so a future DSP chain can sit between push() and the
+ * publish taps without rearchitecting capture or consumers.
+ */
+class AudioBus
+{
+public:
+    class Tap
+    {
+    public:
+        // Pulls up to maxSamples interleaved int16 frames into dst.
+        // Returns the count actually copied. Non-blocking.
+        size_t pull(int16_t *dst, size_t maxSamples);
+
+        size_t available() const;
+
+    private:
+        friend class AudioBus;
+
+        explicit Tap(size_t capacitySamples) : m_capacity(capacitySamples) {}
+
+        void push(const int16_t *src, size_t sampleCount);
+
+        // Drop-oldest when full so a stalled consumer can never wedge
+        // the producer or starve the other taps.
+        size_t              m_capacity;
+        mutable std::mutex  m_mutex;
+        std::deque<int16_t> m_buffer;
+    };
+
+    AudioBus(uint32_t sampleRate, uint32_t channels);
+
+    uint32_t getSampleRate() const { return m_sampleRate; }
+    uint32_t getChannels() const { return m_channels; }
+
+    // Caller owns the returned tap; AudioBus only holds a weak ref, so
+    // dropping the last shared_ptr cleanly removes the tap on the next
+    // push().
+    std::shared_ptr<Tap> createTap(size_t capacitySamples);
+
+    void push(const int16_t *interleaved, size_t sampleCount);
+
+private:
+    uint32_t m_sampleRate;
+    uint32_t m_channels;
+
+    mutable std::mutex                m_tapsMutex;
+    std::vector<std::weak_ptr<Tap>>   m_taps;
+};

--- a/src/audio/AudioCapturePulse.cpp
+++ b/src/audio/AudioCapturePulse.cpp
@@ -4,16 +4,25 @@
 #include <pulse/simple.h>
 #include <pulse/error.h>
 #include <pulse/introspect.h>
+#include <cerrno>
 #include <cstring>
+#include <cstdlib>
 #include <algorithm>
 #include <atomic>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 AudioCapturePulse::AudioCapturePulse()
-    : m_mainloop(nullptr), m_mainloopApi(nullptr), m_context(nullptr), m_stream(nullptr), m_virtualSinkIndex(PA_INVALID_INDEX), m_moduleIndex(PA_INVALID_INDEX), m_inputLoopbackModuleIndex(PA_INVALID_INDEX), m_sampleRate(44100), m_channels(2), m_bytesPerSample(2) // 16-bit
-      ,
+    : m_mainloop(nullptr), m_mainloopApi(nullptr), m_context(nullptr), m_stream(nullptr),
+      m_sampleRate(44100), m_channels(2), m_bytesPerSample(2),
       m_isOpen(false), m_isCapturing(false)
 {
+    m_pipeSourceModuleIndex = PA_INVALID_INDEX;
+    m_bus = std::make_unique<AudioBus>(m_sampleRate, m_channels);
+    // ~2 s of slack at 44.1 kHz stereo. Encoder/recorder pulls every
+    // video frame, so this is comfortably above expected fill.
+    m_localTap = m_bus->createTap(static_cast<size_t>(m_sampleRate) * m_channels * 2);
 }
 
 AudioCapturePulse::~AudioCapturePulse()
@@ -62,32 +71,26 @@ bool AudioCapturePulse::initializePulseAudio()
 void AudioCapturePulse::cleanupPulseAudio()
 {
     stopCapture();
+    if (m_monitor)
+    {
+        m_monitor->stop();
+        m_monitor.reset();
+    }
+    stopPublishSource();
+    disconnectRecordStream();
 
-    // IMPORTANT: Clean up all loopbacks BEFORE removing virtual sink
-    // This ensures we don't leave orphaned modules
-    disconnectInputSource();
+    // Best-effort GC of any pre-0.8 module-null-sink / module-loopback
+    // we may have just inherited from an old session on this host.
+    gcLegacyRetroCaptureModules();
 
-    // Also clean up any orphaned loopbacks that might exist
-    cleanupOrphanedLoopbacks();
-
-    removeVirtualSink();
-
-    // Process events to ensure async operations complete
     if (m_mainloop && m_context)
     {
         int ret = 0;
         for (int i = 0; i < 100; i++)
         {
             pa_mainloop_iterate(m_mainloop, 0, &ret);
-            usleep(10000); // 10ms
+            usleep(10000);
         }
-    }
-
-    if (m_stream)
-    {
-        pa_stream_disconnect(m_stream);
-        pa_stream_unref(m_stream);
-        m_stream = nullptr;
     }
 
     if (m_context)
@@ -104,9 +107,6 @@ void AudioCapturePulse::cleanupPulseAudio()
     }
 
     m_mainloopApi = nullptr;
-    m_virtualSinkIndex = PA_INVALID_INDEX;
-    m_moduleIndex = PA_INVALID_INDEX;
-    m_inputLoopbackModuleIndex = PA_INVALID_INDEX;
 }
 
 void AudioCapturePulse::contextStateCallback(pa_context *c, void *userdata)
@@ -200,11 +200,9 @@ void AudioCapturePulse::streamRead(size_t length)
         size_t samples = bytes / m_bytesPerSample;
         const int16_t *sampleData = static_cast<const int16_t *>(data);
 
+        if (m_bus)
         {
-            std::lock_guard<std::mutex> lock(m_bufferMutex);
-            size_t oldSize = m_audioBuffer.size();
-            m_audioBuffer.resize(oldSize + samples);
-            std::memcpy(m_audioBuffer.data() + oldSize, sampleData, bytes);
+            m_bus->push(sampleData, samples);
         }
 
         if (m_audioCallback)
@@ -253,31 +251,74 @@ bool AudioCapturePulse::open(const std::string &deviceName)
         }
         else if (state == PA_CONTEXT_FAILED || state == PA_CONTEXT_TERMINATED)
         {
-            LOG_ERROR("Failed to conectar ao PulseAudio");
+            LOG_ERROR("Failed to connect to PulseAudio");
             return false;
         }
 
-        usleep(10000); // 10ms
+        usleep(10000);
         iteration++;
     }
 
     if (pa_context_get_state(m_context) != PA_CONTEXT_READY)
     {
-        LOG_ERROR("Timeout ao conectar ao PulseAudio");
+        LOG_ERROR("Timeout connecting to PulseAudio");
         return false;
     }
 
-    // Clean up any orphaned loopbacks from previous sessions before creating new ones
-    cleanupOrphanedLoopbacks();
+    // One-time GC of any module-null-sink / module-loopback left behind
+    // by older RetroCapture binaries on this host. Idempotent against a
+    // clean graph.
+    gcLegacyRetroCaptureModules();
 
-    if (deviceName.empty())
+    if (!connectRecordStream(deviceName))
     {
-        if (!createVirtualSink())
+        return false;
+    }
+
+    if (!startPublishSource())
+    {
+        // Publish failure is non-fatal — capture still works internally
+        // for the encoder/recorder. Log loudly so the user understands
+        // why other apps don't see `RetroCapture` in pactl.
+        LOG_WARN("AudioCapture: failed to publish virtual source 'RetroCapture'; "
+                 "other apps will not see it in the PulseAudio graph");
+    }
+
+    // Open the host-side monitor playback (the "output" half of the
+    // RetroCapture I/O pair). ~2 s tap slack matches the other taps.
+    // The two hardware clocks (capture device + default sink) will
+    // drift in ppm over long sessions, accumulating in this tap; the
+    // bus drop-oldest at the cap is the current safety net. Smooth
+    // sample-rate-matching is a follow-up.
+    {
+        const size_t monitorCapacity =
+            static_cast<size_t>(m_sampleRate) * m_channels * 2;
+        auto monitorTap = m_bus->createTap(monitorCapacity);
+        m_monitor = std::make_unique<MonitorPlayback>();
+        if (!m_monitor->start(std::move(monitorTap), m_sampleRate, m_channels))
         {
-            LOG_ERROR("Failed to criar sink virtual");
-            return false;
+            LOG_WARN("AudioCapture: monitor playback failed to start; "
+                     "user will not hear the input through the default sink");
+            m_monitor.reset();
         }
     }
+
+    m_isOpen = true;
+    LOG_INFO("AudioCapture opened: " + std::to_string(m_sampleRate) + "Hz, " +
+             std::to_string(m_channels) + " channels, source=" +
+             (deviceName.empty() ? "<default>" : deviceName));
+    return true;
+}
+
+bool AudioCapturePulse::connectRecordStream(const std::string &device)
+{
+    if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY)
+    {
+        LOG_ERROR("PulseAudio context not ready for connectRecordStream");
+        return false;
+    }
+
+    disconnectRecordStream();
 
     pa_sample_spec sampleSpec;
     sampleSpec.format = PA_SAMPLE_S16LE;
@@ -293,11 +334,9 @@ bool AudioCapturePulse::open(const std::string &deviceName)
 
     const char *streamName = "RetroCapture Audio Capture";
     m_stream = pa_stream_new(m_context, streamName, &sampleSpec, nullptr);
-
     if (!m_stream)
     {
-        LOG_ERROR("Failed to criar PulseAudio stream");
-        removeVirtualSink();
+        LOG_ERROR("Failed to create PulseAudio stream");
         return false;
     }
 
@@ -307,72 +346,61 @@ bool AudioCapturePulse::open(const std::string &deviceName)
     pa_stream_flags_t flags = static_cast<pa_stream_flags>(
         PA_STREAM_START_CORKED | PA_STREAM_ADJUST_LATENCY);
 
-    std::string monitorDevice;
-    if (m_virtualSinkIndex != PA_INVALID_INDEX)
-    {
-        monitorDevice = "RetroCapture.monitor";
-    }
-    else if (!deviceName.empty())
-    {
-        monitorDevice = deviceName;
-    }
+    const char *deviceArg = device.empty() ? nullptr : device.c_str();
 
-    const char *device = monitorDevice.empty() ? nullptr : monitorDevice.c_str();
-
-    if (pa_stream_connect_record(m_stream, device, &bufferAttr, flags) < 0)
+    if (pa_stream_connect_record(m_stream, deviceArg, &bufferAttr, flags) < 0)
     {
-        LOG_ERROR("Failed to conectar stream de captura: " +
+        LOG_ERROR("Failed to connect record stream: " +
                   std::string(pa_strerror(pa_context_errno(m_context))));
         pa_stream_unref(m_stream);
         m_stream = nullptr;
-        removeVirtualSink();
         return false;
     }
 
-    iteration = 0;
+    int ret = 0;
+    int maxIterations = 100;
+    int iteration = 0;
     while (iteration < maxIterations)
     {
         pa_mainloop_iterate(m_mainloop, 0, &ret);
-
         pa_stream_state_t state = pa_stream_get_state(m_stream);
         if (state == PA_STREAM_READY)
         {
             break;
         }
-        else if (state == PA_STREAM_FAILED || state == PA_STREAM_TERMINATED)
+        if (state == PA_STREAM_FAILED || state == PA_STREAM_TERMINATED)
         {
-            LOG_ERROR("Failed to criar stream de captura");
+            LOG_ERROR("Record stream failed before reaching READY");
             pa_stream_unref(m_stream);
             m_stream = nullptr;
-            removeVirtualSink();
             return false;
         }
-
-        usleep(10000); // 10ms
+        usleep(10000);
         iteration++;
     }
 
     if (pa_stream_get_state(m_stream) != PA_STREAM_READY)
     {
-        LOG_ERROR("Timeout ao criar stream de captura");
+        LOG_ERROR("Timeout opening record stream");
         pa_stream_unref(m_stream);
         m_stream = nullptr;
-        removeVirtualSink();
         return false;
     }
 
-    m_isOpen = true;
-    if (m_virtualSinkIndex != PA_INVALID_INDEX)
-    {
-        LOG_INFO("AudioCapture aberto com sink virtual 'RetroCapture'");
-    }
-    else
-    {
-        LOG_INFO("AudioCapture aberto: " + std::to_string(m_sampleRate) + "Hz, " +
-                 std::to_string(m_channels) + " canais");
-    }
-
+    m_currentInputSourceName = device;
     return true;
+}
+
+void AudioCapturePulse::disconnectRecordStream()
+{
+    if (!m_stream)
+    {
+        return;
+    }
+    pa_stream_disconnect(m_stream);
+    pa_stream_unref(m_stream);
+    m_stream = nullptr;
+    m_isCapturing = false;
 }
 
 void AudioCapturePulse::close()
@@ -383,25 +411,16 @@ void AudioCapturePulse::close()
     }
 
     stopCapture();
-
-    // IMPORTANT: Disconnect all loopbacks BEFORE removing virtual sink
-    // This ensures clean shutdown
-    disconnectInputSource();
-
-    // Also clean up any orphaned loopbacks that might exist
-    cleanupOrphanedLoopbacks();
-
-    if (m_stream)
+    if (m_monitor)
     {
-        pa_stream_disconnect(m_stream);
-        pa_stream_unref(m_stream);
-        m_stream = nullptr;
+        m_monitor->stop();
+        m_monitor.reset();
     }
-
-    removeVirtualSink();
-
+    stopPublishSource();
+    disconnectRecordStream();
+    m_currentInputSourceName.clear();
     m_isOpen = false;
-    LOG_INFO("AudioCapture fechado");
+    LOG_INFO("AudioCapture closed");
 }
 
 bool AudioCapturePulse::isOpen() const
@@ -462,7 +481,8 @@ void AudioCapturePulse::stopCapture()
 
 size_t AudioCapturePulse::getSamples(std::vector<float> &samples)
 {
-    // IMPORTANTE: Processar mainloop mesmo se não estiver aberto
+    // Drive the PA mainloop even if not open so reconnect/teardown
+    // callbacks still fire.
     if (m_mainloop)
     {
         int ret = 0;
@@ -472,31 +492,31 @@ size_t AudioCapturePulse::getSamples(std::vector<float> &samples)
         }
     }
 
-    // Converter int16_t para float
-    std::lock_guard<std::mutex> lock(m_bufferMutex);
-
-    if (m_audioBuffer.empty())
+    if (!m_localTap)
     {
         samples.clear();
         return 0;
     }
 
-    size_t numSamples = m_audioBuffer.size();
-    samples.resize(numSamples);
-
-    // Converter de int16_t (-32768 a 32767) para float (-1.0 a 1.0)
-    for (size_t i = 0; i < numSamples; ++i)
+    const size_t available = m_localTap->available();
+    if (available == 0)
     {
-        samples[i] = static_cast<float>(m_audioBuffer[i]) / 32768.0f;
+        samples.clear();
+        return 0;
     }
 
-    m_audioBuffer.clear();
-    return numSamples;
+    std::vector<int16_t> raw(available);
+    const size_t pulled = m_localTap->pull(raw.data(), available);
+    samples.resize(pulled);
+    for (size_t i = 0; i < pulled; ++i)
+    {
+        samples[i] = static_cast<float>(raw[i]) / 32768.0f;
+    }
+    return pulled;
 }
 
 size_t AudioCapturePulse::getSamples(int16_t *buffer, size_t maxSamples)
 {
-    // IMPORTANTE: Processar mainloop mesmo se não estiver aberto
     if (m_mainloop)
     {
         int ret = 0;
@@ -506,27 +526,12 @@ size_t AudioCapturePulse::getSamples(int16_t *buffer, size_t maxSamples)
         }
     }
 
-    if (!m_isOpen || !buffer || maxSamples == 0)
+    if (!m_isOpen || !buffer || maxSamples == 0 || !m_localTap)
     {
         return 0;
     }
 
-    std::lock_guard<std::mutex> lock(m_bufferMutex);
-
-    if (m_audioBuffer.empty())
-    {
-        return 0;
-    }
-
-    size_t samplesToCopy = std::min(maxSamples, m_audioBuffer.size());
-    if (samplesToCopy > 0)
-    {
-        std::memcpy(buffer, m_audioBuffer.data(), samplesToCopy * sizeof(int16_t));
-        m_audioBuffer.erase(m_audioBuffer.begin(),
-                            m_audioBuffer.begin() + samplesToCopy);
-    }
-
-    return samplesToCopy;
+    return m_localTap->pull(buffer, maxSamples);
 }
 
 uint32_t AudioCapturePulse::getSampleRate() const
@@ -624,9 +629,6 @@ std::vector<AudioDeviceInfo> AudioCapturePulse::listInputSources()
         return devices;
     }
 
-    // Clean up any orphaned loopbacks before listing
-    cleanupOrphanedLoopbacks();
-
     // Clear previous list
     {
         std::lock_guard<std::mutex> lock(g_sourcesMutex);
@@ -711,33 +713,11 @@ void AudioCapturePulse::setAudioCallback(std::function<void(const int16_t *data,
     m_audioCallback = callback;
 }
 
-// Static variables for async operations
-static std::atomic<bool> g_sinkOperationSuccess{false};
-static std::atomic<uint32_t> g_sinkIndex{PA_INVALID_INDEX};
+// Globals for module-load / unload async ops. operationCallback writes
+// g_moduleIndex when load returns; unloadModuleCallback writes
+// g_sinkOperationSuccess.
+static std::atomic<bool>     g_sinkOperationSuccess{false};
 static std::atomic<uint32_t> g_moduleIndex{PA_INVALID_INDEX};
-static std::atomic<uint32_t> g_sinkInputIndex{PA_INVALID_INDEX};
-
-void AudioCapturePulse::sinkInfoCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata)
-{
-    (void)c;
-    (void)userdata;
-    if (eol < 0)
-    {
-        g_sinkOperationSuccess = false;
-        return;
-    }
-
-    if (eol > 0)
-    {
-        return;
-    }
-
-    if (i && strcmp(i->name, "RetroCapture") == 0)
-    {
-        g_sinkIndex = i->index;
-        g_sinkOperationSuccess = true;
-    }
-}
 
 void AudioCapturePulse::operationCallback(pa_context *c, uint32_t index, void *userdata)
 {
@@ -755,241 +735,6 @@ static void unloadModuleCallback(pa_context *c, int success, void *userdata)
     g_sinkOperationSuccess = (success == 0);
 }
 
-bool AudioCapturePulse::createVirtualSink()
-{
-    if (m_virtualSinkIndex != PA_INVALID_INDEX)
-    {
-        return true; // Já criado
-    }
-
-    if (pa_context_get_state(m_context) != PA_CONTEXT_READY)
-    {
-        LOG_ERROR("PulseAudio context not ready");
-        return false;
-    }
-
-    g_sinkOperationSuccess = false;
-    g_sinkIndex = PA_INVALID_INDEX;
-
-    LOG_INFO("Checking whether virtual sink 'RetroCapture' already exists...");
-    pa_operation *op = pa_context_get_sink_info_by_name(m_context, "RetroCapture", sinkInfoCallback, this);
-    if (op)
-    {
-        int ret = 0;
-        int maxIterations = 50;
-        int iteration = 0;
-
-        while (iteration < maxIterations)
-        {
-            pa_mainloop_iterate(m_mainloop, 0, &ret);
-            if (g_sinkIndex != PA_INVALID_INDEX)
-            {
-                break;
-            }
-            usleep(10000);
-            iteration++;
-        }
-        pa_operation_unref(op);
-
-        if (g_sinkIndex != PA_INVALID_INDEX)
-        {
-            m_virtualSinkIndex = g_sinkIndex;
-            m_moduleIndex = PA_INVALID_INDEX;
-            LOG_INFO("Virtual sink 'RetroCapture' already exists (index: " + std::to_string(m_virtualSinkIndex) + ")");
-            return true;
-        }
-    }
-
-    LOG_INFO("Virtual sink 'RetroCapture' not found, creating it...");
-
-    g_sinkOperationSuccess = false;
-    g_moduleIndex = PA_INVALID_INDEX;
-
-    LOG_INFO("Loading module-null-sink...");
-    const char *args = "sink_name=RetroCapture sink_properties='device.description=\"RetroCapture Audio Input\"'";
-    op = pa_context_load_module(m_context, "module-null-sink", args, operationCallback, this);
-
-    if (!op)
-    {
-        LOG_ERROR("Failed to create operation for loading module-null-sink: " +
-                  std::string(pa_strerror(pa_context_errno(m_context))));
-        return false;
-    }
-
-    int ret = 0;
-    int maxIterations = 100;
-    int iteration = 0;
-
-    while (iteration < maxIterations)
-    {
-        pa_mainloop_iterate(m_mainloop, 0, &ret);
-        if (g_sinkOperationSuccess && g_moduleIndex != PA_INVALID_INDEX)
-        {
-            m_moduleIndex = g_moduleIndex;
-            LOG_INFO("module-null-sink loaded (index: " + std::to_string(g_moduleIndex) + ")");
-            break;
-        }
-        usleep(10000);
-        iteration++;
-    }
-
-    pa_operation_unref(op);
-
-    if (!g_sinkOperationSuccess || g_moduleIndex == PA_INVALID_INDEX)
-    {
-        LOG_ERROR("Failed to criar sink virtual");
-        return false;
-    }
-
-    usleep(100000); // 100ms
-
-    LOG_INFO("Looking up index of the new 'RetroCapture' virtual sink...");
-    g_sinkIndex = PA_INVALID_INDEX;
-    g_sinkOperationSuccess = false;
-    op = pa_context_get_sink_info_by_name(m_context, "RetroCapture", sinkInfoCallback, this);
-    if (op)
-    {
-        iteration = 0;
-        while (iteration < maxIterations)
-        {
-            pa_mainloop_iterate(m_mainloop, 0, &ret);
-            if (g_sinkIndex != PA_INVALID_INDEX)
-            {
-                break;
-            }
-            usleep(10000);
-            iteration++;
-        }
-        pa_operation_unref(op);
-    }
-
-    if (g_sinkIndex == PA_INVALID_INDEX)
-    {
-        LOG_WARN("Failed to get the new virtual sink index");
-        m_virtualSinkIndex = 0;
-        return true;
-    }
-
-    m_virtualSinkIndex = g_sinkIndex;
-    LOG_INFO("Virtual sink 'RetroCapture' created (index: " + std::to_string(m_virtualSinkIndex) + ")");
-    return true;
-}
-
-// Static callback to find module that created RetroCapture sink
-static void findRetroCaptureModuleCallback(pa_context *c, const pa_module_info *i, int eol, void *userdata)
-{
-    (void)c;
-    uint32_t *foundModuleIndex = static_cast<uint32_t *>(userdata);
-
-    if (eol < 0 || eol > 0)
-    {
-        return;
-    }
-
-    if (i && i->name && strcmp(i->name, "module-null-sink") == 0)
-    {
-        // Check if this module created the RetroCapture sink
-        if (i->argument && strstr(i->argument, "sink_name=RetroCapture") != nullptr)
-        {
-            *foundModuleIndex = i->index;
-        }
-    }
-}
-
-void AudioCapturePulse::removeVirtualSink()
-{
-    // Note: Loopbacks should be disconnected before calling this
-    // (handled in close() and cleanupPulseAudio())
-
-    if (m_virtualSinkIndex == PA_INVALID_INDEX && m_moduleIndex == PA_INVALID_INDEX)
-    {
-        return;
-    }
-
-    if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY)
-    {
-        m_virtualSinkIndex = PA_INVALID_INDEX;
-        m_moduleIndex = PA_INVALID_INDEX;
-        return;
-    }
-
-    uint32_t moduleIndexToRemove = m_moduleIndex;
-
-    // If we don't have the module index, try to find it by searching for the module that created RetroCapture
-    if (moduleIndexToRemove == PA_INVALID_INDEX)
-    {
-        LOG_INFO("Module index not available, searching for module that created 'RetroCapture' sink...");
-        uint32_t foundModuleIndex = PA_INVALID_INDEX;
-        pa_operation *op = pa_context_get_module_info_list(m_context, findRetroCaptureModuleCallback, &foundModuleIndex);
-
-        if (op)
-        {
-            int ret = 0;
-            int maxIterations = 50;
-            int iteration = 0;
-
-            while (iteration < maxIterations)
-            {
-                pa_mainloop_iterate(m_mainloop, 0, &ret);
-
-                pa_operation_state_t opState = pa_operation_get_state(op);
-                if (opState == PA_OPERATION_DONE || opState == PA_OPERATION_CANCELLED)
-                {
-                    break;
-                }
-
-                usleep(10000);
-                iteration++;
-            }
-
-            pa_operation_unref(op);
-
-            if (foundModuleIndex != PA_INVALID_INDEX)
-            {
-                moduleIndexToRemove = foundModuleIndex;
-            }
-            else
-            {
-                LOG_WARN("Could not find module that created 'RetroCapture' sink");
-            }
-        }
-    }
-
-    if (moduleIndexToRemove == PA_INVALID_INDEX)
-    {
-        LOG_WARN("Cannot remove 'RetroCapture' sink: module index not available");
-        m_virtualSinkIndex = PA_INVALID_INDEX;
-        m_moduleIndex = PA_INVALID_INDEX;
-        return;
-    }
-
-    LOG_INFO("Removing virtual sink 'RetroCapture' (module: " + std::to_string(moduleIndexToRemove) + ")");
-    g_sinkOperationSuccess = false;
-    pa_operation *op = pa_context_unload_module(m_context, moduleIndexToRemove, unloadModuleCallback, this);
-    if (op)
-    {
-        int ret = 0;
-        int maxIterations = 50;
-        int iteration = 0;
-
-        while (iteration < maxIterations)
-        {
-            pa_mainloop_iterate(m_mainloop, 0, &ret);
-            if (g_sinkOperationSuccess)
-            {
-                break;
-            }
-            usleep(10000);
-            iteration++;
-        }
-        pa_operation_unref(op);
-    }
-
-    m_virtualSinkIndex = PA_INVALID_INDEX;
-    m_moduleIndex = PA_INVALID_INDEX;
-    LOG_INFO("Sink virtual 'RetroCapture' removido");
-}
-
 bool AudioCapturePulse::connectInputSource(const std::string &sourceName)
 {
     if (sourceName.empty())
@@ -1004,420 +749,289 @@ bool AudioCapturePulse::connectInputSource(const std::string &sourceName)
         return false;
     }
 
-    if (m_virtualSinkIndex == PA_INVALID_INDEX)
+    const bool wasCapturing = m_isCapturing;
+
+    if (!connectRecordStream(sourceName))
     {
-        LOG_ERROR("Virtual sink not created");
         return false;
     }
 
-    // Clean up orphaned loopbacks first
-    cleanupOrphanedLoopbacks();
-
-    // Disconnect previous source if any
-    disconnectInputSource();
-
-    // Use module-loopback to connect source to sink
-    // IMPORTANT: In PipeWire, we need to ensure the connection goes to the sink input, not the monitor
-    // Use sink_input_name to set the base name of the sink input
-    // Use sink_input_properties with media.name for the display name
-    // Note: PipeWire may interpret sink=RetroCapture differently, so we explicitly avoid connecting to monitor
-    std::string args = "source=" + sourceName + " sink=RetroCapture sink_input_name=RetroCaptureInputLoopback sink_input_properties=\"media.name=RetroCaptureInputLoopback\"";
-
-    g_sinkOperationSuccess = false;
-
-    pa_operation *op = pa_context_load_module(m_context, "module-loopback", args.c_str(), operationCallback, this);
-
-    if (!op)
+    if (wasCapturing)
     {
-        LOG_ERROR("Failed to create operation to load module-loopback");
-        return false;
+        startCapture();
     }
 
-    int ret = 0;
-    int maxIterations = 100;
-    int iteration = 0;
-
-    while (iteration < maxIterations)
-    {
-        {
-            std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-            pa_mainloop_iterate(m_mainloop, 0, &ret);
-        }
-        if (g_sinkOperationSuccess && g_moduleIndex != PA_INVALID_INDEX)
-        {
-            m_inputLoopbackModuleIndex = g_moduleIndex;
-            m_currentInputSourceName = sourceName;
-            break;
-        }
-        usleep(10000);
-        iteration++;
-    }
-
-    pa_operation_unref(op);
-
-    if (!g_sinkOperationSuccess || g_moduleIndex == PA_INVALID_INDEX)
-    {
-        LOG_ERROR("Failed to connect source to sink");
-        return false;
-    }
-
+    LOG_INFO("AudioCapture input switched to: " + sourceName);
     return true;
 }
 
 void AudioCapturePulse::disconnectInputSource()
 {
-    if (m_inputLoopbackModuleIndex == PA_INVALID_INDEX)
+    if (!m_stream && m_currentInputSourceName.empty())
     {
-        cleanupOrphanedLoopbacks();
-        m_currentInputSourceName.clear();
         return;
     }
 
-    if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY)
-    {
-        LOG_WARN("PulseAudio context not ready, cannot disconnect input source");
-        m_inputLoopbackModuleIndex = PA_INVALID_INDEX;
-        m_currentInputSourceName.clear();
-        return;
-    }
-
-    g_sinkOperationSuccess = false;
-    pa_operation *op = pa_context_unload_module(m_context, m_inputLoopbackModuleIndex, unloadModuleCallback, this);
-
-    if (!op)
-    {
-        LOG_ERROR("Failed to create operation to unload module (index: " + std::to_string(m_inputLoopbackModuleIndex) + ")");
-        // Try cleanup as fallback
-        cleanupOrphanedLoopbacks();
-        m_inputLoopbackModuleIndex = PA_INVALID_INDEX;
-        m_currentInputSourceName.clear();
-        return;
-    }
-
-    int ret = 0;
-    int maxIterations = 100; // Increase timeout
-    int iteration = 0;
-
-    while (iteration < maxIterations)
-    {
-        {
-            std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-            pa_mainloop_iterate(m_mainloop, 0, &ret);
-        }
-        
-        pa_operation_state_t opState = pa_operation_get_state(op);
-        if (opState == PA_OPERATION_DONE || opState == PA_OPERATION_CANCELLED)
-        {
-            break;
-        }
-        
-        if (g_sinkOperationSuccess)
-        {
-            break;
-        }
-        
-        usleep(10000);
-        iteration++;
-    }
-
-    pa_operation_unref(op);
-
-    if (iteration >= maxIterations)
-    {
-        LOG_WARN("Timeout waiting for module unload (module index: " + std::to_string(m_inputLoopbackModuleIndex) + ")");
-        // Try cleanup as fallback
-        cleanupOrphanedLoopbacks();
-    }
-
-    m_inputLoopbackModuleIndex = PA_INVALID_INDEX;
+    disconnectRecordStream();
     m_currentInputSourceName.clear();
+    LOG_INFO("AudioCapture input disconnected");
 }
 
 
-// Static callback for module info
-static void moduleInfoCallback(pa_context *c, const pa_module_info *i, int eol, void *userdata)
+// Compact module scan: picks out any pre-0.8 module-null-sink that
+// claimed sink_name=RetroCapture, and any module-loopback that fed it.
+// Once both classes are unloaded, the pre-0.8 RetroCapture sink and its
+// stray sink-inputs vanish on their own. Anything else is left alone.
+// 0.8+ does not load any null-sink or loopback — capture is direct,
+// publish goes via module-pipe-source, monitor playback is in-process
+// (MonitorPlayback / pa_simple) — so on a clean 0.8+ graph this is a
+// no-op.
+static void legacyModuleInfoCallback(pa_context *c, const pa_module_info *i, int eol, void *userdata)
 {
     (void)c;
-    std::vector<uint32_t> *moduleIndices = static_cast<std::vector<uint32_t> *>(userdata);
-
-    if (eol < 0)
+    if (eol || !i || !i->name)
     {
         return;
     }
+    auto *out = static_cast<std::vector<uint32_t> *>(userdata);
+    const std::string name = i->name;
+    const std::string args = i->argument ? i->argument : "";
 
-    if (eol > 0)
+    if (name == "module-null-sink" && args.find("sink_name=RetroCapture") != std::string::npos)
     {
+        out->push_back(i->index);
         return;
     }
-
-    if (i && i->name)
+    if (name == "module-loopback" &&
+        (args.find("sink=RetroCapture") != std::string::npos ||
+         args.find("RetroCaptureInputLoopback") != std::string::npos))
     {
-        std::string moduleName = i->name ? i->name : "";
-        // Check if this is a loopback module related to RetroCapture
-        if (moduleName.find("loopback") != std::string::npos)
-        {
-            bool isRetroCaptureLoopback = false;
-
-            if (i->argument)
-            {
-                std::string argStr = i->argument;
-                // Check for our named input loopbacks (using sink_input_properties or sink_input_name)
-                if (argStr.find("media.name=RetroCaptureInputLoopback") != std::string::npos ||
-                    argStr.find("sink_input_name=\"RetroCaptureInputLoopback\"") != std::string::npos ||
-                    argStr.find("sink_input_name=\"RetroCapture Input\"") != std::string::npos)
-                {
-                    isRetroCaptureLoopback = true;
-                }
-                // Also check for connections to RetroCapture sink (for backward compatibility)
-                else if (argStr.find("sink=RetroCapture") != std::string::npos)
-                {
-                    isRetroCaptureLoopback = true;
-                }
-            }
-
-            if (isRetroCaptureLoopback)
-            {
-                moduleIndices->push_back(i->index);
-            }
-        }
+        out->push_back(i->index);
     }
 }
 
-void AudioCapturePulse::cleanupOrphanedLoopbacks()
+void AudioCapturePulse::gcLegacyRetroCaptureModules()
 {
     if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY)
     {
         return;
     }
 
-    LOG_INFO("Cleaning up orphaned RetroCapture loopbacks...");
-
-    // Get list of all modules
-    std::vector<uint32_t> orphanedModules;
-    pa_operation *op = pa_context_get_module_info_list(m_context, moduleInfoCallback, &orphanedModules);
-
+    std::vector<uint32_t> stale;
+    pa_operation *op = pa_context_get_module_info_list(m_context, legacyModuleInfoCallback, &stale);
     if (op)
     {
         int ret = 0;
-        int maxIterations = 100;
-        int iteration = 0;
-
-        while (iteration < maxIterations)
+        for (int i = 0; i < 100; i++)
         {
             pa_mainloop_iterate(m_mainloop, 0, &ret);
-
-            pa_operation_state_t opState = pa_operation_get_state(op);
-            if (opState == PA_OPERATION_DONE || opState == PA_OPERATION_CANCELLED)
+            pa_operation_state_t st = pa_operation_get_state(op);
+            if (st == PA_OPERATION_DONE || st == PA_OPERATION_CANCELLED)
             {
                 break;
             }
-
             usleep(10000);
-            iteration++;
         }
-
         pa_operation_unref(op);
     }
 
-    // Remove orphaned modules (excluding the ones we're currently using)
-    for (uint32_t moduleIndex : orphanedModules)
+    for (uint32_t idx : stale)
     {
-        if (moduleIndex != m_inputLoopbackModuleIndex)
+        g_sinkOperationSuccess = false;
+        pa_operation *unloadOp = pa_context_unload_module(m_context, idx, unloadModuleCallback, this);
+        if (!unloadOp)
         {
-            g_sinkOperationSuccess = false;
-            pa_operation *unloadOp = pa_context_unload_module(m_context, moduleIndex, unloadModuleCallback, this);
-
-            if (unloadOp)
-            {
-                int ret = 0;
-                for (int i = 0; i < 50; i++)
-                {
-                    {
-                        std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-                        pa_mainloop_iterate(m_mainloop, 0, &ret);
-                    }
-                    if (g_sinkOperationSuccess)
-                    {
-                        break;
-                    }
-                    usleep(10000);
-                }
-                pa_operation_unref(unloadOp);
-            }
+            continue;
         }
-    }
-
-    if (!orphanedModules.empty())
-    {
-        LOG_INFO("Cleaned up " + std::to_string(orphanedModules.size()) + " orphaned loopback(s)");
-    }
-
-    // Also clean up any orphaned sink inputs
-    cleanupOrphanedSinkInputs();
-}
-
-// Static variables for sink input cleanup
-static std::vector<uint32_t> g_retroCaptureSinkInputs;
-static std::mutex g_sinkInputsMutex;
-static uint32_t g_retroCaptureSinkIndex = PA_INVALID_INDEX;
-
-// Callback to get RetroCapture sink index
-static void getRetroCaptureSinkIndexCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata)
-{
-    (void)c;
-    (void)userdata;
-    if (eol < 0 || eol > 0)
-    {
-        return;
-    }
-    if (i && strcmp(i->name, "RetroCapture") == 0)
-    {
-        g_retroCaptureSinkIndex = i->index;
-    }
-}
-
-// Static callback to find RetroCapture sink inputs
-static void sinkInputInfoCallback(pa_context *c, const pa_sink_input_info *i, int eol, void *userdata)
-{
-    (void)c;
-    (void)userdata;
-
-    if (eol < 0 || eol > 0)
-    {
-        return;
-    }
-
-    if (i)
-    {
-        // Check if this sink input is connected to RetroCapture sink
-        if (i->sink == g_retroCaptureSinkIndex && g_retroCaptureSinkIndex != PA_INVALID_INDEX)
-        {
-            // This sink input is connected to RetroCapture sink
-            // Check if it's a loopback (has "loopback" in name or properties)
-            bool isLoopback = false;
-
-            if (i->name && strstr(i->name, "loopback") != nullptr)
-            {
-                isLoopback = true;
-            }
-
-            // Also check properties
-            if (!isLoopback && i->proplist)
-            {
-                const char *mediaName = pa_proplist_gets(i->proplist, PA_PROP_MEDIA_NAME);
-                if (mediaName && (strstr(mediaName, "RetroCapture") != nullptr ||
-                                  strstr(mediaName, "loopback") != nullptr))
-                {
-                    isLoopback = true;
-                }
-            }
-
-            if (isLoopback)
-            {
-                std::lock_guard<std::mutex> lock(g_sinkInputsMutex);
-                g_retroCaptureSinkInputs.push_back(i->index);
-            }
-        }
-    }
-}
-
-void AudioCapturePulse::cleanupOrphanedSinkInputs()
-{
-    if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY)
-    {
-        return;
-    }
-
-    // First, get RetroCapture sink index
-    g_retroCaptureSinkIndex = PA_INVALID_INDEX;
-    pa_operation *sinkOp = pa_context_get_sink_info_by_name(m_context, "RetroCapture", getRetroCaptureSinkIndexCallback, this);
-    if (sinkOp)
-    {
         int ret = 0;
         for (int i = 0; i < 50; i++)
         {
-            {
-                std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-                pa_mainloop_iterate(m_mainloop, 0, &ret);
-            }
-            if (g_retroCaptureSinkIndex != PA_INVALID_INDEX)
-            {
-                break;
-            }
+            pa_mainloop_iterate(m_mainloop, 0, &ret);
+            if (g_sinkOperationSuccess) break;
             usleep(10000);
         }
-        pa_operation_unref(sinkOp);
+        pa_operation_unref(unloadOp);
     }
 
-    // If RetroCapture sink doesn't exist, there are no sink inputs to clean
-    if (g_retroCaptureSinkIndex == PA_INVALID_INDEX)
+    if (!stale.empty())
     {
-        return;
+        LOG_INFO("gcLegacyRetroCaptureModules: unloaded " +
+                 std::to_string(stale.size()) + " pre-0.8 module(s)");
+    }
+}
+
+bool AudioCapturePulse::startPublishSource()
+{
+    if (m_publisher)
+    {
+        return true;
+    }
+    if (!m_context || pa_context_get_state(m_context) != PA_CONTEXT_READY || !m_bus)
+    {
+        return false;
     }
 
-    // Clear previous list
+    // Per-process temp dir keeps the FIFO away from anything the user
+    // might create at /tmp, and lets us `rmdir` cleanly on shutdown.
+    char dirTemplate[] = "/tmp/retrocapture-XXXXXX";
+    if (!mkdtemp(dirTemplate))
     {
-        std::lock_guard<std::mutex> lock(g_sinkInputsMutex);
-        g_retroCaptureSinkInputs.clear();
+        LOG_ERROR("startPublishSource: mkdtemp failed: " +
+                  std::string(std::strerror(errno)));
+        return false;
+    }
+    m_fifoDir  = dirTemplate;
+    m_fifoPath = m_fifoDir + "/RetroCapture.fifo";
+
+    if (mkfifo(m_fifoPath.c_str(), 0600) != 0)
+    {
+        LOG_ERROR("startPublishSource: mkfifo(" + m_fifoPath + ") failed: " +
+                  std::string(std::strerror(errno)));
+        rmdir(m_fifoDir.c_str());
+        m_fifoDir.clear();
+        m_fifoPath.clear();
+        return false;
     }
 
-    // Get list of all sink inputs connected to RetroCapture sink
-    pa_operation *op = pa_context_get_sink_input_info_list(m_context, sinkInputInfoCallback, this);
+    // Format mirrors the bus exactly so a future DSP stage doesn't need
+    // sample-rate conversion between input and publish.
+    std::string args = "source_name=RetroCapture "
+                       "file=" + m_fifoPath + " "
+                       "format=s16le "
+                       "rate=" + std::to_string(m_sampleRate) + " "
+                       "channels=" + std::to_string(m_channels) + " "
+                       "source_properties=device.description=\"RetroCapture\"";
 
-    if (op)
+    g_sinkOperationSuccess = false;
+    g_moduleIndex          = PA_INVALID_INDEX;
+
+    pa_operation *op = pa_context_load_module(m_context, "module-pipe-source",
+                                              args.c_str(),
+                                              operationCallback, this);
+    if (!op)
     {
-        int ret = 0;
-        int maxIterations = 100;
-        int iteration = 0;
+        LOG_ERROR("startPublishSource: pa_context_load_module failed: " +
+                  std::string(pa_strerror(pa_context_errno(m_context))));
+        unlink(m_fifoPath.c_str());
+        rmdir(m_fifoDir.c_str());
+        m_fifoPath.clear();
+        m_fifoDir.clear();
+        return false;
+    }
 
-        while (iteration < maxIterations)
+    int ret = 0;
+    for (int i = 0; i < 200; i++)
+    {
+        pa_mainloop_iterate(m_mainloop, 0, &ret);
+        if (g_sinkOperationSuccess && g_moduleIndex != PA_INVALID_INDEX)
         {
-            {
-                std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-                pa_mainloop_iterate(m_mainloop, 0, &ret);
-            }
-
-            pa_operation_state_t opState = pa_operation_get_state(op);
-            if (opState == PA_OPERATION_DONE || opState == PA_OPERATION_CANCELLED)
-            {
-                break;
-            }
-
-            usleep(10000);
-            iteration++;
+            break;
         }
+        pa_operation_state_t st = pa_operation_get_state(op);
+        if (st == PA_OPERATION_DONE || st == PA_OPERATION_CANCELLED)
+        {
+            break;
+        }
+        usleep(5000);
+    }
+    pa_operation_unref(op);
 
-        pa_operation_unref(op);
+    if (!g_sinkOperationSuccess || g_moduleIndex == PA_INVALID_INDEX)
+    {
+        LOG_ERROR("startPublishSource: module-pipe-source load did not "
+                  "complete successfully");
+        unlink(m_fifoPath.c_str());
+        rmdir(m_fifoDir.c_str());
+        m_fifoPath.clear();
+        m_fifoDir.clear();
+        return false;
+    }
+    m_pipeSourceModuleIndex = g_moduleIndex;
+
+    // ~2 s slack matches the local tap; drop-oldest if a downstream
+    // pipe-source consumer stalls so we don't snowball memory.
+    auto publishTap = m_bus->createTap(static_cast<size_t>(m_sampleRate) *
+                                       m_channels * 2);
+
+    m_publisher = std::make_unique<PipeSourcePublisher>();
+    if (!m_publisher->start(m_fifoPath, std::move(publishTap)))
+    {
+        LOG_ERROR("startPublishSource: PipeSourcePublisher failed to open FIFO");
+        m_publisher.reset();
+        // Unload the module we just loaded so we don't leak a half-set-up source.
+        g_sinkOperationSuccess = false;
+        pa_operation *unload = pa_context_unload_module(m_context,
+                                                        m_pipeSourceModuleIndex,
+                                                        unloadModuleCallback,
+                                                        this);
+        if (unload)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                pa_mainloop_iterate(m_mainloop, 0, &ret);
+                if (g_sinkOperationSuccess) break;
+                usleep(5000);
+            }
+            pa_operation_unref(unload);
+        }
+        m_pipeSourceModuleIndex = PA_INVALID_INDEX;
+        unlink(m_fifoPath.c_str());
+        rmdir(m_fifoDir.c_str());
+        m_fifoPath.clear();
+        m_fifoDir.clear();
+        return false;
     }
 
-    // Get the list of sink inputs to remove
-    std::vector<uint32_t> orphanedSinkInputs;
+    LOG_INFO("Published virtual source 'RetroCapture' (fifo=" + m_fifoPath + ")");
+    return true;
+}
+
+void AudioCapturePulse::resyncMonitor()
+{
+    if (m_monitor)
     {
-        std::lock_guard<std::mutex> lock(g_sinkInputsMutex);
-        orphanedSinkInputs = g_retroCaptureSinkInputs;
+        m_monitor->requestResync();
+    }
+}
+
+void AudioCapturePulse::stopPublishSource()
+{
+    if (m_publisher)
+    {
+        m_publisher->stop();
+        m_publisher.reset();
     }
 
-    // Remove orphaned sink inputs
-    for (uint32_t sinkInputIndex : orphanedSinkInputs)
+    if (m_pipeSourceModuleIndex != PA_INVALID_INDEX && m_context &&
+        pa_context_get_state(m_context) == PA_CONTEXT_READY)
     {
-        pa_operation *killOp = pa_context_kill_sink_input(m_context, sinkInputIndex, nullptr, nullptr);
-        if (killOp)
+        g_sinkOperationSuccess = false;
+        pa_operation *op = pa_context_unload_module(m_context,
+                                                    m_pipeSourceModuleIndex,
+                                                    unloadModuleCallback,
+                                                    this);
+        if (op)
         {
             int ret = 0;
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 100; i++)
             {
-                {
-                    std::lock_guard<std::mutex> mainloopLock(m_mainloopMutex);
-                    pa_mainloop_iterate(m_mainloop, 0, &ret);
-                }
-                usleep(10000);
+                pa_mainloop_iterate(m_mainloop, 0, &ret);
+                if (g_sinkOperationSuccess) break;
+                usleep(5000);
             }
-            pa_operation_unref(killOp);
+            pa_operation_unref(op);
         }
     }
+    m_pipeSourceModuleIndex = PA_INVALID_INDEX;
 
-    if (!orphanedSinkInputs.empty())
+    if (!m_fifoPath.empty())
     {
-        LOG_INFO("Cleaned up " + std::to_string(orphanedSinkInputs.size()) + " orphaned sink input(s)");
+        unlink(m_fifoPath.c_str());
+        m_fifoPath.clear();
+    }
+    if (!m_fifoDir.empty())
+    {
+        rmdir(m_fifoDir.c_str());
+        m_fifoDir.clear();
     }
 }

--- a/src/audio/AudioCapturePulse.h
+++ b/src/audio/AudioCapturePulse.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "IAudioCapture.h"
+#include "AudioBus.h"
+#include "PipeSourcePublisher.h"
+#include "MonitorPlayback.h"
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -13,9 +16,7 @@ struct pa_context;
 struct pa_stream;
 struct pa_mainloop;
 struct pa_mainloop_api;
-struct pa_sink_info;
 struct pa_source_info;
-struct pa_sink_input_info;
 
 /**
  * @brief PulseAudio implementation of IAudioCapture for Linux
@@ -49,13 +50,30 @@ public:
     void setAudioCallback(std::function<void(const int16_t *data, size_t samples)> callback);
 
     // Audio input management
-    // Input: connect audio source directly to RetroCapture:input_FL/FR ports (for capture)
+    // Switch to a different PulseAudio source as the input device. Tears
+    // down the existing record stream and reconnects against the new
+    // source. Empty string means "PulseAudio default device".
     bool connectInputSource(const std::string &sourceName);
+    // Detach the input device. Closes the record stream but keeps the PA
+    // context alive so a subsequent connectInputSource() reattaches
+    // immediately.
     void disconnectInputSource();
     std::string getCurrentInputSource() const { return m_currentInputSourceName; }
     
     // List available devices
     std::vector<AudioDeviceInfo> listInputSources(); // Audio sources (inputs)
+
+    // In-process fan-out bus. Owned by this capture; other consumers
+    // (e.g. the module-pipe-source publisher exposing the `RetroCapture`
+    // virtual source) attach a Tap and pull at their own pace. Lives as
+    // long as the capture is open.
+    AudioBus *getBus() const { return m_bus.get(); }
+
+    // Drop any backlog accumulated in the monitor playback (typically
+    // after a stall) so the user hears live audio again instead of the
+    // delayed buffer that built up during the stall. Safe to call from
+    // any thread; no-op if monitor is not running.
+    void resyncMonitor();
 
 private:
     // PulseAudio callbacks
@@ -63,7 +81,6 @@ private:
     static void streamStateCallback(pa_stream *s, void *userdata);
     static void streamReadCallback(pa_stream *s, size_t length, void *userdata);
     static void streamSuccessCallback(pa_stream *s, int success, void *userdata);
-    static void sinkInfoCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
     static void sourceInfoCallback(pa_context *c, const pa_source_info *i, int eol, void *userdata);
     static void operationCallback(pa_context *c, uint32_t index, void *userdata);
 
@@ -73,20 +90,30 @@ private:
     void streamRead(size_t length);
     bool initializePulseAudio();
     void cleanupPulseAudio();
-    bool createVirtualSink();
-    void removeVirtualSink();
+    // Build + connect a PA_STREAM_RECORD stream against `device` (empty
+    // == PulseAudio default). Replaces any existing m_stream.
+    bool connectRecordStream(const std::string &device);
+    // Disconnect and free m_stream without touching the PA context.
+    void disconnectRecordStream();
+    // Create the FIFO, load module-pipe-source with source_name=
+    // `RetroCapture`, and spawn the writer thread that drains the bus
+    // into the FIFO. Together these publish the virtual source visible
+    // to the rest of the OS audio graph.
+    bool startPublishSource();
+    void stopPublishSource();
     void waitForContextReady();
-    void cleanupOrphanedLoopbacks();
-    void cleanupOrphanedSinkInputs();
+    // One-shot migration GC: unloads any module-null-sink (sink_name=
+    // RetroCapture) and module-loopback (feeding sink=RetroCapture)
+    // left behind by pre-0.8 RetroCapture binaries on this host. No-op
+    // on a clean graph. Safe to drop in a future release once the
+    // 0.7→0.8 transition window has closed.
+    void gcLegacyRetroCaptureModules();
 
     // PulseAudio objects
     pa_mainloop *m_mainloop;
     pa_mainloop_api *m_mainloopApi;
     pa_context *m_context;
     pa_stream *m_stream;
-    uint32_t m_virtualSinkIndex;      // RetroCapture sink index
-    uint32_t m_moduleIndex;            // Module index for RetroCapture sink
-    uint32_t m_inputLoopbackModuleIndex;  // Module index for input source connection
 
     // Audio format
     uint32_t m_sampleRate;
@@ -98,9 +125,28 @@ private:
     bool m_isOpen;
     bool m_isCapturing;
 
-    // Audio buffer (thread-safe)
-    std::vector<int16_t> m_audioBuffer;
-    std::mutex m_bufferMutex;
+    // In-process fan-out + the local tap that backs getSamples().
+    // The old m_audioBuffer is now this tap's queue; the producer side
+    // (streamRead) pushes into m_bus, every live tap (including this
+    // one) receives a copy, and getSamples() drains m_localTap.
+    std::unique_ptr<AudioBus>      m_bus;
+    std::shared_ptr<AudioBus::Tap> m_localTap;
+
+    // module-pipe-source publisher: FIFO + writer thread that exposes
+    // the `RetroCapture` virtual source to the OS audio graph (the
+    // "input" half of the RetroCapture I/O pair).
+    std::unique_ptr<PipeSourcePublisher> m_publisher;
+    uint32_t                              m_pipeSourceModuleIndex = 0; // PA_INVALID_INDEX sentinel set in ctor
+    std::string                           m_fifoPath;
+    std::string                           m_fifoDir;
+
+    // Local monitor playback (the "output" half of the RetroCapture
+    // I/O pair) — drains a tap into PulseAudio's default sink so the
+    // user hears the captured audio without any pavucontrol routing.
+    // Mirror of the client's AudioPlaybackPulse semantics. Owned by us
+    // (not delegated to module-loopback) so a future DSP chain can
+    // sit between the bus and the playback.
+    std::unique_ptr<MonitorPlayback> m_monitor;
     
     // Mainloop mutex (thread-safe access to pa_mainloop)
     std::mutex m_mainloopMutex;

--- a/src/audio/MonitorPlayback.cpp
+++ b/src/audio/MonitorPlayback.cpp
@@ -1,0 +1,130 @@
+#include "MonitorPlayback.h"
+
+#include "../utils/Logger.h"
+
+#include <pulse/simple.h>
+#include <pulse/error.h>
+#include <chrono>
+#include <vector>
+
+MonitorPlayback::~MonitorPlayback()
+{
+    stop();
+}
+
+bool MonitorPlayback::start(std::shared_ptr<AudioBus::Tap> tap,
+                            uint32_t sampleRate, uint32_t channels)
+{
+    if (m_running.load())
+    {
+        return true;
+    }
+    if (!tap || sampleRate == 0 || channels == 0 || channels > 8)
+    {
+        LOG_ERROR("MonitorPlayback::start — invalid args");
+        return false;
+    }
+
+    pa_sample_spec spec;
+    spec.format   = PA_SAMPLE_S16LE;
+    spec.rate     = sampleRate;
+    spec.channels = static_cast<uint8_t>(channels);
+
+    pa_buffer_attr attr;
+    attr.maxlength = static_cast<uint32_t>(-1);
+    attr.tlength   = pa_usec_to_bytes(50 * 1000, &spec);
+    attr.prebuf    = static_cast<uint32_t>(-1);
+    attr.minreq    = static_cast<uint32_t>(-1);
+    attr.fragsize  = static_cast<uint32_t>(-1);
+
+    int err = 0;
+    m_stream = pa_simple_new(nullptr,
+                             "RetroCapture",
+                             PA_STREAM_PLAYBACK,
+                             nullptr,
+                             "Monitor",
+                             &spec,
+                             nullptr,
+                             &attr,
+                             &err);
+    if (!m_stream)
+    {
+        LOG_ERROR(std::string("MonitorPlayback: pa_simple_new failed — ") +
+                  pa_strerror(err));
+        return false;
+    }
+
+    m_sampleRate = sampleRate;
+    m_channels   = channels;
+    m_tap        = std::move(tap);
+    m_running    = true;
+    m_thread     = std::thread(&MonitorPlayback::writerLoop, this);
+    LOG_INFO("MonitorPlayback: opened " + std::to_string(sampleRate) +
+             " Hz x " + std::to_string(channels) + " ch");
+    return true;
+}
+
+void MonitorPlayback::stop()
+{
+    m_running = false;
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+    if (m_stream)
+    {
+        int err = 0;
+        pa_simple_flush(m_stream, &err);
+        pa_simple_free(m_stream);
+        m_stream = nullptr;
+    }
+    m_tap.reset();
+}
+
+void MonitorPlayback::writerLoop()
+{
+    constexpr size_t kChunkSamples = 882 * 2;
+    std::vector<int16_t> chunk(kChunkSamples);
+    std::vector<int16_t> drain;
+
+    while (m_running.load())
+    {
+        if (m_resyncPending.exchange(false))
+        {
+            // Toss everything currently queued in the tap so we
+            // restart from the newest samples the producer is
+            // pushing right now.
+            const size_t available = m_tap->available();
+            if (available > 0)
+            {
+                drain.resize(available);
+                m_tap->pull(drain.data(), available);
+            }
+            // Discard what PulseAudio already has buffered for
+            // playback. After this the stream is empty and the next
+            // pa_simple_write below will refill from "now".
+            int err = 0;
+            pa_simple_flush(m_stream, &err);
+            LOG_INFO("MonitorPlayback: resync (dropped " +
+                     std::to_string(available / (m_channels ? m_channels : 1)) +
+                     " queued frames)");
+        }
+
+        const size_t got = m_tap->pull(chunk.data(), chunk.size());
+        if (got == 0)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        int err = 0;
+        if (pa_simple_write(m_stream, chunk.data(),
+                            got * sizeof(int16_t), &err) < 0)
+        {
+            LOG_ERROR(std::string("MonitorPlayback: pa_simple_write failed — ") +
+                      pa_strerror(err));
+            m_running = false;
+            return;
+        }
+    }
+}

--- a/src/audio/MonitorPlayback.h
+++ b/src/audio/MonitorPlayback.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "AudioBus.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+struct pa_simple;
+
+/**
+ * Local monitor playback: pulls samples from an AudioBus tap and writes
+ * them to PulseAudio's default sink under the stream name `RetroCapture`.
+ *
+ * Mirror of the client's AudioPlaybackPulse — both use pa_simple to
+ * own the playback path in-process rather than delegate to a Pulse
+ * loopback module. Satisfies the "parity with client" requirement of
+ * issue #78 (the host-side symmetric output to the client's playback
+ * stream named `RetroCapture`) AND keeps the audio under our control
+ * so a future DSP chain can sit between the bus and the playback.
+ *
+ * The capture device's clock and the playback sink's clock are
+ * independent hardware crystals; even nominally-44100 Hz they differ
+ * by ppm and would drift visibly over a long session if we just
+ * blindly pa_simple_write everything the tap delivers. The writer
+ * loop watches tap backlog and discards excess samples once it crosses
+ * a small catch-up threshold — that bounds monitor latency to a small
+ * constant regardless of how the two clocks differ.
+ */
+class MonitorPlayback
+{
+public:
+    MonitorPlayback() = default;
+    ~MonitorPlayback();
+
+    MonitorPlayback(const MonitorPlayback &)            = delete;
+    MonitorPlayback &operator=(const MonitorPlayback &) = delete;
+
+    bool start(std::shared_ptr<AudioBus::Tap> tap,
+               uint32_t sampleRate, uint32_t channels);
+    void stop();
+    bool isRunning() const { return m_running.load(); }
+
+    // Snap monitor latency back to ~tlength (50 ms) by draining the
+    // tap and flushing PulseAudio's playback buffer at the next
+    // writer-thread iteration. Useful after a stall that left the
+    // monitor playing behind real-time. Cheap atomic flag — no
+    // cross-thread pa_simple call, no lock contention on the hot path.
+    void requestResync() { m_resyncPending = true; }
+
+private:
+    void writerLoop();
+
+    pa_simple                     *m_stream     = nullptr;
+    uint32_t                       m_sampleRate = 0;
+    uint32_t                       m_channels   = 0;
+    std::shared_ptr<AudioBus::Tap> m_tap;
+    std::atomic<bool>              m_running{false};
+    std::atomic<bool>              m_resyncPending{false};
+    std::thread                    m_thread;
+};

--- a/src/audio/PipeSourcePublisher.cpp
+++ b/src/audio/PipeSourcePublisher.cpp
@@ -1,0 +1,141 @@
+#include "PipeSourcePublisher.h"
+
+#include "../utils/Logger.h"
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include <vector>
+
+PipeSourcePublisher::~PipeSourcePublisher()
+{
+    stop();
+}
+
+bool PipeSourcePublisher::start(const std::string &fifoPath,
+                                std::shared_ptr<AudioBus::Tap> tap)
+{
+    if (m_running.load())
+    {
+        LOG_WARN("PipeSourcePublisher already running");
+        return true;
+    }
+    if (!tap)
+    {
+        LOG_ERROR("PipeSourcePublisher::start — null tap");
+        return false;
+    }
+
+    // O_NONBLOCK on the write end so the writer thread never blocks on
+    // a slow downstream PulseAudio consumer; we drop samples instead
+    // (drop-oldest is also what AudioBus::Tap does once at capacity).
+    m_fd = ::open(fifoPath.c_str(), O_WRONLY | O_NONBLOCK);
+    if (m_fd < 0)
+    {
+        LOG_ERROR("PipeSourcePublisher: open(" + fifoPath + ") failed: " +
+                  std::string(std::strerror(errno)));
+        return false;
+    }
+
+    m_tap     = std::move(tap);
+    m_running = true;
+    m_thread  = std::thread(&PipeSourcePublisher::writerLoop, this);
+    return true;
+}
+
+void PipeSourcePublisher::stop()
+{
+    if (!m_running.exchange(false))
+    {
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+        return;
+    }
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+    if (m_fd >= 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+    m_tap.reset();
+}
+
+void PipeSourcePublisher::writerLoop()
+{
+    // ~10 ms chunks at 44.1 kHz stereo S16LE. Large enough to amortize
+    // syscall overhead, small enough to stay below the FIFO's PIPE_BUF
+    // so partial writes don't fragment frames the reader has to
+    // reassemble. PIPE_BUF on Linux is 4096 bytes; an interleaved S16LE
+    // stereo block of 882 samples = 3528 bytes fits cleanly.
+    constexpr size_t kChunkSamples = 882 * 2;
+    std::vector<int16_t> chunk(kChunkSamples);
+
+    while (m_running.load())
+    {
+        const size_t got = m_tap->pull(chunk.data(), chunk.size());
+        if (got == 0)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        const char *p          = reinterpret_cast<const char *>(chunk.data());
+        size_t      remaining  = got * sizeof(int16_t);
+        bool        droppedAny = false;
+
+        while (remaining > 0 && m_running.load())
+        {
+            const ssize_t w = ::write(m_fd, p, remaining);
+            if (w > 0)
+            {
+                p         += w;
+                remaining -= static_cast<size_t>(w);
+                continue;
+            }
+            if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            {
+                // FIFO full — pipe-source isn't draining fast enough.
+                // Drop the unwritten remainder of this chunk rather than
+                // backing up the in-process bus. Log only the first
+                // occurrence per session at WARN level; subsequent ones
+                // are silent so a chronic mismatch doesn't flood logs.
+                droppedAny = true;
+                break;
+            }
+            if (w < 0 && errno == EINTR)
+            {
+                continue;
+            }
+            if (w < 0 && errno == EPIPE)
+            {
+                // Reader side gone — module-pipe-source unloaded. Exit
+                // the loop; stop() will close the fd.
+                LOG_INFO("PipeSourcePublisher: reader closed FIFO, exiting");
+                m_running = false;
+                return;
+            }
+            // Anything else is unexpected.
+            LOG_ERROR("PipeSourcePublisher: write failed: " +
+                      std::string(std::strerror(errno)));
+            m_running = false;
+            return;
+        }
+
+        if (droppedAny)
+        {
+            static std::atomic<bool> warned{false};
+            if (!warned.exchange(true))
+            {
+                LOG_WARN("PipeSourcePublisher: pipe-source FIFO full, "
+                         "dropping samples (consumer behind)");
+            }
+        }
+    }
+}

--- a/src/audio/PipeSourcePublisher.h
+++ b/src/audio/PipeSourcePublisher.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "AudioBus.h"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+/**
+ * Drains an AudioBus tap into a PulseAudio module-pipe-source FIFO.
+ *
+ * The module itself (the one that publishes the `RetroCapture` virtual
+ * source to the rest of the OS audio graph) is loaded/unloaded by the
+ * caller, which already owns the PulseAudio context. Keeping the PA
+ * context out of this class avoids cross-thread pa_context_* calls —
+ * the writer thread here only does FIFO IO.
+ */
+class PipeSourcePublisher
+{
+public:
+    PipeSourcePublisher() = default;
+    ~PipeSourcePublisher();
+
+    PipeSourcePublisher(const PipeSourcePublisher &)            = delete;
+    PipeSourcePublisher &operator=(const PipeSourcePublisher &) = delete;
+
+    // Opens `fifoPath` for writing (non-blocking) and spawns the writer
+    // thread. Caller must have already loaded module-pipe-source so the
+    // read end of the FIFO is attached, otherwise open() returns ENXIO
+    // and start() fails. Returns false on any setup error.
+    bool start(const std::string &fifoPath, std::shared_ptr<AudioBus::Tap> tap);
+
+    // Signals the writer thread to exit, joins it and closes the fd.
+    // Safe to call from any thread; idempotent.
+    void stop();
+
+    bool isRunning() const { return m_running.load(); }
+
+private:
+    void writerLoop();
+
+    int                            m_fd = -1;
+    std::atomic<bool>              m_running{false};
+    std::thread                    m_thread;
+    std::shared_ptr<AudioBus::Tap> m_tap;
+};

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -3118,8 +3118,18 @@ bool Application::initAudioCapture()
         LOG_WARN("RecordingManager not initialized - recording will not be available");
     }
 
-    // Open default audio device (will create virtual sink)
-    if (!m_audioCapture->open())
+    // Use the saved input source if any (set via UI / web portal in a
+    // previous session). Empty string falls back to PulseAudio's default
+    // source. Replaces the old "open() creates a null-sink and a
+    // separate restoreAudioDeviceConnections() loops the saved source
+    // into it" two-step.
+    std::string savedSource;
+    if (m_ui)
+    {
+        savedSource = m_ui->getAudioInputSourceId();
+    }
+
+    if (!m_audioCapture->open(savedSource))
     {
         LOG_ERROR("Failed to open audio device");
         m_audioCapture.reset();
@@ -3151,29 +3161,10 @@ bool Application::initAudioCapture()
 
 void Application::restoreAudioDeviceConnections()
 {
-    if (!m_audioCapture || !m_ui)
-    {
-        return;
-    }
-
-#ifdef __linux__
-    AudioCapturePulse *pulseCapture = dynamic_cast<AudioCapturePulse *>(m_audioCapture.get());
-    if (!pulseCapture)
-    {
-        return;
-    }
-
-    std::string savedInputSourceId = m_ui->getAudioInputSourceId();
-    if (!savedInputSourceId.empty())
-    {
-        usleep(500000);
-        if (!pulseCapture->connectInputSource(savedInputSourceId))
-        {
-            LOG_WARN("Failed to restore audio input source: " + savedInputSourceId);
-        }
-    }
-
-#endif
+    // Obsolete since 0.8.0-alpha: the saved input source is now passed
+    // directly to AudioCapturePulse::open() during initAudioCapture(),
+    // so there is no separate "load a loopback module into a null-sink"
+    // step to restore. Kept as a no-op for callers that still invoke it.
 }
 
 void Application::run()

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -611,6 +611,10 @@ bool APIController::handlePOST(int clientFd, const std::string &path, const std:
     {
         return handleDisconnectAudioInput(clientFd);
     }
+    else if (path == "/api/v1/audio/resync")
+    {
+        return handleResyncAudioMonitor(clientFd);
+    }
     else if (path == "/api/v1/source/overscan")
     {
         return handleSetSourceOverscan(clientFd, body);
@@ -3103,6 +3107,40 @@ bool APIController::handleDisconnectAudioInput(int clientFd)
     }
 #else
     sendErrorResponse(clientFd, 400, "Audio source selection only available on Linux");
+    return true;
+#endif
+}
+
+bool APIController::handleResyncAudioMonitor(int clientFd)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+
+    IAudioCapture *audioCapture = m_application->getAudioCapture();
+    if (!audioCapture)
+    {
+        sendErrorResponse(clientFd, 400, "Audio capture not available");
+        return true;
+    }
+
+#ifdef __linux__
+    AudioCapturePulse *pulseCapture = dynamic_cast<AudioCapturePulse *>(audioCapture);
+    if (pulseCapture)
+    {
+        pulseCapture->resyncMonitor();
+        nlohmann::json response;
+        response["success"] = true;
+        response["message"] = "Monitor resync requested";
+        sendJSONResponse(clientFd, 200, response.dump());
+        return true;
+    }
+    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux");
+    return true;
+#else
+    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux");
     return true;
 #endif
 }

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -189,6 +189,7 @@ private:
     bool handleUpdatePresetParameters(int clientFd, const std::string &presetName, const std::string &body);
     bool handleSetAudioInputSource(int clientFd, const std::string &body);
     bool handleDisconnectAudioInput(int clientFd);
+    bool handleResyncAudioMonitor(int clientFd);
 
     // Recording profiles (saved snapshots of recording configuration)
     bool handleGETRecordingProfiles(int clientFd);

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -111,9 +111,10 @@ void UIConfigurationAudio::refreshInputSources()
 void UIConfigurationAudio::renderInputSourceSelection()
 {
     ui_section_header("Audio input",
-                      "Pick the audio source captured alongside video. "
-                      "The selection is shared between streaming and "
-                      "recording.");
+                      "Pick the capture-card audio device. RetroCapture "
+                      "records directly from it and republishes the "
+                      "stream as the 'RetroCapture' source so other apps "
+                      "(DAWs, monitors) can pick it up.");
 
     if (!m_audioCapture)
     {
@@ -162,19 +163,17 @@ void UIConfigurationAudio::renderInputSourceSelection()
         sourceNamesCStr.push_back(name.c_str());
     }
 
-    // Input source selection combo
+    // Device dropdown drives the input directly — no more loopback hop
+    // through a virtual sink.
     int prevSelectedIndex = m_selectedInputSourceIndex;
-    if (ImGui::Combo("Input Source", &m_selectedInputSourceIndex, sourceNamesCStr.data(), static_cast<int>(sourceNamesCStr.size())))
+    if (ImGui::Combo("Input device", &m_selectedInputSourceIndex, sourceNamesCStr.data(), static_cast<int>(sourceNamesCStr.size())))
     {
-        // Source changed
         if (m_selectedInputSourceIndex >= 0 && m_selectedInputSourceIndex < static_cast<int>(m_inputSourceIds.size()))
         {
             std::string selectedSourceId = m_inputSourceIds[m_selectedInputSourceIndex];
-            
+
             if (pulseCapture->connectInputSource(selectedSourceId))
             {
-                ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Input source connected successfully");
-                // Save configuration
                 if (m_uiManager)
                 {
                     m_uiManager->setAudioInputSourceId(selectedSourceId);
@@ -183,8 +182,7 @@ void UIConfigurationAudio::renderInputSourceSelection()
             }
             else
             {
-                ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Failed to connect input source");
-                // Revert selection
+                ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Failed to open input device");
                 m_selectedInputSourceIndex = prevSelectedIndex;
             }
         }
@@ -192,18 +190,27 @@ void UIConfigurationAudio::renderInputSourceSelection()
 
     ImGui::Spacing();
 
-    // Current input source info
     std::string currentSource = pulseCapture->getCurrentInputSource();
     if (!currentSource.empty())
     {
-        ImGui::Text("Current Input: %s", currentSource.c_str());
-        
+        ImGui::Text("Capturing from: %s", currentSource.c_str());
+        ImGui::Text("Format: %u Hz, %u channel%s",
+                    pulseCapture->getSampleRate(),
+                    pulseCapture->getChannels(),
+                    pulseCapture->getChannels() == 1 ? "" : "s");
+        ImGui::TextColored(ImVec4(0.6f, 0.9f, 0.6f, 1.0f),
+                           "Published as 'RetroCapture' source");
+
         ImGui::Spacing();
-        if (ImGui::Button("Disconnect Input Source"))
+        if (ImGui::Button("Resync monitor"))
+        {
+            pulseCapture->resyncMonitor();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Stop capture"))
         {
             pulseCapture->disconnectInputSource();
             m_selectedInputSourceIndex = -1;
-            // Save configuration (clear saved source)
             if (m_uiManager)
             {
                 m_uiManager->setAudioInputSourceId("");
@@ -213,9 +220,10 @@ void UIConfigurationAudio::renderInputSourceSelection()
     }
     else
     {
-        ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.0f, 1.0f), "No input source connected");
-        ImGui::TextWrapped("Select an input source above to connect it to RetroCapture. "
-                         "The selected source will be captured for streaming and recording.");
+        ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.0f, 1.0f), "No input device selected");
+        ImGui::TextWrapped("Pick a device above to start capturing. "
+                           "RetroCapture will record from it and publish "
+                           "the audio as the 'RetroCapture' source.");
     }
 #endif
 }

--- a/src/web/api.js
+++ b/src/web/api.js
@@ -282,6 +282,10 @@ class RetroCaptureAPI {
     async disconnectAudioInput() {
         return await this.request('POST', '/audio/disconnect-input');
     }
+
+    async resyncAudioMonitor() {
+        return await this.request('POST', '/audio/resync');
+    }
 }
 
 // Instância global da API

--- a/src/web/config.html
+++ b/src/web/config.html
@@ -801,27 +801,33 @@
                                                 </div>
                                                 <div class="card-body">
                                                     <div class="mb-3">
-                                                        <label class="form-label">Select Input Source</label>
+                                                        <label class="form-label">Input device</label>
                                                         <div class="input-group">
                                                             <select class="form-select" id="audioInputSource">
-                                                                <option value="">Loading sources...</option>
+                                                                <option value="">Loading devices...</option>
                                                             </select>
-                                                            <button class="btn btn-outline-secondary" type="button" onclick="refreshAudioInputSources()" title="Refresh sources">
+                                                            <button class="btn btn-outline-secondary" type="button" onclick="refreshAudioInputSources()" title="Refresh devices">
                                                                 <i class="bi bi-arrow-clockwise"></i>
                                                             </button>
                                                         </div>
-                                                        <small class="form-text text-muted">Select the audio source to capture for streaming and recording</small>
+                                                        <small class="form-text text-muted">Pick the capture-card audio device. RetroCapture records from it and republishes the stream as the 'RetroCapture' source so other apps can pick it up.</small>
                                                     </div>
-                                                    <div class="d-flex gap-2">
+                                                    <div class="d-flex gap-2 flex-wrap">
                                                         <button type="button" class="btn btn-primary" id="connectInputBtn" onclick="connectAudioInput()">
-                                                            <i class="bi bi-plug me-1"></i>Connect
+                                                            <i class="bi bi-plug me-1"></i>Start capture
+                                                        </button>
+                                                        <button type="button" class="btn btn-outline-secondary" id="resyncMonitorBtn" onclick="resyncAudioMonitor()" disabled title="Drop monitor backlog and play live audio again">
+                                                            <i class="bi bi-arrow-counterclockwise me-1"></i>Resync monitor
                                                         </button>
                                                         <button type="button" class="btn btn-secondary" id="disconnectInputBtn" onclick="disconnectAudioInput()" disabled>
-                                                            <i class="bi bi-plug-fill me-1"></i>Disconnect
+                                                            <i class="bi bi-plug-fill me-1"></i>Stop capture
                                                         </button>
                                                     </div>
                                                     <div class="mt-2">
-                                                        <small class="text-muted" id="currentInputSource">No source connected</small>
+                                                        <small class="text-muted" id="currentInputSource">No input device selected</small>
+                                                    </div>
+                                                    <div class="mt-1">
+                                                        <small class="text-muted" id="currentInputFormat"></small>
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/web/control.js
+++ b/src/web/control.js
@@ -2111,7 +2111,7 @@ async function loadAudioInputSources() {
  */
 async function refreshAudioInputSources() {
     await loadAudioInputSources();
-    showAlert('Input sources refreshed', 'success');
+    showAlert('Input devices refreshed', 'success');
 }
 
 /**
@@ -2121,8 +2121,8 @@ function updateAudioInputSourceSelect() {
     const select = document.getElementById('audioInputSource');
     if (!select) return;
 
-    select.innerHTML = '<option value="">Select input source...</option>';
-    
+    select.innerHTML = '<option value="">Select input device...</option>';
+
     audioState.inputSources.forEach(source => {
         const option = document.createElement('option');
         option.value = source.id;
@@ -2141,6 +2141,7 @@ function updateAudioInputSourceSelect() {
 function updateAudioUI() {
     const statusInfo = document.getElementById('audioStatusInfo');
     const currentInputSource = document.getElementById('currentInputSource');
+    const currentInputFormat = document.getElementById('currentInputFormat');
     const connectBtn = document.getElementById('connectInputBtn');
     const disconnectBtn = document.getElementById('disconnectInputBtn');
 
@@ -2157,9 +2158,19 @@ function updateAudioUI() {
     if (currentInputSource) {
         if (audioState.status.currentInputSource) {
             const source = audioState.inputSources.find(s => s.id === audioState.status.currentInputSource);
-            currentInputSource.textContent = `Connected: ${source ? (source.description || source.name) : audioState.status.currentInputSource}`;
+            const label = source ? (source.description || source.name) : audioState.status.currentInputSource;
+            currentInputSource.textContent = `Capturing from: ${label} — published as 'RetroCapture' source`;
         } else {
-            currentInputSource.textContent = 'No source connected';
+            currentInputSource.textContent = 'No input device selected';
+        }
+    }
+
+    if (currentInputFormat) {
+        if (audioState.status.open && audioState.status.currentInputSource) {
+            currentInputFormat.textContent =
+                `Format: ${audioState.status.sampleRate} Hz, ${audioState.status.channels} channel${audioState.status.channels === 1 ? '' : 's'}`;
+        } else {
+            currentInputFormat.textContent = '';
         }
     }
 
@@ -2167,6 +2178,8 @@ function updateAudioUI() {
     const hasInput = !!audioState.status.currentInputSource;
     if (connectBtn) connectBtn.disabled = hasInput;
     if (disconnectBtn) disconnectBtn.disabled = !hasInput;
+    const resyncBtn = document.getElementById('resyncMonitorBtn');
+    if (resyncBtn) resyncBtn.disabled = !hasInput;
 }
 
 /**
@@ -2175,33 +2188,47 @@ function updateAudioUI() {
 async function connectAudioInput() {
     const select = document.getElementById('audioInputSource');
     if (!select || !select.value) {
-        showAlert('Please select an input source', 'warning');
+        showAlert('Please pick an input device', 'warning');
         return;
     }
 
     try {
         await api.setAudioInputSource(select.value);
-        showAlert('Input source connected', 'success');
+        showAlert('Capturing from selected device', 'success');
         await loadAudioStatus();
         updateAudioInputSourceSelect();
     } catch (error) {
-        console.error('Failed to conectar fonte de entrada:', error);
-        showAlert(`Failed to conectar fonte: ${error.message}`, 'danger');
+        console.error('Failed to start capture:', error);
+        showAlert(`Failed to start capture: ${error.message}`, 'danger');
     }
 }
 
 /**
- * Disconnect audio input source
+ * Stop capturing from the selected input device.
  */
 async function disconnectAudioInput() {
     try {
         await api.disconnectAudioInput();
-        showAlert('Input source disconnected', 'success');
+        showAlert('Capture stopped', 'success');
         await loadAudioStatus();
         updateAudioInputSourceSelect();
     } catch (error) {
-        console.error('Failed to desconectar fonte de entrada:', error);
-        showAlert(`Failed to desconectar fonte: ${error.message}`, 'danger');
+        console.error('Failed to stop capture:', error);
+        showAlert(`Failed to stop capture: ${error.message}`, 'danger');
+    }
+}
+
+/**
+ * Force the monitor playback to drop any backlog (typically after a
+ * stall) and snap back to live audio.
+ */
+async function resyncAudioMonitor() {
+    try {
+        await api.resyncAudioMonitor();
+        showAlert('Monitor resync requested', 'success');
+    } catch (error) {
+        console.error('Failed to resync monitor:', error);
+        showAlert(`Failed to resync monitor: ${error.message}`, 'danger');
     }
 }
 


### PR DESCRIPTION
Closes #78.

Replace the pre-0.8 host audio plumbing (`module-null-sink` + `module-loopback` into it, recording from `.monitor`, "route an app into RetroCapture via pavucontrol") with a symmetric `RetroCapture` source/sink pair that mirrors what the client-side `AudioPlaybackPulse` has always done.

## What's in here

### Architecture

- **`AudioBus`** — in-process fan-out shared between encoder/recorder, the published `RetroCapture` source, and the host monitor playback. Single owned pipeline; explicit seam for the future DSP chain follow-up.
- **`PA_STREAM_RECORD` directly** against the user-picked input device. The null-sink is gone.
- **`PipeSourcePublisher`** (`module-pipe-source source_name=RetroCapture`) — publishes what we capture as a virtual source so DAWs, monitoring chains, etc. can record from it. The "input" half of the symmetric pair.
- **`MonitorPlayback`** (`pa_simple` PLAYBACK stream named `RetroCapture`) — plays the captured audio to the user's default sink, so picking a device is audible immediately without any pavucontrol routing. Mirror of the client's `AudioPlaybackPulse`. Kept in-process rather than delegated to `module-loopback` so a future DSP chain can sit between the bus and the playback.

### UX

- **Audio tab** (native + web portal) copy updated to "Input device" / "Start capture" / "Stop capture" with a live "Format: \<Hz\>, \<ch\>" status line and an explicit "Published as 'RetroCapture' source" indicator while capturing.
- **Resync monitor** button (native + web portal, `POST /api/v1/audio/resync`) — drains tap backlog and calls `pa_simple_flush` so the monitor snaps back to ~50 ms latency. Useful when a stall accumulates a delay between captured audio and what the user hears.

### Lifecycle / cleanup

- One-shot legacy GC at startup: unloads any pre-0.8 `module-null-sink sink_name=RetroCapture` and matching `module-loopback` so upgrades from 0.7.x don't leave stale modules in the PulseAudio graph.
- Saved input source is passed directly to `AudioCapturePulse::open()` during init, replacing the old `restoreAudioDeviceConnections()` two-step (load null-sink, then load loopback into it).
- `~700 lines` of dead null-sink / loopback scaffolding removed from `AudioCapturePulse` (`createVirtualSink`, `removeVirtualSink`, `cleanupOrphanedLoopbacks`, `cleanupOrphanedSinkInputs`, their callbacks and dead module-index state).

## Scope

- **Linux only.** WASAPI loopback already works differently on Windows; the host audio path on Windows is untouched in this release.

## Test plan

- [x] Linux x86_64 build (Docker) clean
- [x] Linux arm64v8 build (Docker) clean
- [x] Linux arm32v7 build (Docker) clean
- [x] Windows x86_64 build (MXE/Docker) clean — confirmed the new Pulse-bound sources (`PipeSourcePublisher`, `MonitorPlayback`, `AudioBus`) are correctly excluded on Windows
- [x] Smoke on live x86_64 binary: `pactl list short sources` shows `RetroCapture s16le 2ch 44100Hz`; `pactl list short modules` shows `module-pipe-source source_name=RetroCapture file=/tmp/retrocapture-XXXXXX/RetroCapture.fifo`
- [x] Picking a device under the Audio tab triggers `module-pipe-source` load + `MonitorPlayback` stream open; audio is audible through the default sink without pavucontrol intervention
- [x] Resync button drains backlog and snaps monitor latency back to ~50 ms after a stall

## Known limitations

- Long-running monitor sessions may exhibit gradual A/V drift in the **local monitor** (capture device clock vs default sink clock — two independent hardware crystals). The Resync button is the manual lever for now; a smooth sample-rate-matching pass is a follow-up.