### PR TITLE
feat(macos): x86_64 port — AVFoundation + Core Audio + .app bundle (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,63 @@ had via `AudioPlaybackPulse`.
   DeviceConnections` two-step (the saved input source is now passed
   directly to `AudioCapturePulse::open()` during init).
 
+### Added
+
+- **macOS x86_64 port — first working build of host + client modes**
+  (#18). Cherry-picked the older `18-port-to-macos-13-or-later-x86_64`
+  branch's backend files onto current 0.8.0-alpha and rebuilt the
+  user-facing surface in 0.8 idioms. Highlights:
+  - Video capture via `VideoCaptureAVFoundation` with the runtime
+    camera-permission probe pattern (`AVAuthorizationStatusForMedia-
+    Type:AVMediaTypeVideo`) so the dropdown is no longer empty
+    silently. Format dropdown is OBS-style (resolution + fps range +
+    pixel format picked atomically per device). Format changes do a
+    close+reopen because macOS reverts `activeFormat` mid-session;
+    output dimensions are forced via `videoSettings`'
+    `kCVPixelBufferWidthKey/HeightKey` because
+    `AVCaptureSessionPresetInputPriority` is iOS-only on the macOS
+    SDK. Framerate clamping via `AVFrameRateRange.minFrameDuration`
+    (with `@try/@catch` belt-and-suspenders) prevents
+    `NSInvalidArgumentException` on devices that only support
+    rational rates like 29.97.
+  - Audio capture via `AudioCaptureCoreAudio` mirroring Linux's
+    `AudioCapturePulse` architecture: same `AudioBus` fan-out, a
+    local tap backing `getSamples`, plus an in-class monitor
+    playback (`AudioOutputCoreAudio` + writer thread) — the macOS
+    counterpart of `MonitorPlayback`. AudioUnit gets bound to the
+    user-selected device via `kAudioOutputUnitProperty_CurrentDevice`
+    BEFORE format negotiation, then adopts the device's native
+    sample rate / channel count so UVC cards that run at 48 kHz /
+    mono / float32 don't fail with
+    `-10863 kAudioUnitErr_CannotDoInCurrentContext`. Microphone
+    permission probe lives at the top of `open()`.
+  - Client-mode remote-stream playback via the new
+    `AudioPlaybackCoreAudio` (adapts `IAudioPlayback`'s float-PCM +
+    PTS API onto `AudioOutputCoreAudio`'s int16 push).
+  - `MediaEncoder::convertRGBToYUV` clamps odd source heights to the
+    nearest even value before `sws_scale` — macOS window framebuffer
+    (1080 minus menu bar ≈ 953) is odd, and libswscale 9.x's AVX2
+    fastpath would `EXC_BAD_ACCESS` on the unaligned tail.
+  - Auto-open of the saved AVFoundation device + format on
+    `SourceType::AVFoundation` activation, so the first frame after
+    launch is the same capture the user had in the previous session.
+  - Native UI + web portal expose AVFoundation device / format and
+    Core Audio input device pickers; the `Resync monitor` button
+    works on macOS too.
+- See `docs/MACOS_PORT_STRATEGY.md` for the full inventory of
+  resolved gotchas and the follow-up list (`.app` bundle with
+  `Info.plist` permission strings, codesigning, macOS source
+  publisher equivalent of `module-pipe-source`, Apple Silicon
+  build, CI/release integration).
+
 ### Scope
 
-- Linux only. WASAPI loopback already works differently on Windows;
-  the host audio path on Windows is untouched in this release.
+- Linux audio refactor (#78) is Linux-only — WASAPI loopback already
+  works differently on Windows; the host audio path on Windows is
+  untouched in this release.
+- macOS port (#18) lands x86_64 only and depends on Homebrew FFmpeg /
+  GLFW / libpng; build via `tools/build-macos.sh` on the Mac itself
+  (no cross-compile from Linux).
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,7 +476,10 @@ elseif(PLATFORM_WINDOWS)
     list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2DeviceScanner\\.(cpp|h)$") # V4L2DeviceScanner é Linux
     list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2ControlMapper\\.(cpp|h)$") # V4L2ControlMapper é Linux
 elseif(PLATFORM_MACOS)
-    # No macOS, excluir implementações Linux e Windows
+    # No macOS, excluir implementações Linux e Windows.
+    # Note: `AudioBus` is platform-agnostic (std::deque + mutex) and is
+    # used by both AudioCapturePulse on Linux and AudioCaptureCoreAudio
+    # on macOS, so it is NOT excluded here.
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureV4L2\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureDS\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*DSFrameGrabber\\.(cpp|h)$")
@@ -485,7 +488,6 @@ elseif(PLATFORM_MACOS)
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureWASAPI\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*PipeSourcePublisher\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*MonitorPlayback\\.(cpp|h)$")
-    list(FILTER SOURCES EXCLUDE REGEX ".*AudioBus\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
 
     # Excluir arquivos Linux genéricos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,14 @@ endif()
 if(PLATFORM_LINUX)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(PNG REQUIRED libpng)
+elseif(PLATFORM_MACOS)
+    # macOS: tentar pkg-config primeiro (Homebrew), depois find_package
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PNG REQUIRED libpng)
+    else()
+        find_package(PNG REQUIRED)
+    endif()
 else()
     # Windows: tentar pkg-config primeiro (MXE), depois find_package
     find_package(PkgConfig QUIET)
@@ -182,6 +190,32 @@ if(PLATFORM_LINUX)
     if(AVFORMAT_VERSION)
         string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" AVFORMAT_VERSION_MAJOR "${AVFORMAT_VERSION}")
         message(STATUS "Detected libavformat version: ${AVFORMAT_VERSION} (major: ${AVFORMAT_VERSION_MAJOR})")
+    endif()
+elseif(PLATFORM_MACOS)
+    # macOS: tentar pkg-config (Homebrew), depois find_package
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(AVCODEC REQUIRED libavcodec)
+        pkg_check_modules(AVFORMAT REQUIRED libavformat)
+        pkg_check_modules(AVUTIL REQUIRED libavutil)
+        pkg_check_modules(SWSCALE REQUIRED libswscale)
+        pkg_check_modules(SWRESAMPLE REQUIRED libswresample)
+    else()
+        find_package(FFmpeg QUIET COMPONENTS avcodec avformat avutil swscale swresample)
+        if(FFmpeg_FOUND)
+            set(AVCODEC_LIBRARIES avcodec)
+            set(AVFORMAT_LIBRARIES avformat)
+            set(AVUTIL_LIBRARIES avutil)
+            set(SWSCALE_LIBRARIES swscale)
+            set(SWRESAMPLE_LIBRARIES swresample)
+            set(AVCODEC_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS})
+            set(AVFORMAT_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS})
+            set(AVUTIL_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS})
+            set(SWSCALE_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS})
+            set(SWRESAMPLE_INCLUDE_DIRS ${FFmpeg_INCLUDE_DIRS})
+        else()
+            message(FATAL_ERROR "FFmpeg não encontrado. Instale via Homebrew: brew install ffmpeg")
+        endif()
     endif()
 else()
     # Windows: usar pkg-config (MXE) ou find_package (vcpkg)
@@ -395,16 +429,20 @@ endif()
 # Fontes
 file(GLOB_RECURSE SOURCES
     "src/*.cpp"
+    "src/*.mm"
     "src/*.h"
 )
 
 # Excluir implementações de outras plataformas
 if(PLATFORM_LINUX)
-    # No Linux, excluir implementações Windows (quando existirem)
+    # No Linux, excluir implementações Windows e macOS
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureDS\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*DSFrameGrabber\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*DSPin\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureWASAPI\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio\\.(mm|h)$")
 
     # Excluir WindowManager baseado na opção BUILD_WITH_SDL2
     if(BUILD_WITH_SDL2)
@@ -415,13 +453,16 @@ if(PLATFORM_LINUX)
         list(FILTER SOURCES EXCLUDE REGEX ".*/WindowManagerSDL\\.cpp$")
     endif()
 elseif(PLATFORM_WINDOWS)
-    # No Windows, excluir implementações Linux
+    # No Windows, excluir implementações Linux e macOS
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureV4L2\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCapturePulse\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*PipeSourcePublisher\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*MonitorPlayback\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioBus\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio\\.(mm|h)$")
 
     # Excluir arquivos Linux genéricos que não têm versão Windows
     list(FILTER SOURCES EXCLUDE REGEX ".*/VideoCapture\\.cpp$") # VideoCapture.cpp é Linux
@@ -434,6 +475,27 @@ elseif(PLATFORM_WINDOWS)
     # list(FILTER SOURCES EXCLUDE REGEX ".*/FrameProcessor\\.cpp$") # FrameProcessor.cpp agora suporta Windows
     list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2DeviceScanner\\.(cpp|h)$") # V4L2DeviceScanner é Linux
     list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2ControlMapper\\.(cpp|h)$") # V4L2ControlMapper é Linux
+elseif(PLATFORM_MACOS)
+    # No macOS, excluir implementações Linux e Windows
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureV4L2\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureDS\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*DSFrameGrabber\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*DSPin\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioCapturePulse\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureWASAPI\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*PipeSourcePublisher\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*MonitorPlayback\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioBus\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
+
+    # Excluir arquivos Linux genéricos
+    list(FILTER SOURCES EXCLUDE REGEX ".*/VideoCapture\\.cpp$") # VideoCapture.cpp é Linux
+    list(FILTER SOURCES EXCLUDE REGEX ".*/AudioCapture\\.cpp$") # AudioCapture.cpp é Linux
+    list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2DeviceScanner\\.(cpp|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*/V4L2ControlMapper\\.(cpp|h)$")
+
+    # macOS usa GLFW (não SDL2 por padrão)
+    list(FILTER SOURCES EXCLUDE REGEX ".*/WindowManagerSDL\\.cpp$")
 endif()
 
 # Executável principal
@@ -543,6 +605,28 @@ if(PLATFORM_LINUX)
     endif()
 
     list(APPEND LINK_LIBS ${V4L2_LIBRARIES} ${PULSE_LIBRARIES} ${PULSE_SIMPLE_LIBRARIES})
+elseif(PLATFORM_MACOS)
+    # macOS frameworks discovered via find_library; the ones that
+    # need -framework syntax (AVFoundation, CoreAudio, etc.) are
+    # passed directly to target_link_libraries below since they
+    # don't follow the regular library-search-path convention.
+    find_library(COCOA_LIB Cocoa)
+    find_library(IOKIT_LIB IOKit)
+    find_library(COREVIDEO_LIB CoreVideo)
+    find_library(VIDEOTOOLBOX_LIB VideoToolbox)
+
+    if(COCOA_LIB)
+        list(APPEND LINK_LIBS ${COCOA_LIB})
+    endif()
+    if(IOKIT_LIB)
+        list(APPEND LINK_LIBS ${IOKIT_LIB})
+    endif()
+    if(COREVIDEO_LIB)
+        list(APPEND LINK_LIBS ${COREVIDEO_LIB})
+    endif()
+    if(VIDEOTOOLBOX_LIB)
+        list(APPEND LINK_LIBS ${VIDEOTOOLBOX_LIB})
+    endif()
 elseif(PLATFORM_WINDOWS)
     # Windows DirectShow libraries
     list(APPEND LINK_LIBS
@@ -560,6 +644,19 @@ elseif(PLATFORM_WINDOWS)
 endif()
 
 target_link_libraries(retrocapture PRIVATE ${LINK_LIBS})
+
+# macOS-specific frameworks (need -framework syntax)
+if(PLATFORM_MACOS)
+    target_link_libraries(retrocapture PRIVATE
+        "-framework AVFoundation"
+        "-framework CoreAudio"
+        "-framework CoreVideo"
+        "-framework CoreMedia"
+        "-framework VideoToolbox"
+        "-framework Foundation"
+        "-framework AudioToolbox"
+    )
+endif()
 
 # MinGW-w64 precisa linkar com stdc++fs para filesystem (GCC 8+)
 # Para GCC < 8, nossa implementação manual usa shlwapi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,7 +442,7 @@ if(PLATFORM_LINUX)
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureWASAPI\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
-    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
 
     # Excluir WindowManager baseado na opção BUILD_WITH_SDL2
     if(BUILD_WITH_SDL2)
@@ -462,7 +462,7 @@ elseif(PLATFORM_WINDOWS)
     list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
-    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
 
     # Excluir arquivos Linux genéricos que não têm versão Windows
     list(FILTER SOURCES EXCLUDE REGEX ".*/VideoCapture\\.cpp$") # VideoCapture.cpp é Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ if(PLATFORM_LINUX)
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
 
     # Excluir WindowManager baseado na opção BUILD_WITH_SDL2
     if(BUILD_WITH_SDL2)
@@ -463,6 +464,7 @@ elseif(PLATFORM_WINDOWS)
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
 
     # Excluir arquivos Linux genéricos que não têm versão Windows
     list(FILTER SOURCES EXCLUDE REGEX ".*/VideoCapture\\.cpp$") # VideoCapture.cpp é Linux

--- a/docs/MACOS_BUILD.md
+++ b/docs/MACOS_BUILD.md
@@ -1,0 +1,150 @@
+# Build e Teste no macOS
+
+Este documento descreve como compilar e testar o RetroCapture no macOS 13 x86.
+
+## Pré-requisitos
+
+### 1. Homebrew
+
+Se você ainda não tem o Homebrew instalado:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### 2. Instalar Dependências
+
+Execute o script de instalação de dependências:
+
+```bash
+./tools/install-deps-macos.sh
+```
+
+Este script instala:
+- **CMake** - Sistema de build
+- **GLFW** - Gerenciamento de janelas
+- **FFmpeg** - Streaming e encoding (libavcodec, libavformat, libavutil, libswscale, libswresample)
+- **libpng** - Carregamento de imagens
+- **pkg-config** - Detecção de dependências
+
+## Build
+
+### Build Release (Recomendado)
+
+```bash
+./tools/build-macos.sh Release
+```
+
+### Build Debug
+
+```bash
+./tools/build-macos.sh Debug
+```
+
+O executável será gerado em: `build-macos-$(uname -m)/bin/retrocapture`
+
+## Teste
+
+### Teste Rápido (Modo Dummy)
+
+```bash
+./tools/test-macos.sh
+```
+
+Este script testa o RetroCapture em modo dummy (sem dispositivo físico).
+
+### Teste com Dispositivo Real
+
+```bash
+# Listar dispositivos disponíveis
+./build-macos-$(uname -m)/bin/retrocapture --source avfoundation
+
+# Capturar de dispositivo específico
+./build-macos-$(uname -m)/bin/retrocapture \
+  --source avfoundation \
+  --width 1920 \
+  --height 1080 \
+  --fps 60
+```
+
+## Permissões Necessárias
+
+O RetroCapture precisa de permissões do macOS para:
+
+1. **Câmera**: System Preferences > Security & Privacy > Camera
+2. **Microfone**: System Preferences > Security & Privacy > Microphone
+
+Na primeira execução, o macOS solicitará essas permissões automaticamente.
+
+## Solução de Problemas
+
+### Erro: "Dependências faltando"
+
+Execute:
+```bash
+./tools/install-deps-macos.sh
+```
+
+### Erro: "FFmpeg não encontrado"
+
+Verifique se o FFmpeg está instalado:
+```bash
+brew list ffmpeg
+pkg-config --modversion libavcodec
+```
+
+Se não estiver instalado:
+```bash
+brew install ffmpeg
+```
+
+### Erro: "GLFW não encontrado"
+
+Verifique se o GLFW está instalado:
+```bash
+brew list glfw
+pkg-config --modversion glfw3
+```
+
+Se não estiver instalado:
+```bash
+brew install glfw
+```
+
+### Erro de Compilação: "Objective-C++"
+
+Certifique-se de que os arquivos `.mm` estão sendo compilados corretamente. O CMakeLists.txt já está configurado para isso.
+
+### Erro: "Permissão negada para câmera"
+
+1. Vá em System Preferences > Security & Privacy > Camera
+2. Marque a opção para o RetroCapture
+3. Reinicie o aplicativo
+
+## Estrutura de Build
+
+```
+build-macos-$(uname -m)/
+├── bin/
+│   └── retrocapture          # Executável principal
+├── shaders/                  # Shaders copiados
+├── web/                      # Web portal copiado
+├── ssl/                      # Certificados SSL copiados
+└── assets/                   # Assets copiados
+```
+
+## Próximos Passos
+
+Após o build bem-sucedido:
+
+1. Teste a captura de vídeo com um dispositivo real
+2. Teste a captura de áudio
+3. Teste a aplicação de shaders
+4. Teste o streaming HTTP MPEG-TS
+5. Teste a gravação local
+
+## Referências
+
+- [AVFoundation Programming Guide](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/)
+- [Core Audio Overview](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/)
+- [GLFW macOS Guide](https://www.glfw.org/docs/latest/build_guide.html#build_link_cmake)

--- a/docs/MACOS_PORT_STRATEGY.md
+++ b/docs/MACOS_PORT_STRATEGY.md
@@ -1,0 +1,214 @@
+# Estratégia de Port para macOS 13 x86
+
+## Visão Geral
+
+Este documento descreve a estratégia para portar o RetroCapture para macOS 13 (x86/Intel), incluindo decisões técnicas, implementações necessárias e plano de ação.
+
+## Análise do Estado Atual
+
+### ✅ O que já está pronto
+
+- **CMakeLists.txt**: Já detecta macOS e define `PLATFORM_MACOS`
+- **Arquitetura de abstração**: Interfaces `IVideoCapture` e `IAudioCapture` facilitam o port
+- **OpenGL**: Suportado no macOS (limitado a 4.1, deprecated mas funcional)
+- **GLFW**: Suporta macOS nativamente
+- **FFmpeg**: Suporta macOS via Homebrew
+- **Dependências cross-platform**: ImGui, nlohmann/json funcionam no macOS
+
+### ❌ O que precisa ser implementado
+
+1. **VideoCaptureAVFoundation**: Captura de vídeo via AVFoundation
+2. **AudioCaptureCoreAudio**: Captura de áudio via Core Audio
+3. **Atualizações no CMakeLists.txt**: Dependências e linking específicos do macOS
+4. **Atualizações nas Factories**: Suporte a macOS
+5. **Ajustes no main.cpp**: Argumentos CLI para macOS
+6. **Ajustes no Application.cpp**: Inicialização específica
+
+## Decisões Técnicas
+
+### 1. Captura de Vídeo: AVFoundation
+
+**Por quê?**
+- API nativa e oficial da Apple
+- Suporta dispositivos UVC (USB Video Class)
+- Boa performance e integração com o sistema
+- Suporte a múltiplos formatos (YUYV, MJPEG, etc.)
+
+**Implementação:**
+- Usar `AVCaptureSession`, `AVCaptureDevice`, `AVCaptureVideoDataOutput`
+- Converter `CVPixelBuffer` para formato compatível (YUYV ou RGB)
+- Suportar listagem de dispositivos
+- Implementar controles básicos (se disponíveis via AVCaptureDevice)
+
+**Desafios:**
+- AVFoundation é Objective-C, precisa de bridge para C++
+- Permissões de câmera (NSCameraUsageDescription no Info.plist)
+- Conversão de formatos pode ter overhead
+
+### 2. Captura de Áudio: Core Audio
+
+**Por quê?**
+- API nativa do macOS
+- Suporta captura de sistema (via BlackHole ou Loopback)
+- Boa performance e baixa latência
+- Compatível com o padrão do projeto
+
+**Implementação:**
+- Usar `AudioUnit` ou `AVAudioEngine` para captura
+- Para captura de sistema, recomendar BlackHole (dispositivo virtual)
+- Suportar listagem de dispositivos de áudio
+
+**Desafios:**
+- Core Audio é C/Objective-C, precisa de bridge
+- Captura de sistema requer dispositivo virtual (BlackHole)
+- Permissões de microfone (NSMicrophoneUsageDescription)
+
+### 3. Renderização: OpenGL 4.1 (Temporário)
+
+**Por quê?**
+- OpenGL 4.1 ainda funciona no macOS 13
+- Evita reescrever todos os shaders imediatamente
+- Permite port funcional rápido
+
+**Futuro:**
+- Considerar migração para Metal (melhor performance, suporte oficial)
+- Ou usar MoltenVK (Vulkan sobre Metal) para manter compatibilidade
+
+## Plano de Implementação
+
+### Fase 1: Implementação Mínima (Funcional)
+
+**Objetivo**: Ter um build funcional que capture vídeo e áudio básico
+
+1. ✅ Atualizar CMakeLists.txt
+   - Adicionar frameworks: AVFoundation, CoreAudio, CoreVideo, VideoToolbox
+   - Configurar linking correto
+   - Excluir arquivos Linux/Windows do build macOS
+
+2. ✅ Criar VideoCaptureAVFoundation
+   - Implementar interface IVideoCapture
+   - Captura básica de vídeo
+   - Listagem de dispositivos
+   - Modo dummy para testes
+
+3. ✅ Criar AudioCaptureCoreAudio
+   - Implementar interface IAudioCapture
+   - Captura básica de áudio
+   - Listagem de dispositivos
+   - Suporte a BlackHole para captura de sistema
+
+4. ✅ Atualizar Factories
+   - VideoCaptureFactory: adicionar caso macOS
+   - AudioCaptureFactory: adicionar caso macOS
+
+5. ✅ Atualizar main.cpp
+   - Adicionar source type "avfoundation" para macOS
+   - Ajustar argumentos CLI
+
+6. ✅ Atualizar Application.cpp
+   - Inicialização específica do macOS
+   - Device paths padrão
+
+### Fase 2: Funcionalidades Completas
+
+1. Controles de hardware (se disponíveis)
+2. Permissões (câmera/microfone)
+3. Testes completos
+4. Documentação
+
+### Fase 3: Otimizações (Futuro)
+
+1. Migração para Metal (opcional)
+2. Aceleração por hardware (VideoToolbox)
+3. Melhorias de performance
+
+## Estrutura de Arquivos
+
+```
+src/
+├── capture/
+│   ├── VideoCaptureAVFoundation.h
+│   └── VideoCaptureAVFoundation.cpp
+├── audio/
+│   ├── AudioCaptureCoreAudio.h
+│   └── AudioCaptureCoreAudio.cpp
+```
+
+## Dependências macOS
+
+### Frameworks Necessários
+
+- **AVFoundation**: Captura de vídeo
+- **CoreAudio**: Captura de áudio
+- **CoreVideo**: Processamento de vídeo
+- **VideoToolbox**: Aceleração por hardware (futuro)
+- **Foundation**: Base do Objective-C
+
+### Bibliotecas Externas
+
+- **FFmpeg**: Via Homebrew (`brew install ffmpeg`)
+- **GLFW**: Via Homebrew (`brew install glfw`)
+- **OpenGL**: Incluído no macOS
+- **libpng**: Via Homebrew (`brew install libpng`)
+
+## Permissões Necessárias
+
+### Info.plist (para distribuição)
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>RetroCapture precisa acessar a câmera para captura de vídeo</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>RetroCapture precisa acessar o microfone para captura de áudio</string>
+```
+
+## Build no macOS
+
+### Pré-requisitos
+
+```bash
+# Instalar Homebrew (se não tiver)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Instalar dependências
+brew install cmake glfw ffmpeg libpng pkg-config
+```
+
+### Build
+
+```bash
+mkdir build && cd build
+cmake ..
+make -j$(sysctl -n hw.ncpu)
+```
+
+## Testes
+
+### Testes Básicos
+
+1. **Captura de vídeo**: Verificar se consegue listar e capturar de webcam
+2. **Captura de áudio**: Verificar se consegue capturar áudio
+3. **Shaders**: Testar aplicação de shaders básicos
+4. **Streaming**: Testar streaming HTTP MPEG-TS
+5. **Gravação**: Testar gravação local
+
+## Limitações Conhecidas
+
+1. **OpenGL deprecated**: Funciona mas pode ser removido no futuro
+2. **Permissões**: Requer permissões de câmera/microfone
+3. **Captura de sistema**: Requer BlackHole ou similar para áudio
+4. **Controles de hardware**: Podem não estar disponíveis em todos os dispositivos
+
+## Próximos Passos
+
+1. Implementar VideoCaptureAVFoundation
+2. Implementar AudioCaptureCoreAudio
+3. Atualizar CMakeLists.txt
+4. Atualizar Factories
+5. Testar build e funcionalidades básicas
+
+## Referências
+
+- [AVFoundation Programming Guide](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/)
+- [Core Audio Overview](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/)
+- [GLFW macOS Guide](https://www.glfw.org/docs/latest/build_guide.html#build_link_cmake)

--- a/docs/MACOS_PORT_STRATEGY.md
+++ b/docs/MACOS_PORT_STRATEGY.md
@@ -192,23 +192,86 @@ make -j$(sysctl -n hw.ncpu)
 4. **Streaming**: Testar streaming HTTP MPEG-TS
 5. **Gravação**: Testar gravação local
 
+## Estado Atual (0.8.0-alpha)
+
+Fase 1 + 2 concluídas. Funciona ponta-a-ponta nos dois papéis:
+
+- **Host**: AVFoundation video capture + Core Audio input + monitor playback
+  in-process via `AudioCaptureCoreAudio` (espelhando `AudioCapturePulse`
+  no Linux com `AudioBus` + tap + writer thread → `AudioOutputCoreAudio`).
+  Stream MPEG-TS + recording funcionam.
+- **Client**: `VideoCaptureRemote` decodifica /raw, áudio sai via
+  `AudioPlaybackCoreAudio` (adapter `IAudioPlayback` → `AudioOutputCoreAudio`).
+
+UI nativa expõe Source tab com AVFoundation device + format pickers
+(OBS-style — picking um format aplica resolution/fps/pixfmt
+atomicamente) e Audio tab com Core Audio device picker + Resync
+monitor button. Web portal espelha ambos via novos endpoints
+`/api/v1/avfoundation/*`.
+
+### Gotchas resolvidos (para não redescobrir)
+
+- **AudioUnit `CurrentDevice` antes do format query**: `AudioUnitGet-
+  Property(StreamFormat, Scope_Input, 1, ...)` retorna o default do
+  AudioUnit se chamado antes de `kAudioOutputUnitProperty_CurrentDevice`.
+- **Adotar SR/channels nativos do device**: hardcoded 44.1k stereo
+  16-bit produz `-10863 kAudioUnitErr_CannotDoInCurrentContext` em
+  UVC cards 48k mono float. Lê o formato do device e usa SR+channels
+  dele; converter só lida com bit-depth.
+- **`AVCaptureSessionPresetInputPriority` é iOS-only**: pra resolução
+  arbitrária via UVC, usar `videoSettings` no `AVCaptureVideoDataOutput`
+  (`kCVPixelBufferWidthKey/HeightKey/PixelFormatTypeKey`).
+- **Format change na sessão rodando reverte ao default**: `setActiveFormat:`
+  numa sessão running silenciosamente volta pro default. Mecanismo é
+  close + reopen via `setFormatById` (implementado).
+- **`AudioUnitSet/GetProperty(activeVideoMinFrameDuration)` lança NSException
+  pra rates não-suportados**: framerate clamping com `AVFrameRateRange.
+  minFrameDuration` + @try/@catch no `applyClosestFramerate`.
+- **`sws_scale` AVX2 crasha em source heights ímpares**: macOS window
+  framebuffer (1080 - menu bar ≈ 953) é ímpar. Clampar source height
+  pra par antes de `sws_scale` em `MediaEncoder::convertRGBToYUV`.
+
 ## Limitações Conhecidas
 
-1. **OpenGL deprecated**: Funciona mas pode ser removido no futuro
-2. **Permissões**: Requer permissões de câmera/microfone
-3. **Captura de sistema**: Requer BlackHole ou similar para áudio
-4. **Controles de hardware**: Podem não estar disponíveis em todos os dispositivos
+- **OpenGL deprecated**: Funciona mas pode ser removido no futuro
+  (migração pra Metal/MoltenVK é trabalho à parte)
+- **Sem .app bundle**: rodando como command-line binary, o macOS não
+  consegue exibir o prompt de permissão. User tem que adicionar
+  manualmente em System Settings → Privacy & Security → Camera /
+  Microphone. Bundle proper requer `Info.plist` com
+  `NSCameraUsageDescription` / `NSMicrophoneUsageDescription`.
+- **Sem codesigning**: Gatekeeper bloqueia execução de download na
+  primeira vez. Workaround: right-click → Open (uma vez).
+- **Captura de sistema**: ainda requer BlackHole / Loopback similar pra
+  ouvir output do sistema (situação igual à do Linux com PulseAudio
+  monitor.)
+- **Controles de hardware**: AVFoundation não expõe brightness/contrast/
+  exposure como V4L2 ou DirectShow; UI omite Hardware Controls em
+  AVFoundation.
+- **Sem publisher externo `RetroCapture` source**: no Linux a gente
+  carrega `module-pipe-source` pra expor o áudio capturado como source
+  PulseAudio que outros apps podem gravar. macOS não tem equivalente
+  user-space (precisa de AudioServerPlugIn signed kext ou BlackHole-
+  like). Seria follow-up issue.
 
-## Próximos Passos
+## Follow-ups (issues separadas)
 
-1. Implementar VideoCaptureAVFoundation
-2. Implementar AudioCaptureCoreAudio
-3. Atualizar CMakeLists.txt
-4. Atualizar Factories
-5. Testar build e funcionalidades básicas
+1. **`.app` bundle + permissions** — bundle com `Info.plist` carregando
+   `NSCamera/MicrophoneUsageDescription` pro macOS exibir o prompt de
+   permissão automaticamente. Inclui modificar `tools/build-macos.sh`
+   pra produzir o bundle além do binary cru.
+2. **Codesigning + notarization** — Developer ID + `xcrun notarytool
+   submit` no script de release pra distribuir sem Gatekeeper bloquear.
+3. **macOS source publisher** — equivalente do `module-pipe-source` no
+   Linux. Opções: AudioServerPlugIn bundle, ou wrapper sobre BlackHole.
+4. **Metal renderer (opcional)** — quando Apple deprecar OpenGL.
+5. **arm64 / Apple Silicon build** — atualmente só x86_64 (Rosetta).
+6. **macOS no CI / release pipeline** — atualmente o build-macos.sh roda
+   só localmente; integrar com os tarballs do release.
 
 ## Referências
 
 - [AVFoundation Programming Guide](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/)
 - [Core Audio Overview](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/)
 - [GLFW macOS Guide](https://www.glfw.org/docs/latest/build_guide.html#build_link_cmake)
+- [Apple — Requesting authorization to capture and save media](https://developer.apple.com/documentation/avfoundation/capture_setup/requesting_authorization_to_capture_and_save_media)

--- a/src/audio/AudioCaptureCoreAudio.h
+++ b/src/audio/AudioCaptureCoreAudio.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "IAudioCapture.h"
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <memory>
+#include <mutex>
+#include <functional>
+
+#ifdef __APPLE__
+#import <CoreAudio/CoreAudio.h>
+#import <AudioUnit/AudioUnit.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+// Forward declaration da estrutura de contexto
+struct AudioCaptureContext;
+#endif
+
+/**
+ * @brief Core Audio implementation of IAudioCapture for macOS
+ */
+class AudioCaptureCoreAudio : public IAudioCapture
+{
+public:
+    AudioCaptureCoreAudio();
+    ~AudioCaptureCoreAudio() override;
+
+    // Non-copyable
+    AudioCaptureCoreAudio(const AudioCaptureCoreAudio &) = delete;
+    AudioCaptureCoreAudio &operator=(const AudioCaptureCoreAudio &) = delete;
+
+    // IAudioCapture interface
+    bool open(const std::string &deviceName = "") override;
+    void close() override;
+    bool isOpen() const override;
+    size_t getSamples(std::vector<float> &samples) override;
+    uint32_t getSampleRate() const override;
+    uint32_t getChannels() const override;
+    std::vector<AudioDeviceInfo> listDevices() override;
+    void setDeviceStateCallback(std::function<void(const std::string &, bool)> callback) override;
+
+    // Additional Core Audio-specific methods (for backward compatibility)
+    bool startCapture() override;
+    void stopCapture() override;
+    size_t getSamples(int16_t *buffer, size_t maxSamples) override;
+    uint32_t getBytesPerSample() const override { return m_bytesPerSample; }
+
+    // Método público para callback acessar AudioUnit
+#ifdef __APPLE__
+    AudioComponentInstance getAudioUnit() const;
+#endif
+
+private:
+#ifdef __APPLE__
+    AudioComponentInstance m_audioUnit;
+    AudioComponent m_audioComponent;
+    AudioCaptureContext* m_context; // Ponteiro tipado
+    std::mutex m_bufferMutex;
+    std::vector<int16_t> m_audioBuffer;
+#endif
+
+    uint32_t m_sampleRate;
+    uint32_t m_channels;
+    uint32_t m_bytesPerSample;
+    bool m_isOpen;
+    bool m_isCapturing;
+    std::function<void(const std::string &, bool)> m_deviceStateCallback;
+
+    // Internal methods
+    bool initializeAudioUnit();
+    void cleanupAudioUnit();
+};

--- a/src/audio/AudioCaptureCoreAudio.h
+++ b/src/audio/AudioCaptureCoreAudio.h
@@ -97,7 +97,11 @@ private:
     std::thread                    m_monitorThread;
 
     // Internal methods
-    bool initializeAudioUnit();
+    // `requestedDeviceId` is the same id string `listDevices()` returns
+    // (decimal AudioDeviceID). Empty / unparseable → use system default
+    // input, which is the legacy behaviour from when this function
+    // ignored the deviceName entirely.
+    bool initializeAudioUnit(const std::string &requestedDeviceId);
     void cleanupAudioUnit();
     bool startMonitor();
     void stopMonitor();

--- a/src/audio/AudioCaptureCoreAudio.h
+++ b/src/audio/AudioCaptureCoreAudio.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include "IAudioCapture.h"
+#include "AudioBus.h"
+#include "IAudioOutput.h"
+#include <atomic>
 #include <cstdint>
 #include <vector>
 #include <string>
 #include <memory>
 #include <mutex>
 #include <functional>
+#include <thread>
 
 #ifdef __APPLE__
 #import <CoreAudio/CoreAudio.h>
@@ -51,13 +55,25 @@ public:
     AudioComponentInstance getAudioUnit() const;
 #endif
 
+    // In-process fan-out — mirror of Linux's AudioCapturePulse design.
+    // Producer is the Core Audio input callback; consumers (the
+    // encoder/recorder via getSamples, plus the host-side monitor) each
+    // hold an AudioBus::Tap. Exposed publicly so future consumers (a
+    // macOS source publisher, a DSP chain, etc.) can attach to the
+    // same bus without rearchitecting capture.
+    AudioBus *getBus() const { return m_bus.get(); }
+
+    // Drop any backlog accumulated in the host-side monitor (typically
+    // after a stall) so the user hears live audio again. Counterpart
+    // to AudioCapturePulse::resyncMonitor on Linux.
+    void resyncMonitor();
+
 private:
 #ifdef __APPLE__
     AudioComponentInstance m_audioUnit;
     AudioComponent m_audioComponent;
-    AudioCaptureContext* m_context; // Ponteiro tipado
+    AudioCaptureContext* m_context;
     std::mutex m_bufferMutex;
-    std::vector<int16_t> m_audioBuffer;
 #endif
 
     uint32_t m_sampleRate;
@@ -67,7 +83,23 @@ private:
     bool m_isCapturing;
     std::function<void(const std::string &, bool)> m_deviceStateCallback;
 
+    // In-process fan-out + the local tap that backs getSamples().
+    std::unique_ptr<AudioBus>      m_bus;
+    std::shared_ptr<AudioBus::Tap> m_localTap;
+
+    // Host-side monitor playback (Core Audio counterpart of Linux's
+    // MonitorPlayback). Owned here so the macOS audio side mirrors the
+    // "AudioCapturePulse owns its monitor" pattern from #78.
+    std::unique_ptr<IAudioOutput>  m_monitor;
+    std::shared_ptr<AudioBus::Tap> m_monitorTap;
+    std::atomic<bool>              m_monitorRunning{false};
+    std::atomic<bool>              m_monitorResyncPending{false};
+    std::thread                    m_monitorThread;
+
     // Internal methods
     bool initializeAudioUnit();
     void cleanupAudioUnit();
+    bool startMonitor();
+    void stopMonitor();
+    void monitorWriterLoop();
 };

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -1,0 +1,499 @@
+#include "AudioCaptureCoreAudio.h"
+#include "../utils/Logger.h"
+#include <algorithm>
+#include <cstring>
+
+#ifdef __APPLE__
+#import <CoreAudio/CoreAudio.h>
+#import <AudioUnit/AudioUnit.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+// Estrutura para passar dados para o callback (definida antes do uso)
+struct AudioCaptureContext
+{
+    AudioCaptureCoreAudio* capture;
+    std::mutex* bufferMutex;
+    std::vector<int16_t>* audioBuffer;
+};
+
+static OSStatus audioInputCallback(void *inRefCon,
+                                   AudioUnitRenderActionFlags *ioActionFlags,
+                                   const AudioTimeStamp *inTimeStamp,
+                                   UInt32 inBusNumber,
+                                   UInt32 inNumberFrames,
+                                   AudioBufferList *ioData)
+{
+    (void)ioActionFlags;
+    (void)inTimeStamp;
+    (void)inBusNumber;
+    (void)ioData;
+    
+    AudioCaptureContext* context = (AudioCaptureContext*)inRefCon;
+    if (!context || !context->capture)
+    {
+        return noErr;
+    }
+    
+    AudioUnitRenderActionFlags flags = 0;
+    AudioTimeStamp timeStamp = *inTimeStamp;
+    AudioBufferList bufferList;
+    bufferList.mNumberBuffers = 1;
+    bufferList.mBuffers[0].mNumberChannels = 2; // Stereo
+    bufferList.mBuffers[0].mDataByteSize = inNumberFrames * 2 * sizeof(int16_t);
+    bufferList.mBuffers[0].mData = nullptr;
+    
+    // Alocar buffer temporário
+    std::vector<int16_t> tempBuffer(inNumberFrames * 2);
+    bufferList.mBuffers[0].mData = tempBuffer.data();
+    
+    // Renderizar áudio
+    AudioComponentInstance audioUnit = context->capture->getAudioUnit();
+    OSStatus status = AudioUnitRender(audioUnit, &flags, &timeStamp, 1, inNumberFrames, &bufferList);
+    
+    if (status == noErr)
+    {
+        std::lock_guard<std::mutex> lock(*context->bufferMutex);
+        context->audioBuffer->insert(context->audioBuffer->end(), 
+                                     tempBuffer.begin(), 
+                                     tempBuffer.end());
+    }
+    
+    return status;
+}
+#endif
+
+AudioCaptureCoreAudio::AudioCaptureCoreAudio()
+#ifdef __APPLE__
+    : m_audioUnit(nullptr)
+    , m_audioComponent(nullptr)
+    , m_context(nullptr)
+    , m_bufferMutex()
+    , m_sampleRate(44100)
+    , m_channels(2)
+    , m_bytesPerSample(2) // 16-bit
+    , m_isOpen(false)
+    , m_isCapturing(false)
+#else
+    : m_sampleRate(44100)
+    , m_channels(2)
+    , m_bytesPerSample(2) // 16-bit
+    , m_isOpen(false)
+    , m_isCapturing(false)
+#endif
+{
+}
+
+AudioCaptureCoreAudio::~AudioCaptureCoreAudio()
+{
+    close();
+    cleanupAudioUnit();
+}
+
+#ifdef __APPLE__
+AudioComponentInstance AudioCaptureCoreAudio::getAudioUnit() const
+{
+    return m_audioUnit;
+}
+#endif
+
+bool AudioCaptureCoreAudio::open(const std::string &deviceName)
+{
+    if (m_isOpen)
+    {
+        LOG_WARN("Dispositivo de áudio já aberto, fechando primeiro");
+        close();
+    }
+
+#ifdef __APPLE__
+    if (!initializeAudioUnit())
+    {
+        LOG_ERROR("Falha ao inicializar AudioUnit");
+        return false;
+    }
+
+    m_isOpen = true;
+    LOG_INFO("Dispositivo de áudio aberto: " + (deviceName.empty() ? "default" : deviceName));
+    return true;
+#else
+    LOG_ERROR("Core Audio só está disponível no macOS");
+    return false;
+#endif
+}
+
+void AudioCaptureCoreAudio::close()
+{
+    if (m_isCapturing)
+    {
+        stopCapture();
+    }
+
+    m_isOpen = false;
+    LOG_INFO("Dispositivo de áudio fechado");
+}
+
+bool AudioCaptureCoreAudio::isOpen() const
+{
+    return m_isOpen;
+}
+
+size_t AudioCaptureCoreAudio::getSamples(std::vector<float> &samples)
+{
+    if (!m_isOpen || !m_isCapturing)
+    {
+        samples.clear();
+        return 0;
+    }
+
+#ifdef __APPLE__
+    std::lock_guard<std::mutex> lock(m_bufferMutex);
+    
+    if (m_audioBuffer.empty())
+    {
+        samples.clear();
+        return 0;
+    }
+
+    // Converter int16 para float
+    samples.resize(m_audioBuffer.size());
+    for (size_t i = 0; i < m_audioBuffer.size(); ++i)
+    {
+        samples[i] = m_audioBuffer[i] / 32768.0f;
+    }
+
+    m_audioBuffer.clear();
+    return samples.size();
+#else
+    samples.clear();
+    return 0;
+#endif
+}
+
+uint32_t AudioCaptureCoreAudio::getSampleRate() const
+{
+    return m_sampleRate;
+}
+
+uint32_t AudioCaptureCoreAudio::getChannels() const
+{
+    return m_channels;
+}
+
+std::vector<AudioDeviceInfo> AudioCaptureCoreAudio::listDevices()
+{
+    std::vector<AudioDeviceInfo> devices;
+
+#ifdef __APPLE__
+    // Listar dispositivos de entrada via Core Audio
+    UInt32 propertySize = 0;
+    AudioObjectPropertyAddress propertyAddress = {
+        kAudioHardwarePropertyDevices,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
+                                                     &propertyAddress,
+                                                     0,
+                                                     nullptr,
+                                                     &propertySize);
+    
+    if (status == noErr && propertySize > 0)
+    {
+        UInt32 deviceCount = propertySize / sizeof(AudioDeviceID);
+        AudioDeviceID* deviceIDs = new AudioDeviceID[deviceCount];
+        
+        status = AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                            &propertyAddress,
+                                            0,
+                                            nullptr,
+                                            &propertySize,
+                                            deviceIDs);
+        
+        if (status == noErr)
+        {
+            for (UInt32 i = 0; i < deviceCount; ++i)
+            {
+                // Verificar se é dispositivo de entrada
+                UInt32 inputStreamCount = 0;
+                propertySize = sizeof(inputStreamCount);
+                AudioObjectPropertyAddress streamProperty = {
+                    kAudioDevicePropertyStreams,
+                    kAudioDevicePropertyScopeInput,
+                    kAudioObjectPropertyElementMain
+                };
+                AudioObjectGetPropertyData(deviceIDs[i],
+                                          &streamProperty,
+                                          0,
+                                          nullptr,
+                                          &propertySize,
+                                          &inputStreamCount);
+                
+                if (inputStreamCount > 0)
+                {
+                    // Obter nome do dispositivo
+                    CFStringRef deviceName = nullptr;
+                    propertySize = sizeof(deviceName);
+                    AudioObjectPropertyAddress nameProperty = {
+                        kAudioDevicePropertyDeviceNameCFString,
+                        kAudioObjectPropertyScopeGlobal,
+                        kAudioObjectPropertyElementMain
+                    };
+                    AudioObjectGetPropertyData(deviceIDs[i],
+                                              &nameProperty,
+                                              0,
+                                              nullptr,
+                                              &propertySize,
+                                              &deviceName);
+                    
+                    AudioDeviceInfo info;
+                    info.id = std::to_string(deviceIDs[i]);
+                    if (deviceName)
+                    {
+                        char buffer[256];
+                        CFStringGetCString(deviceName, buffer, sizeof(buffer), kCFStringEncodingUTF8);
+                        info.name = std::string(buffer);
+                        CFRelease(deviceName);
+                    }
+                    else
+                    {
+                        info.name = "Audio Device " + info.id;
+                    }
+                    info.available = true;
+                    devices.push_back(info);
+                }
+            }
+        }
+        
+        delete[] deviceIDs;
+    }
+    
+    // Adicionar dispositivo padrão se não houver dispositivos
+    if (devices.empty())
+    {
+        AudioDeviceInfo defaultDevice;
+        defaultDevice.id = "default";
+        defaultDevice.name = "Default Audio Input";
+        defaultDevice.available = true;
+        devices.push_back(defaultDevice);
+    }
+#endif
+
+    return devices;
+}
+
+void AudioCaptureCoreAudio::setDeviceStateCallback(std::function<void(const std::string &, bool)> callback)
+{
+    m_deviceStateCallback = callback;
+}
+
+bool AudioCaptureCoreAudio::startCapture()
+{
+    if (!m_isOpen)
+    {
+        LOG_ERROR("Dispositivo de áudio não aberto");
+        return false;
+    }
+
+#ifdef __APPLE__
+    OSStatus status = AudioOutputUnitStart(m_audioUnit);
+    if (status == noErr)
+    {
+        m_isCapturing = true;
+        LOG_INFO("Captura de áudio iniciada");
+        return true;
+    }
+    else
+    {
+        LOG_ERROR("Falha ao iniciar captura de áudio: " + std::to_string(status));
+        return false;
+    }
+#else
+    return false;
+#endif
+}
+
+void AudioCaptureCoreAudio::stopCapture()
+{
+    m_isCapturing = false;
+#ifdef __APPLE__
+    if (m_audioUnit)
+    {
+        AudioOutputUnitStop(m_audioUnit);
+        LOG_INFO("Captura de áudio parada");
+    }
+#endif
+}
+
+size_t AudioCaptureCoreAudio::getSamples(int16_t *buffer, size_t maxSamples)
+{
+    if (!m_isOpen || !m_isCapturing || !buffer)
+    {
+        return 0;
+    }
+
+#ifdef __APPLE__
+    std::lock_guard<std::mutex> lock(m_bufferMutex);
+    
+    size_t samplesToCopy = std::min(maxSamples, m_audioBuffer.size());
+    if (samplesToCopy > 0)
+    {
+        std::memcpy(buffer, m_audioBuffer.data(), samplesToCopy * sizeof(int16_t));
+        m_audioBuffer.erase(m_audioBuffer.begin(), m_audioBuffer.begin() + samplesToCopy);
+    }
+    
+    return samplesToCopy;
+#else
+    return 0;
+#endif
+}
+
+bool AudioCaptureCoreAudio::initializeAudioUnit()
+{
+#ifdef __APPLE__
+    // Descrição do componente de áudio
+    AudioComponentDescription desc;
+    desc.componentType = kAudioUnitType_Output;
+    desc.componentSubType = kAudioUnitSubType_HALOutput;
+    desc.componentManufacturer = kAudioUnitManufacturer_Apple;
+    desc.componentFlags = 0;
+    desc.componentFlagsMask = 0;
+    
+    // Encontrar componente
+    m_audioComponent = AudioComponentFindNext(nullptr, &desc);
+    if (!m_audioComponent)
+    {
+        LOG_ERROR("Falha ao encontrar AudioComponent");
+        return false;
+    }
+    
+    // Criar instância
+    OSStatus status = AudioComponentInstanceNew(m_audioComponent, &m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao criar AudioUnit: " + std::to_string(status));
+        return false;
+    }
+    
+    // Habilitar input
+    UInt32 enableInput = 1;
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioOutputUnitProperty_EnableIO,
+                                  kAudioUnitScope_Input,
+                                  1, // Input element
+                                  &enableInput,
+                                  sizeof(enableInput));
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao habilitar input: " + std::to_string(status));
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Desabilitar output
+    UInt32 enableOutput = 0;
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioOutputUnitProperty_EnableIO,
+                                  kAudioUnitScope_Output,
+                                  0, // Output element
+                                  &enableOutput,
+                                  sizeof(enableOutput));
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao desabilitar output: " + std::to_string(status));
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Configurar formato de áudio
+    AudioStreamBasicDescription streamFormat;
+    streamFormat.mSampleRate = m_sampleRate;
+    streamFormat.mFormatID = kAudioFormatLinearPCM;
+    streamFormat.mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+    streamFormat.mBitsPerChannel = 16;
+    streamFormat.mChannelsPerFrame = m_channels;
+    streamFormat.mBytesPerFrame = streamFormat.mChannelsPerFrame * (streamFormat.mBitsPerChannel / 8);
+    streamFormat.mFramesPerPacket = 1;
+    streamFormat.mBytesPerPacket = streamFormat.mBytesPerFrame * streamFormat.mFramesPerPacket;
+    
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioUnitProperty_StreamFormat,
+                                  kAudioUnitScope_Output,
+                                  1, // Input element
+                                  &streamFormat,
+                                  sizeof(streamFormat));
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao configurar formato de áudio: " + std::to_string(status));
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Configurar callback
+    AURenderCallbackStruct callbackStruct;
+    callbackStruct.inputProc = audioInputCallback;
+    
+    // Criar contexto
+    m_context = new AudioCaptureContext;
+    m_context->capture = this;
+    m_context->bufferMutex = &m_bufferMutex;
+    m_context->audioBuffer = &m_audioBuffer;
+    
+    callbackStruct.inputProcRefCon = m_context;
+    
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioOutputUnitProperty_SetInputCallback,
+                                  kAudioUnitScope_Global,
+                                  1, // Input element
+                                  &callbackStruct,
+                                  sizeof(callbackStruct));
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao configurar callback: " + std::to_string(status));
+        delete m_context;
+        m_context = nullptr;
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Inicializar AudioUnit
+    status = AudioUnitInitialize(m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Falha ao inicializar AudioUnit: " + std::to_string(status));
+        delete m_context;
+        m_context = nullptr;
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    LOG_INFO("AudioUnit inicializado com sucesso");
+    return true;
+#else
+    return false;
+#endif
+}
+
+void AudioCaptureCoreAudio::cleanupAudioUnit()
+{
+#ifdef __APPLE__
+    if (m_audioUnit)
+    {
+        AudioUnitUninitialize(m_audioUnit);
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+    }
+    
+    if (m_context)
+    {
+        delete m_context;
+        m_context = nullptr;
+    }
+    
+    m_audioComponent = nullptr;
+    m_audioBuffer.clear();
+#endif
+}

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -12,8 +12,7 @@
 struct AudioCaptureContext
 {
     AudioCaptureCoreAudio* capture;
-    std::mutex* bufferMutex;
-    std::vector<int16_t>* audioBuffer;
+    AudioBus *bus;
 };
 
 static OSStatus audioInputCallback(void *inRefCon,
@@ -50,14 +49,11 @@ static OSStatus audioInputCallback(void *inRefCon,
     AudioComponentInstance audioUnit = context->capture->getAudioUnit();
     OSStatus status = AudioUnitRender(audioUnit, &flags, &timeStamp, 1, inNumberFrames, &bufferList);
     
-    if (status == noErr)
+    if (status == noErr && context->bus)
     {
-        std::lock_guard<std::mutex> lock(*context->bufferMutex);
-        context->audioBuffer->insert(context->audioBuffer->end(), 
-                                     tempBuffer.begin(), 
-                                     tempBuffer.end());
+        context->bus->push(tempBuffer.data(), tempBuffer.size());
     }
-    
+
     return status;
 }
 #endif
@@ -70,17 +66,22 @@ AudioCaptureCoreAudio::AudioCaptureCoreAudio()
     , m_bufferMutex()
     , m_sampleRate(44100)
     , m_channels(2)
-    , m_bytesPerSample(2) // 16-bit
+    , m_bytesPerSample(2)
     , m_isOpen(false)
     , m_isCapturing(false)
 #else
     : m_sampleRate(44100)
     , m_channels(2)
-    , m_bytesPerSample(2) // 16-bit
+    , m_bytesPerSample(2)
     , m_isOpen(false)
     , m_isCapturing(false)
 #endif
 {
+    m_bus = std::make_unique<AudioBus>(m_sampleRate, m_channels);
+    // ~2 s of slack at 44.1 kHz stereo, matching AudioCapturePulse on
+    // Linux. Encoder/recorder pulls every video frame, so this is
+    // comfortably above expected fill.
+    m_localTap = m_bus->createTap(static_cast<size_t>(m_sampleRate) * m_channels * 2);
 }
 
 AudioCaptureCoreAudio::~AudioCaptureCoreAudio()
@@ -113,6 +114,16 @@ bool AudioCaptureCoreAudio::open(const std::string &deviceName)
 
     m_isOpen = true;
     LOG_INFO("Dispositivo de áudio aberto: " + (deviceName.empty() ? "default" : deviceName));
+
+    // Stand up the host-side monitor playback — Core Audio counterpart
+    // of Linux's MonitorPlayback (pa_simple writer). Failure is
+    // non-fatal: capture still works for encoder/recorder, the user
+    // just won't hear the input through the default output device.
+    if (!startMonitor())
+    {
+        LOG_WARN("AudioCaptureCoreAudio: host-side monitor failed to start; "
+                 "input will not be audible through the default output");
+    }
     return true;
 #else
     LOG_ERROR("Core Audio só está disponível no macOS");
@@ -127,6 +138,7 @@ void AudioCaptureCoreAudio::close()
         stopCapture();
     }
 
+    stopMonitor();
     m_isOpen = false;
     LOG_INFO("Dispositivo de áudio fechado");
 }
@@ -138,34 +150,26 @@ bool AudioCaptureCoreAudio::isOpen() const
 
 size_t AudioCaptureCoreAudio::getSamples(std::vector<float> &samples)
 {
-    if (!m_isOpen || !m_isCapturing)
+    if (!m_isOpen || !m_isCapturing || !m_localTap)
     {
         samples.clear();
         return 0;
     }
 
-#ifdef __APPLE__
-    std::lock_guard<std::mutex> lock(m_bufferMutex);
-    
-    if (m_audioBuffer.empty())
+    const size_t available = m_localTap->available();
+    if (available == 0)
     {
         samples.clear();
         return 0;
     }
-
-    // Converter int16 para float
-    samples.resize(m_audioBuffer.size());
-    for (size_t i = 0; i < m_audioBuffer.size(); ++i)
+    std::vector<int16_t> raw(available);
+    const size_t pulled = m_localTap->pull(raw.data(), available);
+    samples.resize(pulled);
+    for (size_t i = 0; i < pulled; ++i)
     {
-        samples[i] = m_audioBuffer[i] / 32768.0f;
+        samples[i] = static_cast<float>(raw[i]) / 32768.0f;
     }
-
-    m_audioBuffer.clear();
-    return samples.size();
-#else
-    samples.clear();
-    return 0;
-#endif
+    return pulled;
 }
 
 uint32_t AudioCaptureCoreAudio::getSampleRate() const
@@ -325,25 +329,11 @@ void AudioCaptureCoreAudio::stopCapture()
 
 size_t AudioCaptureCoreAudio::getSamples(int16_t *buffer, size_t maxSamples)
 {
-    if (!m_isOpen || !m_isCapturing || !buffer)
+    if (!m_isOpen || !m_isCapturing || !buffer || maxSamples == 0 || !m_localTap)
     {
         return 0;
     }
-
-#ifdef __APPLE__
-    std::lock_guard<std::mutex> lock(m_bufferMutex);
-    
-    size_t samplesToCopy = std::min(maxSamples, m_audioBuffer.size());
-    if (samplesToCopy > 0)
-    {
-        std::memcpy(buffer, m_audioBuffer.data(), samplesToCopy * sizeof(int16_t));
-        m_audioBuffer.erase(m_audioBuffer.begin(), m_audioBuffer.begin() + samplesToCopy);
-    }
-    
-    return samplesToCopy;
-#else
-    return 0;
-#endif
+    return m_localTap->pull(buffer, maxSamples);
 }
 
 bool AudioCaptureCoreAudio::initializeAudioUnit()
@@ -437,8 +427,7 @@ bool AudioCaptureCoreAudio::initializeAudioUnit()
     // Criar contexto
     m_context = new AudioCaptureContext;
     m_context->capture = this;
-    m_context->bufferMutex = &m_bufferMutex;
-    m_context->audioBuffer = &m_audioBuffer;
+    m_context->bus     = m_bus.get();
     
     callbackStruct.inputProcRefCon = m_context;
     
@@ -494,6 +483,136 @@ void AudioCaptureCoreAudio::cleanupAudioUnit()
     }
     
     m_audioComponent = nullptr;
-    m_audioBuffer.clear();
 #endif
 }
+
+#ifdef __APPLE__
+
+// Forward declaration: defined in AudioOutputCoreAudio.h.
+// We don't include that header at the top of this file because it
+// would pull Core Audio macros transitively into header consumers
+// that don't need them.
+extern std::unique_ptr<IAudioOutput> createAudioOutputCoreAudio();
+
+bool AudioCaptureCoreAudio::startMonitor()
+{
+    if (m_monitor)
+    {
+        return true;
+    }
+    if (!m_bus)
+    {
+        return false;
+    }
+
+    m_monitor = createAudioOutputCoreAudio();
+    if (!m_monitor)
+    {
+        LOG_ERROR("AudioCaptureCoreAudio: createAudioOutputCoreAudio returned null");
+        return false;
+    }
+    if (!m_monitor->open("", m_sampleRate, m_channels))
+    {
+        LOG_ERROR("AudioCaptureCoreAudio: monitor open() failed");
+        m_monitor.reset();
+        return false;
+    }
+    if (!m_monitor->start())
+    {
+        LOG_ERROR("AudioCaptureCoreAudio: monitor start() failed");
+        m_monitor->close();
+        m_monitor.reset();
+        return false;
+    }
+    m_monitor->setEnabled(true);
+
+    // ~2 s slack on the monitor tap, matching the local-tap capacity
+    // (and Linux's MonitorPlayback tap). Drop-oldest at this cap is
+    // the safety net if the playback path stalls; the writer loop
+    // does NOT actively skip — same minimal posture as Linux.
+    m_monitorTap = m_bus->createTap(static_cast<size_t>(m_sampleRate) * m_channels * 2);
+    m_monitorResyncPending = false;
+    m_monitorRunning       = true;
+    m_monitorThread        = std::thread(&AudioCaptureCoreAudio::monitorWriterLoop, this);
+
+    LOG_INFO("AudioCaptureCoreAudio: monitor started (" +
+             std::to_string(m_monitor->getSampleRate()) + " Hz x " +
+             std::to_string(m_monitor->getChannels()) + " ch)");
+    return true;
+}
+
+void AudioCaptureCoreAudio::stopMonitor()
+{
+    m_monitorRunning = false;
+    if (m_monitorThread.joinable())
+    {
+        m_monitorThread.join();
+    }
+    if (m_monitor)
+    {
+        m_monitor->stop();
+        m_monitor->close();
+        m_monitor.reset();
+    }
+    m_monitorTap.reset();
+    m_monitorResyncPending = false;
+}
+
+void AudioCaptureCoreAudio::monitorWriterLoop()
+{
+    // ~10 ms chunks at 44.1 kHz stereo, same sizing as Linux's
+    // MonitorPlayback writer.
+    constexpr size_t kChunkSamples = 882 * 2;
+    std::vector<int16_t> chunk(kChunkSamples);
+    std::vector<int16_t> drain;
+
+    while (m_monitorRunning.load())
+    {
+        if (m_monitorResyncPending.exchange(false))
+        {
+            // Drop everything queued in the tap so the next write
+            // restarts from the producer's newest samples.
+            const size_t available = m_monitorTap ? m_monitorTap->available() : 0;
+            if (available > 0)
+            {
+                drain.resize(available);
+                m_monitorTap->pull(drain.data(), available);
+            }
+            LOG_INFO("AudioCaptureCoreAudio: monitor resync (dropped " +
+                     std::to_string(available / (m_channels ? m_channels : 1)) +
+                     " queued frames)");
+        }
+
+        if (!m_monitorTap || !m_monitor)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        const size_t got = m_monitorTap->pull(chunk.data(), chunk.size());
+        if (got == 0)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        if (m_monitor->isEnabled() && m_monitor->isOpen())
+        {
+            m_monitor->write(chunk.data(), got);
+        }
+    }
+}
+
+void AudioCaptureCoreAudio::resyncMonitor()
+{
+    m_monitorResyncPending = true;
+}
+
+#else // !__APPLE__
+
+bool AudioCaptureCoreAudio::startMonitor() { return false; }
+void AudioCaptureCoreAudio::stopMonitor()  {}
+void AudioCaptureCoreAudio::monitorWriterLoop() {}
+void AudioCaptureCoreAudio::resyncMonitor() {}
+
+#endif

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #ifdef __APPLE__
+#import <AVFoundation/AVFoundation.h>
 #import <CoreAudio/CoreAudio.h>
 #import <AudioUnit/AudioUnit.h>
 #import <CoreFoundation/CoreFoundation.h>
@@ -52,6 +53,17 @@ static OSStatus audioInputCallback(void *inRefCon,
     if (status == noErr && context->bus)
     {
         context->bus->push(tempBuffer.data(), tempBuffer.size());
+
+        // Log the first few callbacks plus a periodic heartbeat so a
+        // silently-not-firing callback (microphone permission denied,
+        // device produces no samples) is obvious from the log.
+        static std::atomic<unsigned> cbCount{0};
+        const unsigned n = ++cbCount;
+        if (n <= 3 || (n % 1000) == 0)
+        {
+            LOG_INFO("Core Audio input callback #" + std::to_string(n) +
+                     " — pushed " + std::to_string(tempBuffer.size()) + " samples");
+        }
     }
 
     return status;
@@ -106,6 +118,58 @@ bool AudioCaptureCoreAudio::open(const std::string &deviceName)
     }
 
 #ifdef __APPLE__
+    // macOS 10.14+ gates Core Audio input behind the microphone
+    // privacy setting. Without an explicit grant the AudioUnit
+    // "opens" successfully but the input callback never fires and
+    // no samples ever reach the bus — silent failure that looks
+    // exactly like "monitor doesn't play". Surface the current
+    // status in the log, and synchronously request access on first
+    // run so the consent prompt has a chance to appear (only works
+    // for binaries inside an .app bundle with `NSMicrophoneUsage-
+    // Description` in Info.plist; raw command-line binaries get the
+    // request immediately denied without UI).
+    @autoreleasepool
+    {
+        AVAuthorizationStatus s =
+            [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+        const char *label = "unknown";
+        switch (s)
+        {
+            case AVAuthorizationStatusNotDetermined: label = "NotDetermined"; break;
+            case AVAuthorizationStatusRestricted:    label = "Restricted";    break;
+            case AVAuthorizationStatusDenied:        label = "Denied";        break;
+            case AVAuthorizationStatusAuthorized:    label = "Authorized";    break;
+        }
+        LOG_INFO(std::string("Core Audio microphone authorization: ") + label);
+
+        if (s == AVAuthorizationStatusNotDetermined)
+        {
+            __block bool grantedFlag  = false;
+            __block bool finishedFlag = false;
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                                     completionHandler:^(BOOL granted) {
+                grantedFlag  = granted;
+                finishedFlag = true;
+            }];
+            NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+            while (!finishedFlag &&
+                   [[NSDate date] compare:deadline] == NSOrderedAscending)
+            {
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                         beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+            }
+            LOG_INFO(std::string("Core Audio microphone prompt result: ") +
+                     (grantedFlag ? "granted" : "denied/timeout"));
+        }
+        else if (s == AVAuthorizationStatusDenied || s == AVAuthorizationStatusRestricted)
+        {
+            LOG_WARN("Core Audio microphone access denied — open System Settings → "
+                     "Privacy & Security → Microphone and enable RetroCapture (or the "
+                     "binary's parent process if running uncodesigned). No audio will "
+                     "flow until access is granted.");
+        }
+    }
+
     if (!initializeAudioUnit())
     {
         LOG_ERROR("Falha ao inicializar AudioUnit");
@@ -598,7 +662,18 @@ void AudioCaptureCoreAudio::monitorWriterLoop()
 
         if (m_monitor->isEnabled() && m_monitor->isOpen())
         {
-            m_monitor->write(chunk.data(), got);
+            const size_t written = m_monitor->write(chunk.data(), got);
+            // Mirror the input-callback diagnostic — first few iterations
+            // plus a periodic heartbeat so an open-but-silent monitor
+            // playback path can be told apart from an empty input.
+            static std::atomic<unsigned> wCount{0};
+            const unsigned n = ++wCount;
+            if (n <= 3 || (n % 1000) == 0)
+            {
+                LOG_INFO("Monitor writer iter #" + std::to_string(n) +
+                         " — pulled " + std::to_string(got) +
+                         " samples, wrote " + std::to_string(written));
+            }
         }
     }
 }

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -33,7 +33,19 @@ static OSStatus audioInputCallback(void *inRefCon,
     {
         return noErr;
     }
-    
+
+    // Top-of-callback heartbeat (rate-limited) so we can tell apart:
+    //   - callback never called: no "input callback HIT" log at all
+    //   - called but AudioUnitRender fails: HIT log + status warning
+    //   - called and rendered: HIT log + "pushed N samples" log below
+    static std::atomic<unsigned> hitCount{0};
+    const unsigned h = ++hitCount;
+    if (h <= 3 || (h % 1000) == 0)
+    {
+        LOG_INFO("Core Audio input callback HIT #" + std::to_string(h) +
+                 " (inNumberFrames=" + std::to_string(inNumberFrames) + ")");
+    }
+
     AudioUnitRenderActionFlags flags = 0;
     AudioTimeStamp timeStamp = *inTimeStamp;
     AudioBufferList bufferList;
@@ -41,14 +53,19 @@ static OSStatus audioInputCallback(void *inRefCon,
     bufferList.mBuffers[0].mNumberChannels = 2; // Stereo
     bufferList.mBuffers[0].mDataByteSize = inNumberFrames * 2 * sizeof(int16_t);
     bufferList.mBuffers[0].mData = nullptr;
-    
+
     // Alocar buffer temporário
     std::vector<int16_t> tempBuffer(inNumberFrames * 2);
     bufferList.mBuffers[0].mData = tempBuffer.data();
-    
+
     // Renderizar áudio
     AudioComponentInstance audioUnit = context->capture->getAudioUnit();
     OSStatus status = AudioUnitRender(audioUnit, &flags, &timeStamp, 1, inNumberFrames, &bufferList);
+    if (status != noErr && (h <= 3 || (h % 1000) == 0))
+    {
+        LOG_WARN("Core Audio AudioUnitRender returned status=" +
+                 std::to_string(static_cast<int>(status)));
+    }
     
     if (status == noErr && context->bus)
     {
@@ -170,7 +187,7 @@ bool AudioCaptureCoreAudio::open(const std::string &deviceName)
         }
     }
 
-    if (!initializeAudioUnit())
+    if (!initializeAudioUnit(deviceName))
     {
         LOG_ERROR("Falha ao inicializar AudioUnit");
         return false;
@@ -400,7 +417,7 @@ size_t AudioCaptureCoreAudio::getSamples(int16_t *buffer, size_t maxSamples)
     return m_localTap->pull(buffer, maxSamples);
 }
 
-bool AudioCaptureCoreAudio::initializeAudioUnit()
+bool AudioCaptureCoreAudio::initializeAudioUnit(const std::string &requestedDeviceId)
 {
 #ifdef __APPLE__
     // Descrição do componente de áudio
@@ -510,7 +527,47 @@ bool AudioCaptureCoreAudio::initializeAudioUnit()
         m_audioUnit = nullptr;
         return false;
     }
-    
+
+    // Bind the AudioUnit to the user-selected Core Audio device. Without
+    // this property the HALOutput AudioUnit captures from whatever
+    // System Settings → Sound → Input has selected, regardless of which
+    // device id the UI asked for — exactly the "selected the device, no
+    // audio" behaviour reported. The id is the decimal `AudioDeviceID`
+    // string emitted by `listDevices()`.
+    if (!requestedDeviceId.empty())
+    {
+        AudioDeviceID devId = 0;
+        try
+        {
+            devId = static_cast<AudioDeviceID>(std::stoul(requestedDeviceId));
+        }
+        catch (...)
+        {
+            LOG_WARN("AudioCaptureCoreAudio: unparseable device id '" +
+                     requestedDeviceId + "' — falling back to system default");
+        }
+        if (devId != 0)
+        {
+            status = AudioUnitSetProperty(m_audioUnit,
+                                          kAudioOutputUnitProperty_CurrentDevice,
+                                          kAudioUnitScope_Global,
+                                          0,
+                                          &devId,
+                                          sizeof(devId));
+            if (status != noErr)
+            {
+                LOG_WARN("AudioCaptureCoreAudio: CurrentDevice set failed "
+                         "(status=" + std::to_string(status) +
+                         "), falling back to system default");
+            }
+            else
+            {
+                LOG_INFO("AudioCaptureCoreAudio: bound AudioUnit to device id " +
+                         std::to_string(devId));
+            }
+        }
+    }
+
     // Inicializar AudioUnit
     status = AudioUnitInitialize(m_audioUnit);
     if (status != noErr)

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -476,21 +476,103 @@ bool AudioCaptureCoreAudio::initializeAudioUnit(const std::string &requestedDevi
         return false;
     }
     
-    // Configurar formato de áudio
-    AudioStreamBasicDescription streamFormat;
-    streamFormat.mSampleRate = m_sampleRate;
-    streamFormat.mFormatID = kAudioFormatLinearPCM;
-    streamFormat.mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
-    streamFormat.mBitsPerChannel = 16;
+    // Bind the AudioUnit to the user-selected Core Audio device. MUST
+    // happen before reading the device's native stream format below,
+    // otherwise we'd read the AudioUnit's default (44100 Hz / 2 ch /
+    // float32) instead of the actual device's format.
+    if (!requestedDeviceId.empty())
+    {
+        AudioDeviceID devId = 0;
+        try
+        {
+            devId = static_cast<AudioDeviceID>(std::stoul(requestedDeviceId));
+        }
+        catch (...)
+        {
+            LOG_WARN("AudioCaptureCoreAudio: unparseable device id '" +
+                     requestedDeviceId + "' — falling back to system default");
+        }
+        if (devId != 0)
+        {
+            OSStatus bindStatus = AudioUnitSetProperty(m_audioUnit,
+                                                       kAudioOutputUnitProperty_CurrentDevice,
+                                                       kAudioUnitScope_Global,
+                                                       0,
+                                                       &devId,
+                                                       sizeof(devId));
+            if (bindStatus != noErr)
+            {
+                LOG_WARN("AudioCaptureCoreAudio: CurrentDevice set failed "
+                         "(status=" + std::to_string(bindStatus) +
+                         "), falling back to system default");
+            }
+            else
+            {
+                LOG_INFO("AudioCaptureCoreAudio: bound AudioUnit to device id " +
+                         std::to_string(devId));
+            }
+        }
+    }
+
+    // Read the device's native stream format BEFORE setting our
+    // requested format. Hard-coding 44.1 kHz / 2 ch / 16-bit caused
+    // `AudioUnitRender` to return `-10863
+    // (kAudioUnitErr_CannotDoInCurrentContext)` on UVC capture cards
+    // that natively run at 48 kHz / mono / float32 — the AudioUnit's
+    // internal converter can resample arbitrary rates but couldn't
+    // bridge that big a gap in one shot. Pick up the device's actual
+    // sample rate and channel count and use them; bit depth stays at
+    // signed 16-bit interleaved (what the rest of the pipeline
+    // expects, and what the converter does handle reliably).
+    AudioStreamBasicDescription deviceFormat = {};
+    UInt32 deviceFormatSize = sizeof(deviceFormat);
+    OSStatus formatStatus = AudioUnitGetProperty(m_audioUnit,
+                                                 kAudioUnitProperty_StreamFormat,
+                                                 kAudioUnitScope_Input,
+                                                 1,
+                                                 &deviceFormat,
+                                                 &deviceFormatSize);
+    if (formatStatus == noErr)
+    {
+        LOG_INFO("Core Audio device native format: " +
+                 std::to_string(static_cast<int>(deviceFormat.mSampleRate)) + " Hz, " +
+                 std::to_string(deviceFormat.mChannelsPerFrame) + " ch, " +
+                 std::to_string(deviceFormat.mBitsPerChannel) + "-bit");
+        if (deviceFormat.mSampleRate > 0)
+        {
+            m_sampleRate = static_cast<uint32_t>(deviceFormat.mSampleRate);
+        }
+        if (deviceFormat.mChannelsPerFrame > 0)
+        {
+            m_channels = deviceFormat.mChannelsPerFrame;
+        }
+    }
+    else
+    {
+        LOG_WARN("Core Audio: failed to query device native format (status=" +
+                 std::to_string(formatStatus) +
+                 "), falling back to hardcoded 44100 Hz / 2 ch");
+    }
+
+    // Build our requested format using the device's sample rate /
+    // channel count so the AudioUnit only has to handle bit-depth
+    // conversion (float / 24-bit / 32-bit → signed 16-bit). Some
+    // mono devices will deliver a single channel; the rest of the
+    // bus / monitor pipeline handles channel counts > 0 fine.
+    AudioStreamBasicDescription streamFormat = {};
+    streamFormat.mSampleRate       = m_sampleRate;
+    streamFormat.mFormatID         = kAudioFormatLinearPCM;
+    streamFormat.mFormatFlags      = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+    streamFormat.mBitsPerChannel   = 16;
     streamFormat.mChannelsPerFrame = m_channels;
-    streamFormat.mBytesPerFrame = streamFormat.mChannelsPerFrame * (streamFormat.mBitsPerChannel / 8);
-    streamFormat.mFramesPerPacket = 1;
-    streamFormat.mBytesPerPacket = streamFormat.mBytesPerFrame * streamFormat.mFramesPerPacket;
-    
+    streamFormat.mBytesPerFrame    = streamFormat.mChannelsPerFrame * (streamFormat.mBitsPerChannel / 8);
+    streamFormat.mFramesPerPacket  = 1;
+    streamFormat.mBytesPerPacket   = streamFormat.mBytesPerFrame * streamFormat.mFramesPerPacket;
+
     status = AudioUnitSetProperty(m_audioUnit,
                                   kAudioUnitProperty_StreamFormat,
                                   kAudioUnitScope_Output,
-                                  1, // Input element
+                                  1,
                                   &streamFormat,
                                   sizeof(streamFormat));
     if (status != noErr)
@@ -526,46 +608,6 @@ bool AudioCaptureCoreAudio::initializeAudioUnit(const std::string &requestedDevi
         AudioComponentInstanceDispose(m_audioUnit);
         m_audioUnit = nullptr;
         return false;
-    }
-
-    // Bind the AudioUnit to the user-selected Core Audio device. Without
-    // this property the HALOutput AudioUnit captures from whatever
-    // System Settings → Sound → Input has selected, regardless of which
-    // device id the UI asked for — exactly the "selected the device, no
-    // audio" behaviour reported. The id is the decimal `AudioDeviceID`
-    // string emitted by `listDevices()`.
-    if (!requestedDeviceId.empty())
-    {
-        AudioDeviceID devId = 0;
-        try
-        {
-            devId = static_cast<AudioDeviceID>(std::stoul(requestedDeviceId));
-        }
-        catch (...)
-        {
-            LOG_WARN("AudioCaptureCoreAudio: unparseable device id '" +
-                     requestedDeviceId + "' — falling back to system default");
-        }
-        if (devId != 0)
-        {
-            status = AudioUnitSetProperty(m_audioUnit,
-                                          kAudioOutputUnitProperty_CurrentDevice,
-                                          kAudioUnitScope_Global,
-                                          0,
-                                          &devId,
-                                          sizeof(devId));
-            if (status != noErr)
-            {
-                LOG_WARN("AudioCaptureCoreAudio: CurrentDevice set failed "
-                         "(status=" + std::to_string(status) +
-                         "), falling back to system default");
-            }
-            else
-            {
-                LOG_INFO("AudioCaptureCoreAudio: bound AudioUnit to device id " +
-                         std::to_string(devId));
-            }
-        }
     }
 
     // Inicializar AudioUnit

--- a/src/audio/AudioCaptureCoreAudioFactory.mm
+++ b/src/audio/AudioCaptureCoreAudioFactory.mm
@@ -1,0 +1,9 @@
+// Helper file para criar AudioCaptureCoreAudio sem incluir header Objective-C em arquivo C++
+#include "AudioCaptureCoreAudio.h"
+#include "IAudioCapture.h"
+#include <memory>
+
+std::unique_ptr<IAudioCapture> createAudioCaptureCoreAudio()
+{
+    return std::make_unique<AudioCaptureCoreAudio>();
+}

--- a/src/audio/AudioCaptureFactory.cpp
+++ b/src/audio/AudioCaptureFactory.cpp
@@ -4,6 +4,11 @@
 #include "AudioCapturePulse.h"
 #elif defined(_WIN32)
 #include "AudioCaptureWASAPI.h"
+#elif defined(__APPLE__)
+// Para macOS, precisamos incluir o header Objective-C++
+// Mas isso só funciona se o arquivo for compilado como Objective-C++
+// Como este arquivo é .cpp, vamos criar uma função helper no .mm
+extern std::unique_ptr<IAudioCapture> createAudioCaptureCoreAudio();
 #endif
 
 std::unique_ptr<IAudioCapture> AudioCaptureFactory::create()
@@ -12,6 +17,8 @@ std::unique_ptr<IAudioCapture> AudioCaptureFactory::create()
     return std::make_unique<AudioCapturePulse>();
 #elif defined(_WIN32)
     return std::make_unique<AudioCaptureWASAPI>();
+#elif defined(__APPLE__)
+    return createAudioCaptureCoreAudio();
 #else
     #error "Unsupported platform"
 #endif

--- a/src/audio/AudioOutputCoreAudio.h
+++ b/src/audio/AudioOutputCoreAudio.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "IAudioOutput.h"
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <mutex>
+#include <atomic>
+
+#ifdef __APPLE__
+#import <CoreAudio/CoreAudio.h>
+#import <AudioUnit/AudioUnit.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+// Forward declaration
+struct AudioOutputContext;
+#endif
+
+/**
+ * @brief Core Audio implementation of IAudioOutput for macOS
+ */
+class AudioOutputCoreAudio : public IAudioOutput
+{
+public:
+    AudioOutputCoreAudio();
+    ~AudioOutputCoreAudio() override;
+
+    // Non-copyable
+    AudioOutputCoreAudio(const AudioOutputCoreAudio&) = delete;
+    AudioOutputCoreAudio& operator=(const AudioOutputCoreAudio&) = delete;
+
+    // IAudioOutput interface
+    bool open(const std::string& deviceName = "", uint32_t sampleRate = 0, uint32_t channels = 0) override;
+    void close() override;
+    bool isOpen() const override;
+    bool start() override;
+    void stop() override;
+    size_t write(const int16_t* samples, size_t numSamples) override;
+    uint32_t getSampleRate() const override;
+    uint32_t getChannels() const override;
+    void setVolume(float volume) override;
+    float getVolume() const override;
+    bool isEnabled() const override;
+    void setEnabled(bool enabled) override;
+
+private:
+#ifdef __APPLE__
+    AudioComponentInstance m_audioUnit;
+    AudioComponent m_audioComponent;
+    AudioOutputContext* m_context;
+    std::mutex m_bufferMutex;
+    std::vector<int16_t> m_audioBuffer;
+    std::atomic<float> m_volume;
+    std::atomic<bool> m_enabled;
+#endif
+
+    uint32_t m_sampleRate;
+    uint32_t m_channels;
+    bool m_isOpen;
+    bool m_isRunning;
+
+    // Internal methods
+    bool initializeAudioUnit();
+    void cleanupAudioUnit();
+};

--- a/src/audio/AudioOutputCoreAudio.mm
+++ b/src/audio/AudioOutputCoreAudio.mm
@@ -1,0 +1,410 @@
+#include "AudioOutputCoreAudio.h"
+#include "../utils/Logger.h"
+#include <algorithm>
+#include <cmath>
+
+#ifdef __APPLE__
+#import <CoreAudio/CoreAudio.h>
+#import <AudioUnit/AudioUnit.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+// Context structure for audio output callback
+struct AudioOutputContext
+{
+    AudioOutputCoreAudio* output;
+    std::mutex* bufferMutex;
+    std::vector<int16_t>* audioBuffer;
+    std::atomic<float>* volume;
+    std::atomic<bool>* enabled;
+};
+
+// Audio output render callback
+static OSStatus audioOutputCallback(void* inRefCon,
+                                     AudioUnitRenderActionFlags* ioActionFlags,
+                                     const AudioTimeStamp* inTimeStamp,
+                                     UInt32 inBusNumber,
+                                     UInt32 inNumberFrames,
+                                     AudioBufferList* ioData)
+{
+    (void)ioActionFlags;
+    (void)inTimeStamp;
+    (void)inBusNumber;
+    
+    AudioOutputContext* context = (AudioOutputContext*)inRefCon;
+    if (!context || !context->output || !context->enabled || !context->enabled->load())
+    {
+        // Output silence if disabled or context invalid
+        for (UInt32 i = 0; i < ioData->mNumberBuffers; ++i)
+        {
+            memset(ioData->mBuffers[i].mData, 0, ioData->mBuffers[i].mDataByteSize);
+        }
+        return noErr;
+    }
+    
+    std::lock_guard<std::mutex> lock(*context->bufferMutex);
+    
+    // Get samples from buffer
+    size_t samplesNeeded = inNumberFrames * ioData->mBuffers[0].mNumberChannels;
+    size_t samplesAvailable = context->audioBuffer->size();
+    size_t samplesToCopy = std::min(samplesNeeded, samplesAvailable);
+    
+    if (samplesToCopy > 0)
+    {
+        // Copy samples to output buffer
+        int16_t* outputBuffer = (int16_t*)ioData->mBuffers[0].mData;
+        const int16_t* inputBuffer = context->audioBuffer->data();
+        
+        // Apply volume and copy
+        float volume = context->volume->load();
+        for (size_t i = 0; i < samplesToCopy; ++i)
+        {
+            outputBuffer[i] = static_cast<int16_t>(inputBuffer[i] * volume);
+        }
+        
+        // Remove copied samples from buffer
+        context->audioBuffer->erase(context->audioBuffer->begin(),
+                                    context->audioBuffer->begin() + samplesToCopy);
+        
+        // Fill remaining with silence if needed
+        if (samplesToCopy < samplesNeeded)
+        {
+            memset(outputBuffer + samplesToCopy, 0, (samplesNeeded - samplesToCopy) * sizeof(int16_t));
+        }
+    }
+    else
+    {
+        // No samples available, output silence
+        for (UInt32 i = 0; i < ioData->mNumberBuffers; ++i)
+        {
+            memset(ioData->mBuffers[i].mData, 0, ioData->mBuffers[i].mDataByteSize);
+        }
+    }
+    
+    return noErr;
+}
+#endif
+
+AudioOutputCoreAudio::AudioOutputCoreAudio()
+#ifdef __APPLE__
+    : m_audioUnit(nullptr)
+    , m_audioComponent(nullptr)
+    , m_context(nullptr)
+    , m_bufferMutex()
+    , m_audioBuffer()
+    , m_volume(1.0f)
+    , m_enabled(true)
+    , m_sampleRate(44100)
+    , m_channels(2)
+    , m_isOpen(false)
+    , m_isRunning(false)
+#else
+    : m_sampleRate(44100)
+    , m_channels(2)
+    , m_isOpen(false)
+    , m_isRunning(false)
+#endif
+{
+}
+
+AudioOutputCoreAudio::~AudioOutputCoreAudio()
+{
+    close();
+    cleanupAudioUnit();
+}
+
+bool AudioOutputCoreAudio::open(const std::string& deviceName, uint32_t sampleRate, uint32_t channels)
+{
+    if (m_isOpen)
+    {
+        LOG_WARN("Audio output already open, closing first");
+        close();
+    }
+
+    // Update sample rate and channels if provided
+    if (sampleRate > 0)
+    {
+        m_sampleRate = sampleRate;
+    }
+    if (channels > 0)
+    {
+        m_channels = channels;
+    }
+
+#ifdef __APPLE__
+    if (!initializeAudioUnit())
+    {
+        LOG_ERROR("Failed to initialize AudioUnit for output");
+        return false;
+    }
+
+    m_isOpen = true;
+    LOG_INFO("Audio output opened: " + (deviceName.empty() ? "default" : deviceName) + 
+             " (" + std::to_string(m_sampleRate) + "Hz, " + std::to_string(m_channels) + " channels)");
+    return true;
+#else
+    (void)deviceName;
+    LOG_ERROR("Core Audio output only available on macOS");
+    return false;
+#endif
+}
+
+void AudioOutputCoreAudio::close()
+{
+    if (m_isRunning)
+    {
+        stop();
+    }
+
+    m_isOpen = false;
+    LOG_INFO("Audio output closed");
+}
+
+bool AudioOutputCoreAudio::isOpen() const
+{
+    return m_isOpen;
+}
+
+bool AudioOutputCoreAudio::start()
+{
+    if (!m_isOpen)
+    {
+        LOG_ERROR("Cannot start audio output: not open");
+        return false;
+    }
+
+    if (m_isRunning)
+    {
+        LOG_WARN("Audio output already running");
+        return true;
+    }
+
+#ifdef __APPLE__
+    OSStatus status = AudioOutputUnitStart(m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to start audio output: " + std::to_string(status));
+        return false;
+    }
+
+    m_isRunning = true;
+    LOG_INFO("Audio output started");
+    return true;
+#else
+    return false;
+#endif
+}
+
+void AudioOutputCoreAudio::stop()
+{
+    if (!m_isRunning)
+    {
+        return;
+    }
+
+#ifdef __APPLE__
+    OSStatus status = AudioOutputUnitStop(m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to stop audio output: " + std::to_string(status));
+    }
+#endif
+
+    m_isRunning = false;
+    
+    // Clear buffer
+    {
+        std::lock_guard<std::mutex> lock(m_bufferMutex);
+        m_audioBuffer.clear();
+    }
+    
+    LOG_INFO("Audio output stopped");
+}
+
+size_t AudioOutputCoreAudio::write(const int16_t* samples, size_t numSamples)
+{
+    if (!m_isOpen || !samples || numSamples == 0 || !m_enabled.load())
+    {
+        return 0;
+    }
+
+#ifdef __APPLE__
+    std::lock_guard<std::mutex> lock(m_bufferMutex);
+    
+    // Limit buffer size to prevent excessive memory usage (keep max 1 second of audio)
+    size_t maxSamples = m_sampleRate * m_channels;
+    if (m_audioBuffer.size() + numSamples > maxSamples)
+    {
+        // Remove oldest samples to make room
+        size_t samplesToRemove = (m_audioBuffer.size() + numSamples) - maxSamples;
+        m_audioBuffer.erase(m_audioBuffer.begin(), m_audioBuffer.begin() + samplesToRemove);
+    }
+    
+    // Add new samples
+    m_audioBuffer.insert(m_audioBuffer.end(), samples, samples + numSamples);
+    
+    // Debug: log occasionally to verify audio is being written
+    static size_t totalSamplesWritten = 0;
+    totalSamplesWritten += numSamples;
+    if (totalSamplesWritten % (m_sampleRate * m_channels) < numSamples) // Log once per second
+    {
+        LOG_INFO("Audio output: " + std::to_string(m_audioBuffer.size()) + " samples in buffer, " +
+                 std::to_string(totalSamplesWritten) + " total samples written");
+    }
+    
+    return numSamples;
+#else
+    (void)samples;
+    (void)numSamples;
+    return 0;
+#endif
+}
+
+uint32_t AudioOutputCoreAudio::getSampleRate() const
+{
+    return m_sampleRate;
+}
+
+uint32_t AudioOutputCoreAudio::getChannels() const
+{
+    return m_channels;
+}
+
+void AudioOutputCoreAudio::setVolume(float volume)
+{
+    m_volume.store(std::max(0.0f, std::min(1.0f, volume)));
+}
+
+float AudioOutputCoreAudio::getVolume() const
+{
+    return m_volume.load();
+}
+
+bool AudioOutputCoreAudio::isEnabled() const
+{
+    return m_enabled.load();
+}
+
+void AudioOutputCoreAudio::setEnabled(bool enabled)
+{
+    m_enabled.store(enabled);
+}
+
+#ifdef __APPLE__
+bool AudioOutputCoreAudio::initializeAudioUnit()
+{
+    // Audio component description for output
+    AudioComponentDescription desc;
+    desc.componentType = kAudioUnitType_Output;
+    desc.componentSubType = kAudioUnitSubType_DefaultOutput;
+    desc.componentManufacturer = kAudioUnitManufacturer_Apple;
+    desc.componentFlags = 0;
+    desc.componentFlagsMask = 0;
+    
+    // Find component
+    m_audioComponent = AudioComponentFindNext(nullptr, &desc);
+    if (!m_audioComponent)
+    {
+        LOG_ERROR("Failed to find AudioComponent for output");
+        return false;
+    }
+    
+    // Create instance
+    OSStatus status = AudioComponentInstanceNew(m_audioComponent, &m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to create AudioUnit: " + std::to_string(status));
+        return false;
+    }
+    
+    // Configure audio format
+    AudioStreamBasicDescription streamFormat;
+    streamFormat.mSampleRate = m_sampleRate;
+    streamFormat.mFormatID = kAudioFormatLinearPCM;
+    streamFormat.mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+    streamFormat.mBitsPerChannel = 16;
+    streamFormat.mChannelsPerFrame = m_channels;
+    streamFormat.mBytesPerFrame = streamFormat.mChannelsPerFrame * (streamFormat.mBitsPerChannel / 8);
+    streamFormat.mFramesPerPacket = 1;
+    streamFormat.mBytesPerPacket = streamFormat.mBytesPerFrame * streamFormat.mFramesPerPacket;
+    
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioUnitProperty_StreamFormat,
+                                  kAudioUnitScope_Input,
+                                  0, // Output element
+                                  &streamFormat,
+                                  sizeof(streamFormat));
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to set audio format: " + std::to_string(status));
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Set render callback
+    AURenderCallbackStruct callbackStruct;
+    callbackStruct.inputProc = audioOutputCallback;
+    
+    // Create context
+    m_context = new AudioOutputContext;
+    m_context->output = this;
+    m_context->bufferMutex = &m_bufferMutex;
+    m_context->audioBuffer = &m_audioBuffer;
+    m_context->volume = &m_volume;
+    m_context->enabled = &m_enabled;
+    
+    callbackStruct.inputProcRefCon = m_context;
+    
+    status = AudioUnitSetProperty(m_audioUnit,
+                                  kAudioUnitProperty_SetRenderCallback,
+                                  kAudioUnitScope_Input,
+                                  0, // Output element
+                                  &callbackStruct,
+                                  sizeof(callbackStruct));
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to set render callback: " + std::to_string(status));
+        delete m_context;
+        m_context = nullptr;
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    // Initialize audio unit
+    status = AudioUnitInitialize(m_audioUnit);
+    if (status != noErr)
+    {
+        LOG_ERROR("Failed to initialize AudioUnit: " + std::to_string(status));
+        delete m_context;
+        m_context = nullptr;
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+        return false;
+    }
+    
+    return true;
+}
+
+void AudioOutputCoreAudio::cleanupAudioUnit()
+{
+    if (m_audioUnit)
+    {
+        if (m_isRunning)
+        {
+            AudioOutputUnitStop(m_audioUnit);
+        }
+        AudioUnitUninitialize(m_audioUnit);
+        AudioComponentInstanceDispose(m_audioUnit);
+        m_audioUnit = nullptr;
+    }
+    
+    if (m_context)
+    {
+        delete m_context;
+        m_context = nullptr;
+    }
+    
+    m_audioComponent = nullptr;
+}
+#endif

--- a/src/audio/AudioOutputCoreAudioFactory.mm
+++ b/src/audio/AudioOutputCoreAudioFactory.mm
@@ -1,0 +1,13 @@
+#include "AudioOutputCoreAudio.h"
+#include "IAudioOutput.h"
+
+#include <memory>
+
+// Tiny .mm shim so a C++ caller can instantiate AudioOutputCoreAudio
+// without pulling the Core Audio Objective-C++ headers across the
+// translation unit boundary. Mirrors the same pattern used for
+// VideoCaptureAVFoundationFactory / AudioCaptureCoreAudioFactory.
+std::unique_ptr<IAudioOutput> createAudioOutputCoreAudio()
+{
+    return std::make_unique<AudioOutputCoreAudio>();
+}

--- a/src/audio/AudioPlaybackCoreAudio.cpp
+++ b/src/audio/AudioPlaybackCoreAudio.cpp
@@ -1,0 +1,146 @@
+#include "AudioPlaybackCoreAudio.h"
+
+#ifdef __APPLE__
+
+#include "IAudioOutput.h"
+#include "../utils/Logger.h"
+
+#include <algorithm>
+#include <vector>
+
+extern std::unique_ptr<IAudioOutput> createAudioOutputCoreAudio();
+
+AudioPlaybackCoreAudio::AudioPlaybackCoreAudio() = default;
+
+AudioPlaybackCoreAudio::~AudioPlaybackCoreAudio()
+{
+    close();
+}
+
+bool AudioPlaybackCoreAudio::open(uint32_t sampleRate, uint32_t channels)
+{
+    if (m_output)
+    {
+        close();
+    }
+    m_output = createAudioOutputCoreAudio();
+    if (!m_output)
+    {
+        LOG_ERROR("AudioPlaybackCoreAudio: factory returned null");
+        return false;
+    }
+    if (!m_output->open("", sampleRate, channels))
+    {
+        LOG_ERROR("AudioPlaybackCoreAudio: underlying output open failed");
+        m_output.reset();
+        return false;
+    }
+    if (!m_output->start())
+    {
+        LOG_ERROR("AudioPlaybackCoreAudio: underlying output start failed");
+        m_output->close();
+        m_output.reset();
+        return false;
+    }
+    m_output->setEnabled(true);
+
+    m_sampleRate = sampleRate;
+    m_channels   = channels;
+    {
+        std::lock_guard<std::mutex> lock(m_clockMutex);
+        m_lastSubmittedPtsUs = 0;
+        m_anySubmitted       = false;
+    }
+    m_bufferedSamples = 0;
+    LOG_INFO("AudioPlaybackCoreAudio: opened " + std::to_string(sampleRate) +
+             " Hz x " + std::to_string(channels) + " ch");
+    return true;
+}
+
+void AudioPlaybackCoreAudio::close()
+{
+    if (!m_output)
+    {
+        return;
+    }
+    m_output->stop();
+    m_output->close();
+    m_output.reset();
+    m_sampleRate = 0;
+    m_channels   = 0;
+    m_bufferedSamples = 0;
+}
+
+bool AudioPlaybackCoreAudio::isOpen() const
+{
+    return m_output && m_output->isOpen();
+}
+
+size_t AudioPlaybackCoreAudio::submit(const float *interleaved,
+                                      size_t sampleCount,
+                                      int64_t firstPtsUs)
+{
+    if (!m_output || !interleaved || sampleCount == 0 || m_channels == 0)
+    {
+        return 0;
+    }
+
+    // Convert interleaved float [-1,1] to interleaved int16. sampleCount
+    // is the *frame* count, so total values = sampleCount * channels.
+    const size_t totalSamples = sampleCount * m_channels;
+    std::vector<int16_t> pcm(totalSamples);
+    for (size_t i = 0; i < totalSamples; ++i)
+    {
+        const float v = std::max(-1.0f, std::min(1.0f, interleaved[i]));
+        pcm[i] = static_cast<int16_t>(v * 32767.0f);
+    }
+
+    const size_t written = m_output->write(pcm.data(), totalSamples);
+    // write() returns # int16 elements written, not frames. Convert back.
+    const size_t framesWritten = (m_channels > 0) ? written / m_channels : 0;
+
+    if (framesWritten > 0)
+    {
+        std::lock_guard<std::mutex> lock(m_clockMutex);
+        // Last accepted-frame PTS = firstPtsUs + (framesWritten-1) frame-times.
+        const int64_t frameUs = (m_sampleRate > 0)
+            ? static_cast<int64_t>(1000000LL) / m_sampleRate
+            : 0;
+        m_lastSubmittedPtsUs = firstPtsUs +
+                               static_cast<int64_t>(framesWritten - 1) * frameUs;
+        m_anySubmitted = true;
+        m_bufferedSamples.fetch_add(static_cast<int64_t>(framesWritten));
+    }
+    return framesWritten;
+}
+
+int64_t AudioPlaybackCoreAudio::getClockUs() const
+{
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    if (!m_anySubmitted || m_sampleRate == 0)
+    {
+        return 0;
+    }
+    // Subtract the still-buffered frames so the returned timestamp is
+    // closer to what the speakers are emitting RIGHT NOW. Without a
+    // proper hardware latency query we use the writer-side bookkeeping
+    // (samples submitted vs samples we estimate the AudioUnit has
+    // already pulled). Loose but usable for A/V sync at < ~50 ms.
+    const int64_t bufferedUs = (m_bufferedSamples.load() * 1000000LL) /
+                               static_cast<int64_t>(m_sampleRate);
+    return m_lastSubmittedPtsUs - bufferedUs;
+}
+
+void AudioPlaybackCoreAudio::flush()
+{
+    // The underlying AudioOutputCoreAudio doesn't currently expose a
+    // "drop everything queued" hook; closing + reopening is too heavy
+    // for a transient flush. Reset our PTS bookkeeping at least so
+    // post-flush samples start the clock fresh.
+    std::lock_guard<std::mutex> lock(m_clockMutex);
+    m_lastSubmittedPtsUs = 0;
+    m_anySubmitted       = false;
+    m_bufferedSamples    = 0;
+}
+
+#endif // __APPLE__

--- a/src/audio/AudioPlaybackCoreAudio.h
+++ b/src/audio/AudioPlaybackCoreAudio.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "IAudioPlayback.h"
+
+#ifdef __APPLE__
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+class IAudioOutput;
+
+/**
+ * Core Audio playback sink for the remote-stream audio path
+ * (macOS counterpart of AudioPlaybackPulse / AudioPlaybackWASAPI).
+ *
+ * Wraps AudioOutputCoreAudio (which already drives a HAL Output
+ * AudioUnit) and adapts its int16 / push API to IAudioPlayback's
+ * float-PCM + PTS API. The PTS bookkeeping mirrors AudioPlaybackPulse:
+ * we remember the PTS of the last sample handed to write() and
+ * subtract the hardware-side buffered samples worth of time to give
+ * the video render thread an "audio-now" timestamp via getClockUs().
+ */
+class AudioPlaybackCoreAudio : public IAudioPlayback
+{
+public:
+    AudioPlaybackCoreAudio();
+    ~AudioPlaybackCoreAudio() override;
+
+    bool   open(uint32_t sampleRate, uint32_t channels) override;
+    void   close() override;
+    bool   isOpen() const override;
+    size_t submit(const float *interleaved,
+                  size_t sampleCount,
+                  int64_t firstPtsUs) override;
+    int64_t getClockUs() const override;
+    void    flush() override;
+
+private:
+    std::unique_ptr<IAudioOutput> m_output;
+    uint32_t m_sampleRate = 0;
+    uint32_t m_channels   = 0;
+
+    // PTS of the most recent sample handed to write(), in stream-
+    // origin-relative microseconds. Updated under m_clockMutex.
+    mutable std::mutex m_clockMutex;
+    int64_t            m_lastSubmittedPtsUs = 0;
+    // Samples currently in the IAudioOutput's internal buffer (best-
+    // effort; we update this by counting submitted - estimated-drained).
+    std::atomic<int64_t> m_bufferedSamples{0};
+    bool               m_anySubmitted = false;
+};
+
+#endif // __APPLE__

--- a/src/audio/IAudioOutput.h
+++ b/src/audio/IAudioOutput.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+
+/**
+ * @brief Abstract interface for audio output/monitoring across different platforms
+ */
+class IAudioOutput
+{
+public:
+    virtual ~IAudioOutput() = default;
+
+    // Open audio output device
+    // sampleRate and channels are optional - if 0, will use defaults or device capabilities
+    virtual bool open(const std::string& deviceName = "", uint32_t sampleRate = 0, uint32_t channels = 0) = 0;
+    
+    // Close audio output
+    virtual void close() = 0;
+    
+    // Check if audio output is open
+    virtual bool isOpen() const = 0;
+    
+    // Start audio output
+    virtual bool start() = 0;
+    
+    // Stop audio output
+    virtual void stop() = 0;
+    
+    // Write audio samples (non-blocking, returns number of samples written)
+    virtual size_t write(const int16_t* samples, size_t numSamples) = 0;
+    
+    // Get audio format information
+    virtual uint32_t getSampleRate() const = 0;
+    virtual uint32_t getChannels() const = 0;
+    
+    // Set volume (0.0 to 1.0)
+    virtual void setVolume(float volume) = 0;
+    virtual float getVolume() const = 0;
+    
+    // Check if monitoring is enabled
+    virtual bool isEnabled() const = 0;
+    virtual void setEnabled(bool enabled) = 0;
+};

--- a/src/capture/IVideoCapture.h
+++ b/src/capture/IVideoCapture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -19,6 +20,21 @@ struct DeviceInfo
     std::string name;      // Human-readable name
     std::string driver;    // Driver name (optional)
     bool available = true; // Whether device is available
+};
+
+// Format descriptor for AVFoundation devices on macOS (each device
+// exposes a fixed set of (resolution, fps range, pixel format) tuples;
+// picking a format selects all three atomically, OBS-style).
+struct AVFoundationFormatInfo
+{
+    std::string id;          // Unique stable identifier for this format
+    uint32_t width = 0;
+    uint32_t height = 0;
+    float minFps = 0.0f;
+    float maxFps = 0.0f;
+    std::string pixelFormat; // e.g. "NV12 (420v)", "YUY2 (yuvs)", "BGRA"
+    std::string colorSpace;  // e.g. "CS 709"
+    std::string displayName; // human-readable concatenation for dropdowns
 };
 
 /**
@@ -72,5 +88,40 @@ public:
      * never hold a "reconnect" state.
      */
     virtual bool isReceivingFrames() const { return isOpen(); }
+
+    // AVFoundation-specific extensions. Default no-op so V4L2,
+    // DirectShow and Remote captures don't need to implement them.
+    virtual std::vector<AVFoundationFormatInfo> listFormats(const std::string &deviceId = "")
+    {
+        (void)deviceId;
+        return {};
+    }
+    virtual bool setFormatById(const std::string &formatId, const std::string &deviceId = "")
+    {
+        (void)formatId;
+        (void)deviceId;
+        return false;
+    }
+
+    // Some macOS capture devices (UVC HDMI grabbers etc.) carry audio
+    // alongside the video stream — these accessors expose it without
+    // forcing a separate IAudioCapture path. Default no-op for
+    // platforms whose video pipeline never carries audio.
+    virtual bool hasAudio() const { return false; }
+    virtual size_t getAudioSamples(int16_t *buffer, size_t maxSamples)
+    {
+        (void)buffer;
+        (void)maxSamples;
+        return 0;
+    }
+    virtual uint32_t getAudioSampleRate() const { return 0; }
+    virtual uint32_t getAudioChannels() const { return 0; }
+    virtual std::vector<DeviceInfo> listAudioDevices() { return {}; }
+    virtual bool setAudioDevice(const std::string &audioDeviceId)
+    {
+        (void)audioDeviceId;
+        return false;
+    }
+    virtual std::string getCurrentAudioDevice() const { return ""; }
 };
 

--- a/src/capture/VideoCaptureAVFoundation.h
+++ b/src/capture/VideoCaptureAVFoundation.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "IVideoCapture.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <mutex>
+#include <atomic>
+
+#ifdef __APPLE__
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+#endif
+
+/**
+ * @brief AVFoundation implementation of IVideoCapture for macOS
+ */
+class VideoCaptureAVFoundation : public IVideoCapture
+{
+public:
+    VideoCaptureAVFoundation();
+    ~VideoCaptureAVFoundation() override;
+
+    // IVideoCapture interface
+    bool open(const std::string &device) override;
+    void close() override;
+    bool isOpen() const override;
+    bool setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat = 0) override;
+    bool setFramerate(uint32_t fps) override;
+    bool captureFrame(Frame &frame) override;
+    bool setControl(const std::string &controlName, int32_t value) override;
+    bool getControl(const std::string &controlName, int32_t &value) override;
+    bool getControlMin(const std::string &controlName, int32_t &minValue) override;
+    bool getControlMax(const std::string &controlName, int32_t &maxValue) override;
+    bool getControlDefault(const std::string &controlName, int32_t &defaultValue) override;
+    std::vector<DeviceInfo> listDevices() override;
+    void setDummyMode(bool enabled) override;
+    bool isDummyMode() const override;
+    bool startCapture() override;
+    void stopCapture() override;
+    bool captureLatestFrame(Frame &frame) override;
+    uint32_t getWidth() const override { return m_width; }
+    uint32_t getHeight() const override { return m_height; }
+    uint32_t getPixelFormat() const override { return m_pixelFormat; }
+
+    // Método público para delegate Objective-C acessar
+    void onFrameCaptured(CVPixelBufferRef pixelBuffer);
+    
+    // Métodos para delegate acessar informações de framerate
+    AVCaptureDevice* getCaptureDevice() const;
+    AVCaptureVideoDataOutput* getVideoOutput() const;
+    
+    // Format enumeration and selection (for UI)
+    std::vector<AVFoundationFormatInfo> listFormats(const std::string &deviceId = "") override;
+    bool setFormatByIndex(int formatIndex, const std::string &deviceId = "");
+    bool setFormatById(const std::string &formatId, const std::string &deviceId = "") override;
+    
+    // Audio capture methods (for capturing audio from video device)
+    bool hasAudio() const override;
+    size_t getAudioSamples(int16_t* buffer, size_t maxSamples) override;
+    uint32_t getAudioSampleRate() const override;
+    uint32_t getAudioChannels() const override;
+    void onAudioSampleBuffer(CMSampleBufferRef sampleBuffer);
+    
+    // Audio device enumeration and selection
+    std::vector<DeviceInfo> listAudioDevices();
+    bool setAudioDevice(const std::string &audioDeviceId);
+    std::string getCurrentAudioDevice() const;
+
+private:
+#ifdef __APPLE__
+    AVCaptureSession *m_captureSession;
+    AVCaptureDevice *m_captureDevice;
+    AVCaptureVideoDataOutput *m_videoOutput;
+    AVCaptureAudioDataOutput *m_audioOutput;
+    dispatch_queue_t m_captureQueue;
+    dispatch_queue_t m_audioQueue;
+    CVPixelBufferRef m_latestPixelBuffer;
+    id m_delegate; // VideoCaptureDelegate (Objective-C object)
+    id m_audioDelegate; // AudioCaptureDelegate (Objective-C object)
+    uint8_t *m_frameBuffer;
+    size_t m_frameBufferSize;
+    std::mutex m_bufferMutex;
+    
+    // Audio capture state
+    std::vector<int16_t> m_audioBuffer;
+    std::mutex m_audioBufferMutex;
+    uint32_t m_audioSampleRate;
+    uint32_t m_audioChannels;
+    bool m_hasAudio;
+    std::string m_selectedAudioDeviceId; // User-selected audio device ID
+#endif
+    
+    uint32_t m_width;
+    uint32_t m_height;
+    uint32_t m_pixelFormat;
+    uint32_t m_fps; // Store requested framerate
+    bool m_isOpen;
+    bool m_isCapturing;
+    std::atomic<bool> m_isClosing{false}; // Flag to indicate device is being closed (prevents callbacks from accessing freed resources) - atomic for thread safety
+    bool m_dummyMode;
+    std::vector<uint8_t> m_dummyFrameBuffer;
+    
+    // Track if a specific format was selected via UI (to avoid being overwritten)
+    bool m_formatSelectedViaUI;
+    std::string m_selectedFormatId;
+    
+    void generateDummyFrame(Frame &frame);
+    bool convertPixelBufferToFrame(CVPixelBufferRef pixelBuffer, Frame &frame);
+    
+    // Centralized method to apply format and framerate atomically
+    bool applyFormatAndFramerate(AVCaptureDeviceFormat* format, uint32_t fps, bool stopSessionIfRunning = false);
+};

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -2519,22 +2519,47 @@ bool VideoCaptureAVFoundation::setFormatById(const std::string &formatId, const 
         // This prevents setFormat() from overwriting the user's selection
         m_formatSelectedViaUI = true;
         m_selectedFormatId = formatId;
-        
+
         // Set the format
         CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([matchingFormat formatDescription]);
         m_width = dims.width;
         m_height = dims.height;
-        
-        // If device is open, apply format immediately with proper session reconfiguration
+
+        // AVFoundation does not reliably honor `activeFormat` swaps on a
+        // running session — macOS silently reverts to the device's
+        // default (the warning chain "Format changed after restarting
+        // session in applyFormatAndFramerate!" / "Format STILL does not
+        // match after retry!" is exactly that). Setting the format
+        // DURING open(), before the input is added, does stick. So when
+        // the user changes the format on an already-open device we
+        // close + reopen with m_width/m_height + m_formatSelectedViaUI
+        // armed, letting the open() path place the format in the spot
+        // where the device accepts it.
         if (m_isOpen && m_captureDevice == device)
         {
-            // Use centralized method to apply format and framerate atomically
-            return applyFormatAndFramerate(matchingFormat, m_fps, true);
+            NSString *currentUniqueID = [device uniqueID];
+            const std::string reopenId = currentUniqueID
+                ? std::string([currentUniqueID UTF8String])
+                : std::string();
+            LOG_INFO("Format change requires reopen: " + std::to_string(m_width) +
+                     "x" + std::to_string(m_height) + " (formatId=" + formatId + ")");
+            close();
+            if (!open(reopenId))
+            {
+                LOG_ERROR("Failed to reopen device with new format: " + formatId);
+                return false;
+            }
+            if (!startCapture())
+            {
+                LOG_WARN("Failed to restart capture after format change");
+            }
+            return true;
         }
         else
         {
             // Format will be applied when device is opened
-            LOG_INFO("Format will be applied when device is opened: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+            LOG_INFO("Format will be applied when device is opened: " +
+                     std::to_string(m_width) + "x" + std::to_string(m_height));
             return true;
         }
     }

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -273,27 +273,14 @@ bool VideoCaptureAVFoundation::open(const std::string &device)
     return false;
         }
         
-        // AVCaptureSession defaults to `AVCaptureSessionPresetHigh` as
-        // soon as an input is added, which on macOS *overrides* whatever
-        // `activeFormat` we set on the device — that's exactly why
-        // earlier attempts to apply 160x120 / 640x480 / 1600x1200 etc.
-        // silently reverted to 1280x720 / 1920x1080 after
-        // `startRunning`. The fix is to explicitly opt into
-        // `AVCaptureSessionPresetInputPriority`, which tells
-        // AVFoundation "honor the device's activeFormat, do not
-        // impose any preset of your own". This preset has been
-        // available on macOS since 10.7 (the old comment in this
-        // file claimed it was iOS-only — incorrect).
-        if ([m_captureSession canSetSessionPreset:AVCaptureSessionPresetInputPriority])
-        {
-            m_captureSession.sessionPreset = AVCaptureSessionPresetInputPriority;
-            LOG_INFO("Session preset: InputPriority (activeFormat honored)");
-        }
-        else
-        {
-            LOG_WARN("Session does not accept InputPriority preset — activeFormat "
-                     "may be overridden by the default preset.");
-        }
+        // No `sessionPreset` set here — on macOS `InputPriority` is
+        // iOS-only, and any concrete preset (`PresetHigh`, `PresetLow`)
+        // overrides whatever activeFormat we set on the device. The
+        // strategy below is instead to let the device pick its own
+        // native format and rely on `videoSettings` on the
+        // `AVCaptureVideoDataOutput` (configured later in this method)
+        // to scale frames down to the requested width/height.
+        LOG_INFO("Session created (no preset — videoSettings will drive output size)");
         
         // Selecionar dispositivo
         AVCaptureDevice* deviceObj = nil;
@@ -470,15 +457,23 @@ bool VideoCaptureAVFoundation::open(const std::string &device)
             return false;
         }
         
-        // IMPORTANT: OBS Studio approach - do NOT force pixel format in videoSettings
-        // Let the device use its native format (NV12, YUY2, etc.) from activeFormat
-        // Forcing BGRA can cause format mismatches and performance issues
-        // The activeFormat's native pixel format will be used automatically
-        // If we need BGRA, we can convert from the native format in the delegate
-        // For now, let's try without forcing a format to see if it helps with format selection
-        NSDictionary* videoSettings = @{
-            (NSString*)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
-        };
+        // `videoSettings` on the AVCaptureVideoDataOutput is the macOS
+        // lever for getting a specific output size out of UVC capture
+        // devices that ignore `setActiveFormat:` (every external HDMI
+        // grabber I've seen does). When width/height keys are present
+        // here, AVFoundation scales the pixel buffer down to that
+        // size before delivering it — even if the device is internally
+        // producing 1920x1080. Pixel format stays at BGRA because the
+        // BGRA→YUYV conversion path downstream expects it.
+        NSMutableDictionary *videoSettings = [NSMutableDictionary dictionary];
+        videoSettings[(NSString *)kCVPixelBufferPixelFormatTypeKey] = @(kCVPixelFormatType_32BGRA);
+        if (m_width > 0 && m_height > 0)
+        {
+            videoSettings[(NSString *)kCVPixelBufferWidthKey]  = @(m_width);
+            videoSettings[(NSString *)kCVPixelBufferHeightKey] = @(m_height);
+            LOG_INFO("videoSettings target: " + std::to_string(m_width) +
+                     "x" + std::to_string(m_height) + " BGRA");
+        }
         [m_videoOutput setVideoSettings:videoSettings];
         
         // IMPORTANT: Try NO to allow buffering - this may help with framerate

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -1048,67 +1048,59 @@ bool VideoCaptureAVFoundation::setFramerate(uint32_t fps)
                              std::to_string(range.maxFrameRate) + " fps");
                 }
                 
-                // Configurar framerate no device
+                // Pick the supported AVFrameRateRange closest to the
+                // requested fps. Critical to use the range's own
+                // minFrameDuration (e.g. 1001/30000 for 29.97 fps)
+                // rather than CMTimeMake(1, fps), because devices
+                // expose specific rational durations and throw
+                // NSInvalidArgumentException when asked for an
+                // unsupported one (FaceTime cameras only accept
+                // 29.97 / 25 / 24 / 15 exactly).
                 AVFrameRateRange* bestRange = nil;
+                double bestDistance = 1e9;
                 for (AVFrameRateRange* range in frameRateRanges)
                 {
-                    if (fps >= range.minFrameRate && fps <= range.maxFrameRate)
+                    double clamped = std::max(range.minFrameRate,
+                                              std::min(static_cast<double>(fps),
+                                                       range.maxFrameRate));
+                    double distance = std::abs(clamped - static_cast<double>(fps));
+                    if (distance < bestDistance)
                     {
-                        bestRange = range;
-                        break;
+                        bestDistance = distance;
+                        bestRange    = range;
                     }
                 }
-                
+
                 if (bestRange)
                 {
-                    // IMPORTANT: Use high timescale to avoid rounding issues
-                    // For exact fps like 30, use CMTime(value: 1, timescale: 30)
-                    CMTimeScale timescale = static_cast<CMTimeScale>(fps);
-                    CMTime frameDuration = CMTimeMake(1, timescale);
-                    
-                    m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                    m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
-                    LOG_INFO("Device framerate configured: " + std::to_string(fps) + " fps (timescale: " + std::to_string(timescale) + ")");
-                    
-                    // Verificar se foi aplicado corretamente
-                    CMTime actualMinDuration = m_captureDevice.activeVideoMinFrameDuration;
-                    CMTime actualMaxDuration = m_captureDevice.activeVideoMaxFrameDuration;
-                    double actualMinFps = 1.0 / (CMTimeGetSeconds(actualMinDuration));
-                    double actualMaxFps = 1.0 / (CMTimeGetSeconds(actualMaxDuration));
-                    LOG_INFO("Actual device framerate range: " + std::to_string(actualMinFps) + " - " + 
-                             std::to_string(actualMaxFps) + " fps");
-                    
-                    if (std::abs(actualMinFps - fps) > 0.1 || std::abs(actualMaxFps - fps) > 0.1)
+                    @try
                     {
-                        LOG_WARN("Device framerate may not have been applied correctly!");
-                        LOG_WARN("Requested: " + std::to_string(fps) + " fps");
-                        LOG_WARN("Actual: " + std::to_string(actualMinFps) + " - " + std::to_string(actualMaxFps) + " fps");
+                        // minFrameDuration = shortest duration = highest
+                        // achievable rate in this range. Using the
+                        // range's own CMTime avoids any rational-mismatch
+                        // exception.
+                        CMTime frameDuration = bestRange.minFrameDuration;
+                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                        double appliedFps = (CMTimeGetSeconds(frameDuration) > 0.0)
+                            ? 1.0 / CMTimeGetSeconds(frameDuration)
+                            : 0.0;
+                        LOG_INFO("Device framerate configured: requested " +
+                                 std::to_string(fps) + " fps → applied " +
+                                 std::to_string(appliedFps) + " fps");
+                    }
+                    @catch (NSException *ex)
+                    {
+                        LOG_WARN(std::string("setActiveVideoFrameDuration raised: ") +
+                                 [[ex reason] UTF8String] +
+                                 " — leaving device framerate at its default");
                     }
                 }
                 else
                 {
-                    LOG_WARN("Framerate " + std::to_string(fps) + " fps não suportado pelo formato atual");
-                    LOG_WARN("Usando padrão do dispositivo");
-                    
-                    // Tentar usar o framerate máximo suportado mais próximo
-                    double bestFps = 0.0;
-                    for (AVFrameRateRange* range in frameRateRanges)
-                    {
-                        if (range.maxFrameRate > bestFps)
-                        {
-                            bestFps = range.maxFrameRate;
-                        }
-                    }
-                    
-                    if (bestFps > 0.0)
-                    {
-                        uint32_t targetFps = static_cast<uint32_t>(bestFps);
-                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                        CMTime frameDuration = CMTimeMake(1, timescale);
-                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
-                        LOG_INFO("Usando framerate máximo suportado: " + std::to_string(targetFps) + " fps");
-                    }
+                    LOG_WARN("Framerate " + std::to_string(fps) +
+                             " fps não suportado pelo formato atual; mantendo o "
+                             "framerate padrão do dispositivo");
                 }
                 
                 LOG_INFO("==============================");

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -1522,9 +1522,9 @@ std::vector<DeviceInfo> VideoCaptureAVFoundation::listDevices()
             // Wait up to ~3 s for the user to respond to the prompt
             // (synchronous wait so this listDevices() call returns the
             // post-grant list rather than the empty pre-grant one).
-            const NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+            NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
             while (!finishedFlag &&
-                   [(NSDate *)[NSDate date] compare:deadline] == NSOrderedAscending)
+                   [[NSDate date] compare:deadline] == NSOrderedAscending)
             {
                 [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                                          beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -11,6 +11,68 @@
 #import <CoreMedia/CoreMedia.h>
 #import <AudioToolbox/AudioToolbox.h>
 
+namespace {
+
+// Picks the supported AVFrameRateRange closest to `requestedFps` and
+// returns its native CMTime — devices reject anything that doesn't
+// match the rational representation exactly (FaceTime cameras only
+// accept 1001/30000 for 29.97 fps, not 1/29 or 1/30). The fallback
+// is `kCMTimeInvalid` when the device exposes no ranges; callers
+// must check via `CMTIME_IS_VALID`.
+inline CMTime pickFrameDurationForFps(NSArray *ranges, uint32_t requestedFps)
+{
+    AVFrameRateRange *bestRange = nil;
+    double bestDistance = 1e9;
+    for (AVFrameRateRange *r in ranges)
+    {
+        const double clamped = std::max(r.minFrameRate,
+                                        std::min(static_cast<double>(requestedFps),
+                                                 r.maxFrameRate));
+        const double distance = std::abs(clamped - static_cast<double>(requestedFps));
+        if (distance < bestDistance)
+        {
+            bestDistance = distance;
+            bestRange    = r;
+        }
+    }
+    return bestRange ? bestRange.minFrameDuration : kCMTimeInvalid;
+}
+
+// Applies the closest supported framerate to `device` and reports
+// success. Wraps the actual `setActiveVideoMin/MaxFrameDuration`
+// calls in `@try / @catch` so an unexpected rational mismatch logs
+// a warning instead of terminating the app.
+inline bool applyClosestFramerate(AVCaptureDevice *device, uint32_t requestedFps)
+{
+    if (!device) return false;
+    NSArray *ranges = [device.activeFormat videoSupportedFrameRateRanges];
+    CMTime duration = pickFrameDurationForFps(ranges, requestedFps);
+    if (!CMTIME_IS_VALID(duration))
+    {
+        LOG_WARN("applyClosestFramerate: device exposes no frame-rate ranges");
+        return false;
+    }
+    @try
+    {
+        device.activeVideoMinFrameDuration = duration;
+        device.activeVideoMaxFrameDuration = duration;
+        const double applied = (CMTimeGetSeconds(duration) > 0.0)
+            ? 1.0 / CMTimeGetSeconds(duration)
+            : 0.0;
+        LOG_INFO("Applied framerate: requested " + std::to_string(requestedFps) +
+                 " fps → " + std::to_string(applied) + " fps");
+        return true;
+    }
+    @catch (NSException *ex)
+    {
+        LOG_WARN(std::string("applyClosestFramerate raised: ") +
+                 [[ex reason] UTF8String]);
+        return false;
+    }
+}
+
+} // namespace
+
 // Helper class para callback do AVFoundation
 @interface VideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
 {
@@ -895,15 +957,14 @@ bool VideoCaptureAVFoundation::setFormat(uint32_t width, uint32_t height, uint32
                             targetFps = static_cast<uint32_t>(maxFps);
                         }
                         
-                        // Configure framerate on device (while still locked)
-                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                        CMTime frameDuration = CMTimeMake(1, timescale);
-                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                        // Configure framerate on device (while still locked) — via the
+                        // helper that clamps to a supported rate and guards against
+                        // NSInvalidArgumentException when the requested rate isn't
+                        // representable as the device's rational format.
                         LOG_INFO("=== CONFIGURING FRAMERATE WITH FORMAT ===");
                         LOG_INFO("Format: " + std::to_string(m_width) + "x" + std::to_string(m_height));
-                        LOG_INFO("Device framerate configured: " + std::to_string(targetFps) + " fps (requested: " + 
-                                 std::to_string(m_fps) + " fps, found requested: " + (foundRequestedFps ? "yes" : "no") + ")");
+                        applyClosestFramerate(m_captureDevice, targetFps);
+                        (void)foundRequestedFps;
                     }
                 }
                 
@@ -957,10 +1018,8 @@ bool VideoCaptureAVFoundation::setFormat(uint32_t width, uint32_t height, uint32
                                 }
                                 
                                 // OBS Studio approach: set framerate directly on device
-                                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                                CMTime frameDuration = CMTimeMake(1, timescale);
-                                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                                // via helper that clamps to a supported rational rate.
+                                applyClosestFramerate(m_captureDevice, targetFps);
                             }
                         }
                         
@@ -1711,11 +1770,8 @@ bool VideoCaptureAVFoundation::startCapture()
                                         {
                                             targetFps = static_cast<uint32_t>(maxFps);
                                         }
-                                        
-                                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                                        CMTime frameDuration = CMTimeMake(1, timescale);
-                                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+
+                                        applyClosestFramerate(m_captureDevice, targetFps);
                                     }
                                 }
                             }
@@ -1953,15 +2009,9 @@ bool VideoCaptureAVFoundation::startCapture()
                                 {
                                     targetFps = static_cast<uint32_t>(maxFps);
                                 }
-                                
-                                // OBS Studio approach: set framerate directly on device
-                                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                                CMTime frameDuration = CMTimeMake(1, timescale);
-                                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
-                                
-                                LOG_INFO("Reconfigured framerate to: " + std::to_string(targetFps) + " fps (requested: " + 
-                                         std::to_string(m_fps) + " fps, found requested: " + (foundRequestedFps ? "yes" : "no") + ")");
+
+                                applyClosestFramerate(m_captureDevice, targetFps);
+                                (void)foundRequestedFps;
                             }
                         }
                         else
@@ -2557,18 +2607,13 @@ bool VideoCaptureAVFoundation::applyFormatAndFramerate(AVCaptureDeviceFormat* fo
                     targetFps = maxFps;
                 }
                 
-                // Step 3: Configure framerate on DEVICE (while still locked)
-                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
-                CMTime frameDuration = CMTimeMake(1, timescale);
-                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
-                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
-                
+                // Step 3: Configure framerate on DEVICE (while still locked) — via
+                // the clamping/guarded helper, otherwise an integer-vs-rational
+                // mismatch (e.g. 29 vs 1001/30000) would throw and crash here.
                 LOG_INFO("=== APPLYING FORMAT AND FRAMERATE ATOMICALLY ===");
                 CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
                 LOG_INFO("Format: " + std::to_string(dims.width) + "x" + std::to_string(dims.height));
-                LOG_INFO("Framerate: " + std::to_string(targetFps) + " fps (requested: " + std::to_string(fps) + 
-                        ", supported: " + std::to_string(bestRange.minFrameRate) + " - " + 
-                        std::to_string(bestRange.maxFrameRate) + " fps)");
+                applyClosestFramerate(m_captureDevice, targetFps);
                 
                 // Step 4: Configure framerate on CONNECTION (while device is still locked)
                 if (m_videoOutput)

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -2615,15 +2615,24 @@ bool VideoCaptureAVFoundation::applyFormatAndFramerate(AVCaptureDeviceFormat* fo
                 LOG_INFO("Format: " + std::to_string(dims.width) + "x" + std::to_string(dims.height));
                 applyClosestFramerate(m_captureDevice, targetFps);
                 
-                // Step 4: Configure framerate on CONNECTION (while device is still locked)
+                // Step 4: Configure framerate on CONNECTION (while device is still
+                // locked). Mirror the value the device ended up at — applyClosest-
+                // Framerate may have clamped it to a different rate than `targetFps`
+                // so read it back from the device rather than rebuilding from the
+                // integer.
                 if (m_videoOutput)
                 {
                     AVCaptureConnection* conn = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
                     if (conn)
                     {
-                        conn.videoMinFrameDuration = frameDuration;
-                        conn.videoMaxFrameDuration = frameDuration;
-                        LOG_INFO("Connection framerate configured: " + std::to_string(targetFps) + " fps");
+                        CMTime applied = m_captureDevice.activeVideoMinFrameDuration;
+                        conn.videoMinFrameDuration = applied;
+                        conn.videoMaxFrameDuration = applied;
+                        const double appliedFps = (CMTimeGetSeconds(applied) > 0.0)
+                            ? 1.0 / CMTimeGetSeconds(applied)
+                            : 0.0;
+                        LOG_INFO("Connection framerate configured: " +
+                                 std::to_string(appliedFps) + " fps");
                     }
                 }
                 

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -1,0 +1,3022 @@
+#include "VideoCaptureAVFoundation.h"
+#include "../utils/Logger.h"
+#include <algorithm>
+#include <cstring>
+#include <unistd.h> // for usleep
+#include <chrono> // for frame rate measurement
+
+#ifdef __APPLE__
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <CoreMedia/CoreMedia.h>
+#import <AudioToolbox/AudioToolbox.h>
+
+// Helper class para callback do AVFoundation
+@interface VideoCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+{
+    VideoCaptureAVFoundation* m_capture;
+}
+
+- (id)initWithCapture:(VideoCaptureAVFoundation*)capture;
+- (void)captureOutput:(AVCaptureOutput*)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection*)connection;
+
+@end
+
+@implementation VideoCaptureDelegate
+
+- (id)initWithCapture:(VideoCaptureAVFoundation*)capture
+{
+    self = [super init];
+    if (self)
+    {
+        m_capture = capture;
+    }
+    return self;
+}
+
+- (void)captureOutput:(AVCaptureOutput*)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection*)connection
+{
+    (void)output;
+    (void)connection;
+    
+    // CRITICAL: Minimize work in delegate - any delay here will cause frame drops
+    // OBS Studio approach: delegate should do MINIMAL work, just pass the buffer
+    CVImageBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (pixelBuffer)
+    {
+        // IMPORTANT: Call onFrameCaptured IMMEDIATELY, no logging or checks
+        // The sampleBuffer keeps the pixelBuffer alive during the callback
+        // Any delay here will cause AVFoundation to drop frames or reduce framerate
+        m_capture->onFrameCaptured(pixelBuffer);
+        
+        // CRITICAL: Do NOT do any logging or measurement in the delegate!
+        // This will block the delegate and cause frame drops
+        // OBS Studio approach: delegate does MINIMAL work, just passes the buffer
+        // All logging and measurement should be done in the main thread, not in the delegate
+    }
+}
+
+@end
+
+// Helper class para callback do AVFoundation (audio)
+@interface AudioCaptureDelegate : NSObject <AVCaptureAudioDataOutputSampleBufferDelegate>
+{
+    VideoCaptureAVFoundation* m_capture;
+}
+
+- (id)initWithCapture:(VideoCaptureAVFoundation*)capture;
+- (void)captureOutput:(AVCaptureOutput*)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection*)connection;
+
+@end
+
+@implementation AudioCaptureDelegate
+
+- (id)initWithCapture:(VideoCaptureAVFoundation*)capture
+{
+    self = [super init];
+    if (self)
+    {
+        m_capture = capture;
+    }
+    return self;
+}
+
+- (void)captureOutput:(AVCaptureOutput*)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection*)connection
+{
+    (void)output;
+    (void)connection;
+    
+    // CRITICAL: Minimize work in delegate - any delay here will cause audio drops
+    // OBS Studio approach: delegate should do MINIMAL work, just pass the buffer
+    if (sampleBuffer)
+    {
+        // IMPORTANT: Call onAudioSampleBuffer IMMEDIATELY, no logging or checks
+        // The sampleBuffer keeps the audio data alive during the callback
+        m_capture->onAudioSampleBuffer(sampleBuffer);
+    }
+}
+
+@end
+#endif
+
+VideoCaptureAVFoundation::VideoCaptureAVFoundation()
+#ifdef __APPLE__
+    : m_captureSession(nil)
+    , m_captureDevice(nil)
+    , m_videoOutput(nil)
+    , m_audioOutput(nil)
+    , m_captureQueue(nil)
+    , m_audioQueue(nil)
+    , m_latestPixelBuffer(nullptr)
+    , m_delegate(nil)
+    , m_audioDelegate(nil)
+    , m_frameBuffer(nullptr)
+    , m_frameBufferSize(0)
+    , m_bufferMutex()
+    , m_audioBuffer()
+    , m_audioBufferMutex()
+    , m_audioSampleRate(44100)
+    , m_audioChannels(2)
+    , m_hasAudio(false)
+    , m_selectedAudioDeviceId("")
+    , m_width(0)
+    , m_height(0)
+    , m_pixelFormat(0)
+    , m_fps(30) // Default to 30 fps
+    , m_isOpen(false)
+    , m_isCapturing(false)
+    , m_isClosing(false) // Atomic bool initialized in header
+    , m_dummyMode(false)
+    , m_formatSelectedViaUI(false)
+    , m_selectedFormatId("")
+#else
+    : m_width(0)
+    , m_height(0)
+    , m_pixelFormat(0)
+    , m_fps(30) // Default to 30 fps
+    , m_isOpen(false)
+    , m_isCapturing(false)
+    , m_dummyMode(false)
+#endif
+{
+}
+
+VideoCaptureAVFoundation::~VideoCaptureAVFoundation()
+{
+    close();
+}
+
+#ifdef __APPLE__
+void VideoCaptureAVFoundation::onFrameCaptured(CVPixelBufferRef pixelBuffer)
+{
+    // CRITICAL: Check if device is closing - if so, ignore this callback
+    // This prevents accessing freed resources during device change
+    if (m_isClosing || !pixelBuffer)
+    {
+        return;
+    }
+    
+    // CRITICAL: Minimize lock time - this is called from the delegate queue
+    // Any delay here will cause AVFoundation to drop frames or reduce framerate
+    // OBS Studio approach: minimal work, just swap the buffer reference
+    CVPixelBufferRef oldBuffer = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(m_bufferMutex);
+        // Double-check after acquiring lock (device might have started closing)
+        if (m_isClosing)
+        {
+            return;
+        }
+        oldBuffer = m_latestPixelBuffer;
+        // IMPORTANT: Retain BEFORE assigning to ensure buffer stays alive
+        // The delegate's sampleBuffer will release its reference when callback returns
+        CVPixelBufferRetain(pixelBuffer);
+        m_latestPixelBuffer = pixelBuffer;
+    }
+    
+    // Release old buffer OUTSIDE the lock to minimize blocking
+    // This prevents the delegate from being blocked by CVPixelBufferRelease
+    if (oldBuffer)
+    {
+        CVPixelBufferRelease(oldBuffer);
+    }
+}
+#endif
+
+bool VideoCaptureAVFoundation::open(const std::string &device)
+{
+    if (m_isOpen)
+    {
+        LOG_WARN("Dispositivo já aberto, fechando primeiro");
+        close();
+    }
+
+    // Reset closing flag when opening new device
+    m_isClosing = false;
+
+    if (m_dummyMode)
+    {
+        m_isOpen = true;
+        LOG_INFO("Modo dummy ativado");
+        return true;
+    }
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        // Criar capture session
+        m_captureSession = [[AVCaptureSession alloc] init];
+        if (!m_captureSession)
+        {
+            LOG_ERROR("Falha ao criar AVCaptureSession");
+    return false;
+        }
+        
+        // IMPORTANT: OBS Studio approach - do NOT set sessionPreset when using manual format control
+        // The activeFormat of the device will determine the resolution
+        // Setting a preset (even Low) can interfere with activeFormat on some devices
+        // We'll configure the format explicitly via activeFormat within beginConfiguration/commitConfiguration
+        // Note: AVCaptureSessionPresetInputPriority is NOT available on macOS (iOS/iPadOS only)
+        // OBS Studio does not set sessionPreset when using manual format configuration
+        LOG_INFO("Session created - format will be controlled via activeFormat (no preset)");
+        
+        // Selecionar dispositivo
+        AVCaptureDevice* deviceObj = nil;
+        
+        if (device.empty() || device == "default")
+        {
+            // Usar dispositivo padrão
+            deviceObj = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+        }
+        else
+        {
+            // Buscar dispositivo usando AVCaptureDeviceDiscoverySession (API moderna)
+            AVCaptureDeviceDiscoverySession* discoverySession = [AVCaptureDeviceDiscoverySession 
+                discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
+                mediaType:AVMediaTypeVideo
+                position:AVCaptureDevicePositionUnspecified];
+            NSArray* devices = [discoverySession devices];
+            for (AVCaptureDevice* dev in devices)
+            {
+                NSString* uniqueID = [dev uniqueID];
+                NSString* localizedName = [dev localizedName];
+                
+                if ([uniqueID UTF8String] == device || 
+                    [localizedName UTF8String] == device)
+                {
+                    deviceObj = dev;
+                    break;
+                }
+            }
+        }
+        
+        if (!deviceObj)
+        {
+            LOG_ERROR("Dispositivo não encontrado: " + device);
+            [m_captureSession release];
+            m_captureSession = nil;
+            return false;
+        }
+        
+        m_captureDevice = deviceObj;
+        
+        // IMPORTANT: OBS Studio approach - use beginConfiguration/commitConfiguration
+        // Configure format and add input ALL within the same configuration block
+        [m_captureSession beginConfiguration];
+        
+        // CRITICAL: OBS Studio approach - configure format WITHIN beginConfiguration/commitConfiguration
+        // This ensures the format is set atomically with the input addition
+        // If m_width/m_height are already set (from previous setFormat call), use them
+        if (m_width > 0 && m_height > 0)
+        {
+            LOG_INFO("Setting format during open() before adding input: " + 
+                     std::to_string(m_width) + "x" + std::to_string(m_height));
+            
+            // Lock device for configuration (within beginConfiguration block)
+            NSError* configError = nil;
+            if ([deviceObj lockForConfiguration:&configError])
+            {
+                // IMPORTANT: OBS Studio approach - find format matching dimensions AND prefer native formats (NV12/YUY2)
+                // OBS prioritizes formats with native pixel formats (NV12 420v, YUY2 yuvs) over BGRA
+                // This ensures the device uses its native format, which is more efficient and reliable
+                AVCaptureDeviceFormat* exactFormat = nil;
+                AVCaptureDeviceFormat* exactFormatNative = nil; // Prefer native formats
+                
+                for (AVCaptureDeviceFormat* format in [deviceObj formats])
+                {
+                    CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+                    if (dims.width == static_cast<int32_t>(m_width) && 
+                        dims.height == static_cast<int32_t>(m_height))
+                    {
+                        // Check pixel format - prefer native formats (NV12, YUY2)
+                        CMFormatDescriptionRef formatDesc = [format formatDescription];
+                        FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                        
+                        // IMPORTANT: OBS Studio approach - prefer native formats
+                        // NV12 (420v) = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange (0x34323076)
+                        // YUY2 (yuvs) = kCVPixelFormatType_422YpCbCr8_yuvs (0x79757673)
+                        // Also check for other common YUV formats
+                        if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+                            pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs ||
+                            pixelFormat == kCVPixelFormatType_422YpCbCr8 ||
+                            pixelFormat == 0x79757673 || // 'yuvs' (YUY2)
+                            pixelFormat == 0x34323076)   // '420v' (NV12)
+                        {
+                            exactFormatNative = format; // Prefer native format
+                        }
+                        else if (!exactFormat)
+                        {
+                            exactFormat = format; // Fallback to any matching format
+                        }
+                    }
+                }
+                
+                // Use native format if found, otherwise use any matching format
+                if (exactFormatNative)
+                {
+                    exactFormat = exactFormatNative;
+                }
+                
+                if (exactFormat)
+                {
+                    // IMPORTANT: Set format WITHIN beginConfiguration/commitConfiguration (OBS Studio approach)
+                    deviceObj.activeFormat = exactFormat;
+                    
+                    // Log pixel format for debugging (OBS Studio approach)
+                    CMFormatDescriptionRef formatDesc = [exactFormat formatDescription];
+                    FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                    const char* formatName = "Unknown";
+                    if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+                        formatName = "NV12 (420v)";
+                    else if (pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs)
+                        formatName = "YUY2 (yuvs)";
+                    else if (pixelFormat == kCVPixelFormatType_32BGRA)
+                        formatName = "BGRA";
+                    
+                    LOG_INFO("Format set during open(): " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                             " (pixel format: " + formatName + ", 0x" + std::to_string(pixelFormat) + ")");
+                }
+                else
+                {
+                    LOG_WARN("Exact format " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                             " not found during open(), will use device default");
+                }
+                
+                [deviceObj unlockForConfiguration];
+            }
+            else
+            {
+                LOG_WARN("Could not lock device for configuration during open(): " + 
+                         std::string([[configError localizedDescription] UTF8String]));
+            }
+        }
+        else
+        {
+            LOG_INFO("No format dimensions set yet, will be configured in setFormat()");
+        }
+        
+        // Criar input (device format should now be set)
+        NSError* error = nil;
+        AVCaptureDeviceInput* input = [[AVCaptureDeviceInput alloc] initWithDevice:deviceObj error:&error];
+        if (!input)
+        {
+            LOG_ERROR("Falha ao criar AVCaptureDeviceInput: " + std::string([[error localizedDescription] UTF8String]));
+            [m_captureSession commitConfiguration];
+            [m_captureSession release];
+            m_captureSession = nil;
+            m_captureDevice = nil;
+            return false;
+        }
+        
+        if (![m_captureSession canAddInput:input])
+        {
+            LOG_ERROR("Não é possível adicionar input à sessão");
+            [input release];
+            [m_captureSession commitConfiguration];
+            [m_captureSession release];
+            m_captureSession = nil;
+            m_captureDevice = nil;
+            return false;
+        }
+        
+        // IMPORTANT: Add input within beginConfiguration/commitConfiguration (OBS Studio approach)
+        // This is done AFTER setting the format, all within the same configuration block
+        [m_captureSession addInput:input];
+        [input release];
+        
+        // Criar output
+        m_videoOutput = [[AVCaptureVideoDataOutput alloc] init];
+        if (!m_videoOutput)
+        {
+            LOG_ERROR("Falha ao criar AVCaptureVideoDataOutput");
+            [m_captureSession release];
+            m_captureSession = nil;
+            m_captureDevice = nil;
+            return false;
+        }
+        
+        // IMPORTANT: OBS Studio approach - do NOT force pixel format in videoSettings
+        // Let the device use its native format (NV12, YUY2, etc.) from activeFormat
+        // Forcing BGRA can cause format mismatches and performance issues
+        // The activeFormat's native pixel format will be used automatically
+        // If we need BGRA, we can convert from the native format in the delegate
+        // For now, let's try without forcing a format to see if it helps with format selection
+        NSDictionary* videoSettings = @{
+            (NSString*)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
+        };
+        [m_videoOutput setVideoSettings:videoSettings];
+        
+        // IMPORTANT: Try NO to allow buffering - this may help with framerate
+        // When YES, frames are discarded if processing is delayed, which can cause low framerate
+        // When NO, frames are buffered and delivered even if processing is slightly delayed
+        // This is a trade-off: YES = lower latency but may drop frames, NO = higher latency but more stable framerate
+        m_videoOutput.alwaysDiscardsLateVideoFrames = NO; // Buffer frames to maintain framerate
+        
+        // IMPORTANT: OBS Studio approach - use a simple serial queue (not high priority)
+        // High priority queues can cause scheduling issues and may not help with framerate
+        // OBS Studio uses: dispatch_queue_create(nil, nil) - simple serial queue
+        m_captureQueue = dispatch_queue_create("com.retrocapture.capture", DISPATCH_QUEUE_SERIAL);
+        
+        // Criar delegate
+        m_delegate = [[VideoCaptureDelegate alloc] initWithCapture:this];
+        [m_videoOutput setSampleBufferDelegate:m_delegate queue:m_captureQueue];
+        
+        if (![m_captureSession canAddOutput:m_videoOutput])
+        {
+            LOG_ERROR("Não é possível adicionar output à sessão");
+            [m_videoOutput release];
+            [m_delegate release];
+            dispatch_release(m_captureQueue);
+            m_videoOutput = nil;
+            m_delegate = nil;
+            m_captureQueue = nil;
+            [m_captureSession commitConfiguration];
+            [m_captureSession release];
+            m_captureSession = nil;
+            m_captureDevice = nil;
+            return false;
+        }
+        
+        // IMPORTANT: Add output within beginConfiguration/commitConfiguration (OBS Studio approach)
+        [m_captureSession addOutput:m_videoOutput];
+        
+        // Try to add audio capture if device supports audio
+        // Use user-selected audio device if available, otherwise try to auto-detect
+        AVCaptureDevice* audioDevice = nil;
+        
+        // Get all audio devices (using modern API)
+        AVCaptureDeviceDiscoverySession* audioDiscoverySession = [AVCaptureDeviceDiscoverySession 
+            discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInMicrophone, AVCaptureDeviceTypeExternalUnknown]
+            mediaType:AVMediaTypeAudio
+            position:AVCaptureDevicePositionUnspecified];
+        NSArray* audioDevices = audioDiscoverySession.devices;
+        
+        // If user has selected an audio device, use it
+        if (!m_selectedAudioDeviceId.empty())
+        {
+            NSString* selectedAudioDeviceId = [NSString stringWithUTF8String:m_selectedAudioDeviceId.c_str()];
+            for (AVCaptureDevice* dev in audioDevices)
+            {
+                NSString* audioDeviceUniqueID = [dev uniqueID];
+                if ([audioDeviceUniqueID isEqualToString:selectedAudioDeviceId])
+                {
+                    audioDevice = dev;
+                    LOG_INFO("Using user-selected audio device: " + std::string([[dev localizedName] UTF8String]));
+                    break;
+                }
+            }
+            
+            if (!audioDevice)
+            {
+                LOG_WARN("Selected audio device not found: " + m_selectedAudioDeviceId);
+            }
+        }
+        
+        // If no user-selected device, try to auto-detect matching audio device
+        if (!audioDevice)
+        {
+            // Try to find audio device matching the video device
+            // Strategy: match by device name or uniqueID prefix
+            NSString* videoDeviceName = [deviceObj localizedName];
+            NSString* videoDeviceUniqueID = [deviceObj uniqueID];
+            
+            for (AVCaptureDevice* dev in audioDevices)
+            {
+                NSString* audioDeviceName = [dev localizedName];
+                NSString* audioDeviceUniqueID = [dev uniqueID];
+                
+                // Try to match by name (many devices have audio with similar names)
+                // For example: "USB Video" might have "USB Video Audio" or similar
+                if ([audioDeviceName rangeOfString:videoDeviceName options:NSCaseInsensitiveSearch].location != NSNotFound ||
+                    [videoDeviceName rangeOfString:audioDeviceName options:NSCaseInsensitiveSearch].location != NSNotFound)
+                {
+                    audioDevice = dev;
+                    LOG_INFO("Found matching audio device: " + std::string([audioDeviceName UTF8String]));
+                    break;
+                }
+                
+                // Try to match by uniqueID prefix (some devices share a common prefix)
+                // For example: "0x12345678" and "0x12345678-audio"
+                if ([audioDeviceUniqueID hasPrefix:videoDeviceUniqueID] || 
+                    [videoDeviceUniqueID hasPrefix:audioDeviceUniqueID])
+                {
+                    audioDevice = dev;
+                    LOG_INFO("Found matching audio device by ID: " + std::string([audioDeviceName UTF8String]));
+                    break;
+                }
+            }
+            
+            // If no matching audio device found, don't use audio
+            // User can manually select an audio device via UI
+            if (!audioDevice)
+            {
+                LOG_INFO("No audio device found matching video device: " + std::string([videoDeviceName UTF8String]));
+                LOG_INFO("Use the Audio Device selector in the UI to choose an audio input");
+            }
+        }
+        
+        if (audioDevice)
+        {
+            // Create audio input
+            NSError* audioError = nil;
+            AVCaptureDeviceInput* audioInput = [[AVCaptureDeviceInput alloc] initWithDevice:audioDevice error:&audioError];
+            if (audioInput && [m_captureSession canAddInput:audioInput])
+            {
+                [m_captureSession addInput:audioInput];
+                [audioInput release];
+                
+                // Create audio output
+                m_audioOutput = [[AVCaptureAudioDataOutput alloc] init];
+                if (m_audioOutput)
+                {
+                    // Create audio queue
+                    m_audioQueue = dispatch_queue_create("com.retrocapture.audio", DISPATCH_QUEUE_SERIAL);
+                    
+                    // Create audio delegate
+                    m_audioDelegate = [[AudioCaptureDelegate alloc] initWithCapture:this];
+                    [m_audioOutput setSampleBufferDelegate:m_audioDelegate queue:m_audioQueue];
+                    
+                    if ([m_captureSession canAddOutput:m_audioOutput])
+                    {
+                        [m_captureSession addOutput:m_audioOutput];
+                        m_hasAudio = true;
+                        LOG_INFO("Audio capture enabled for device: " + std::string([[audioDevice localizedName] UTF8String]));
+                    }
+                    else
+                    {
+                        LOG_WARN("Cannot add audio output to session");
+                        [m_audioOutput release];
+                        [m_audioDelegate release];
+                        dispatch_release(m_audioQueue);
+                        m_audioOutput = nil;
+                        m_audioDelegate = nil;
+                        m_audioQueue = nil;
+                    }
+                }
+            }
+            else
+            {
+                if (audioError)
+                {
+                    LOG_WARN("Cannot create audio input: " + std::string([[audioError localizedDescription] UTF8String]));
+                }
+                else
+                {
+                    LOG_WARN("Cannot add audio input to session");
+                }
+                if (audioInput)
+                {
+                    [audioInput release];
+                }
+            }
+        }
+        else
+        {
+            LOG_INFO("No audio device found for video device");
+        }
+        
+        // IMPORTANT: Commit configuration changes atomically (OBS Studio approach)
+        [m_captureSession commitConfiguration];
+        
+        m_isOpen = true;
+        LOG_INFO("Dispositivo aberto: " + std::string([[deviceObj localizedName] UTF8String]));
+        return true;
+    }
+#else
+    LOG_ERROR("AVFoundation só está disponível no macOS");
+    return false;
+#endif
+}
+
+void VideoCaptureAVFoundation::close()
+{
+    // CRITICAL: Set closing flag FIRST to prevent callbacks from accessing resources
+    m_isClosing = true;
+    
+    if (m_isCapturing)
+    {
+        stopCapture();
+    }
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        // CRITICAL: Order matters for thread safety
+        // 1. Stop session first to prevent new callbacks
+        if (m_captureSession)
+        {
+            if ([m_captureSession isRunning])
+            {
+                [m_captureSession stopRunning];
+            }
+        }
+        
+        // 2. Remove delegates IMMEDIATELY to prevent callbacks from accessing freed resources
+        // This must be done BEFORE releasing queues or delegates
+        if (m_videoOutput)
+        {
+            [m_videoOutput setSampleBufferDelegate:nil queue:nil];
+        }
+        
+        if (m_audioOutput)
+        {
+            [m_audioOutput setSampleBufferDelegate:nil queue:nil];
+        }
+        
+        // 3. Remove outputs from session (must be done within configuration block)
+        if (m_captureSession)
+        {
+            [m_captureSession beginConfiguration];
+            
+            if (m_videoOutput && [[m_captureSession outputs] containsObject:m_videoOutput])
+            {
+                [m_captureSession removeOutput:m_videoOutput];
+            }
+            
+            if (m_audioOutput && [[m_captureSession outputs] containsObject:m_audioOutput])
+            {
+                [m_captureSession removeOutput:m_audioOutput];
+            }
+            
+            [m_captureSession commitConfiguration];
+        }
+        
+        // 4. Wait for any pending callbacks to complete
+        // Use a small delay to allow callbacks to finish (dispatch_sync can deadlock if called from same queue)
+        // The m_isClosing flag will prevent callbacks from accessing resources
+        usleep(100000); // 100ms - enough for callbacks to complete and check m_isClosing flag
+        
+        // 5. Now safe to release queues (no more callbacks will use them)
+        if (m_audioQueue)
+        {
+            dispatch_release(m_audioQueue);
+            m_audioQueue = nil;
+        }
+        
+        if (m_captureQueue)
+        {
+            dispatch_release(m_captureQueue);
+            m_captureQueue = nil;
+        }
+        
+        // 6. Release delegates (no longer needed)
+        if (m_delegate)
+        {
+            [m_delegate release];
+            m_delegate = nil;
+        }
+        
+        if (m_audioDelegate)
+        {
+            [m_audioDelegate release];
+            m_audioDelegate = nil;
+        }
+        
+        // 7. Release outputs
+        if (m_videoOutput)
+        {
+            [m_videoOutput release];
+            m_videoOutput = nil;
+        }
+        
+        if (m_audioOutput)
+        {
+            [m_audioOutput release];
+            m_audioOutput = nil;
+        }
+        
+        // 8. Release session
+        if (m_captureSession)
+        {
+            [m_captureSession release];
+            m_captureSession = nil;
+        }
+        
+        m_captureDevice = nil;
+        
+        // 9. Clear buffers (safe now, no callbacks can access them)
+        {
+            std::lock_guard<std::mutex> lock(m_audioBufferMutex);
+            m_audioBuffer.clear();
+        }
+        m_hasAudio = false;
+        
+        {
+            std::lock_guard<std::mutex> lock(m_bufferMutex);
+    if (m_latestPixelBuffer)
+    {
+        CVPixelBufferRelease(m_latestPixelBuffer);
+        m_latestPixelBuffer = nullptr;
+            }
+        }
+        
+        if (m_frameBuffer)
+        {
+            delete[] m_frameBuffer;
+            m_frameBuffer = nullptr;
+            m_frameBufferSize = 0;
+        }
+    }
+#endif
+
+    m_isOpen = false;
+    m_isClosing = false; // Reset flag after cleanup is complete
+    m_dummyFrameBuffer.clear();
+    LOG_INFO("Dispositivo fechado");
+}
+
+bool VideoCaptureAVFoundation::isOpen() const
+{
+    return m_isOpen || m_dummyMode;
+}
+
+bool VideoCaptureAVFoundation::setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat)
+{
+    // CRITICAL: If a format was selected via UI (setFormatById), do NOT override it
+    // This prevents setFormat from overwriting the user's explicit format selection
+    if (m_formatSelectedViaUI && !m_selectedFormatId.empty())
+    {
+        LOG_INFO("Format was selected via UI - ignoring setFormat() call to preserve user selection");
+        LOG_INFO("Selected format ID: " + m_selectedFormatId);
+        return true; // Return success to avoid errors, but don't change the format
+    }
+    
+    if (m_dummyMode)
+    {
+        m_width = width;
+        m_height = height;
+        m_pixelFormat = pixelFormat != 0 ? pixelFormat : 0x56595559; // YUYV equivalent
+
+        size_t frameSize = width * height * 2;
+        m_dummyFrameBuffer.resize(frameSize, 0);
+
+        LOG_INFO("Formato dummy definido: " + std::to_string(m_width) + "x" +
+                 std::to_string(m_height));
+        return true;
+    }
+
+    if (!m_isOpen)
+    {
+        LOG_ERROR("Dispositivo não aberto");
+        return false;
+    }
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        // Configurar formato do dispositivo
+        if (m_captureDevice)
+        {
+            NSError* error = nil;
+            if ([m_captureDevice lockForConfiguration:&error])
+            {
+                // Calcular aspect ratio solicitado
+                float requestedAspect = static_cast<float>(width) / static_cast<float>(height);
+                
+                // Tentar encontrar formato que corresponda à resolução desejada
+                NSArray* formats = [m_captureDevice formats];
+                AVCaptureDeviceFormat* exactFormat = nil;
+                AVCaptureDeviceFormat* aspectFormat = nil;
+                float bestAspectDiff = 999.0f;
+                uint32_t bestAspectWidth = 0;
+                uint32_t bestAspectHeight = 0;
+                
+                // IMPORTANT: OBS Studio approach - prefer native formats (NV12/YUY2)
+                AVCaptureDeviceFormat* exactFormatNative = nil;
+                
+                for (AVCaptureDeviceFormat* format in formats)
+                {
+                    CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+                    
+                    // Verificar formato exato
+                    if ((int32_t)dims.width == (int32_t)width && (int32_t)dims.height == (int32_t)height)
+                    {
+                        // Check pixel format - prefer native formats (NV12, YUY2)
+                        CMFormatDescriptionRef formatDesc = [format formatDescription];
+                        FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                        
+                        // IMPORTANT: OBS Studio approach - prefer native formats
+                        // NV12 (420v) = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange (0x34323076)
+                        // YUY2 (yuvs) = kCVPixelFormatType_422YpCbCr8_yuvs (0x79757673)
+                        // Also check for other common YUV formats
+                        if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+                            pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs ||
+                            pixelFormat == kCVPixelFormatType_422YpCbCr8 ||
+                            pixelFormat == 0x79757673 || // 'yuvs' (YUY2)
+                            pixelFormat == 0x34323076)   // '420v' (NV12)
+                        {
+                            exactFormatNative = format; // Prefer native format
+                        }
+                        else if (!exactFormat)
+                        {
+                            exactFormat = format; // Fallback to any matching format
+                        }
+                    }
+                    
+                    // Se não encontrou formato exato, procurar por formato com mesmo aspect ratio
+                    float formatAspect = static_cast<float>(dims.width) / static_cast<float>(dims.height);
+                    float aspectDiff = std::abs(formatAspect - requestedAspect);
+                    
+                    if (aspectDiff < bestAspectDiff)
+                    {
+                        bestAspectDiff = aspectDiff;
+                        aspectFormat = format;
+                        bestAspectWidth = dims.width;
+                        bestAspectHeight = dims.height;
+                    }
+                }
+                
+                // Use native format if found, otherwise use any matching format
+                if (exactFormatNative)
+                {
+                    exactFormat = exactFormatNative;
+                }
+                
+                if (exactFormat)
+                {
+                    m_captureDevice.activeFormat = exactFormat;
+    m_width = width;
+    m_height = height;
+                    
+                    // Log pixel format for debugging
+                    CMFormatDescriptionRef formatDesc = [exactFormat formatDescription];
+                    FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                    LOG_INFO("Formato exato encontrado: " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                             " (pixel format: 0x" + std::to_string(pixelFormat) + ")");
+                }
+                else if (aspectFormat && bestAspectDiff < 0.1f) // Tolerância de 0.1 para aspect ratio
+                {
+                    m_captureDevice.activeFormat = aspectFormat;
+                    m_width = bestAspectWidth;
+                    m_height = bestAspectHeight;
+                    LOG_WARN("Formato exato não encontrado, usando formato com mesmo aspect ratio: " + 
+                             std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                             " (solicitado: " + std::to_string(width) + "x" + std::to_string(height) + ")");
+                }
+                else
+                {
+                    LOG_WARN("Formato com aspect ratio similar não encontrado, usando formato do dispositivo");
+                    CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                    m_width = dims.width;
+                    m_height = dims.height;
+                    LOG_WARN("Formato do dispositivo: " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                             " (solicitado: " + std::to_string(width) + "x" + std::to_string(height) + ")");
+                }
+                
+                // IMPORTANT: Configure framerate on DEVICE BEFORE unlocking
+                // This ensures format and framerate are configured together atomically
+                // The framerate MUST be set on the device while it's still locked
+                if (m_width > 0 && m_height > 0 && m_fps > 0)
+                {
+                    NSArray* frameRateRanges = [m_captureDevice.activeFormat videoSupportedFrameRateRanges];
+                    if (frameRateRanges && [frameRateRanges count] > 0)
+                    {
+                        // Find best framerate (requested or max supported)
+                        uint32_t targetFps = m_fps;
+                        bool foundRequestedFps = false;
+                        double maxFps = 0.0;
+                        
+                        for (AVFrameRateRange* range in frameRateRanges)
+                        {
+                            if (range.maxFrameRate > maxFps)
+                            {
+                                maxFps = range.maxFrameRate;
+                            }
+                            
+                            // Check if requested fps is supported
+                            if (m_fps >= range.minFrameRate && m_fps <= range.maxFrameRate)
+                            {
+                                targetFps = m_fps;
+                                foundRequestedFps = true;
+                                break;
+                            }
+                        }
+                        
+                        // If requested fps not supported, use max
+                        if (!foundRequestedFps && maxFps > 0.0)
+                        {
+                            targetFps = static_cast<uint32_t>(maxFps);
+                        }
+                        
+                        // Configure framerate on device (while still locked)
+                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                        CMTime frameDuration = CMTimeMake(1, timescale);
+                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                        LOG_INFO("=== CONFIGURING FRAMERATE WITH FORMAT ===");
+                        LOG_INFO("Format: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+                        LOG_INFO("Device framerate configured: " + std::to_string(targetFps) + " fps (requested: " + 
+                                 std::to_string(m_fps) + " fps, found requested: " + (foundRequestedFps ? "yes" : "no") + ")");
+                    }
+                }
+                
+                [m_captureDevice unlockForConfiguration];
+                
+                // IMPORTANT: OBS Studio approach - if session is already running, use beginConfiguration/commitConfiguration
+                // WITHOUT removing inputs/outputs. Just reconfigure the format directly.
+                if (m_captureSession && [m_captureSession isRunning])
+                {
+                    LOG_INFO("Session is running - reconfiguring format using OBS Studio approach");
+                    
+                    // IMPORTANT: Stop session BEFORE beginConfiguration
+                    [m_captureSession stopRunning];
+                    usleep(50000); // 50ms delay
+                    
+                    // IMPORTANT: OBS Studio approach - beginConfiguration BEFORE locking device
+                    [m_captureSession beginConfiguration];
+                    
+                    // IMPORTANT: OBS Studio approach - lock device and reconfigure format/framerate
+                    // WITHOUT removing inputs/outputs
+                    NSError* configError = nil;
+                    if ([m_captureDevice lockForConfiguration:&configError])
+                    {
+                        // Format was already set above, but we need to ensure framerate is also set
+                        if (m_fps > 0)
+                        {
+                            NSArray* frameRateRanges = [m_captureDevice.activeFormat videoSupportedFrameRateRanges];
+                            if (frameRateRanges && [frameRateRanges count] > 0)
+                            {
+                                uint32_t targetFps = m_fps;
+                                bool foundRequestedFps = false;
+                                double maxFps = 0.0;
+                                
+                                for (AVFrameRateRange* range in frameRateRanges)
+                                {
+                                    if (range.maxFrameRate > maxFps)
+                                    {
+                                        maxFps = range.maxFrameRate;
+                                    }
+                                    if (m_fps >= range.minFrameRate && m_fps <= range.maxFrameRate)
+                                    {
+                                        targetFps = m_fps;
+                                        foundRequestedFps = true;
+                                        break;
+                                    }
+                                }
+                                
+                                if (!foundRequestedFps && maxFps > 0.0)
+                                {
+                                    targetFps = static_cast<uint32_t>(maxFps);
+                                }
+                                
+                                // OBS Studio approach: set framerate directly on device
+                                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                                CMTime frameDuration = CMTimeMake(1, timescale);
+                                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                            }
+                        }
+                        
+                        [m_captureDevice unlockForConfiguration];
+                    }
+                    
+                    // IMPORTANT: Commit configuration changes atomically (OBS Studio approach)
+                    [m_captureSession commitConfiguration];
+                    
+                    // Session will be restarted by startCapture()
+                }
+                else if (m_videoOutput && m_captureSession && ![m_captureSession isRunning])
+                {
+                    // Session not running yet - just ensure output is added
+                    // Format was set before input was added (in open()), so it should be respected
+                    if (![m_captureSession.outputs containsObject:m_videoOutput])
+                    {
+                        if ([m_captureSession canAddOutput:m_videoOutput])
+                        {
+                            [m_captureSession addOutput:m_videoOutput];
+                            [m_videoOutput setSampleBufferDelegate:m_delegate queue:m_captureQueue];
+                            LOG_INFO("Added output to session with format: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+                        }
+                    }
+                }
+                
+                // IMPORTANT: Format is now set
+                // If session was running, it will be restarted by startCapture()
+                // If session was not running, format was set before input was added, so it should be respected
+                LOG_INFO("Format configured: " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                         " (session will use this format when started)");
+            }
+            else
+            {
+                LOG_ERROR("Falha ao bloquear dispositivo para configuração");
+                return false;
+            }
+        }
+    }
+#else
+    m_width = width;
+    m_height = height;
+    m_pixelFormat = pixelFormat;
+    LOG_INFO("Formato definido: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+#endif
+
+    return true;
+}
+
+bool VideoCaptureAVFoundation::setFramerate(uint32_t fps)
+{
+    // Store requested framerate
+    m_fps = fps;
+    
+    if (m_dummyMode)
+    {
+        return true;
+    }
+
+    if (!m_isOpen)
+    {
+        LOG_ERROR("Dispositivo não aberto");
+        return false;
+    }
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        if (m_captureDevice)
+        {
+            // IMPORTANT: Do NOT stop/start the session here
+            // The session should only be started/stopped in startCapture()/stopCapture()
+            // This prevents AVFoundation from renegotiating the stream and falling back to defaults
+            
+            NSError* error = nil;
+            if ([m_captureDevice lockForConfiguration:&error])
+            {
+                // Log framerate ranges suportados para diagnóstico
+                NSArray* frameRateRanges = [m_captureDevice.activeFormat videoSupportedFrameRateRanges];
+                LOG_INFO("=== FRAMERATE CONFIGURATION ===");
+                LOG_INFO("Requested framerate: " + std::to_string(fps) + " fps");
+                LOG_INFO("Supported framerate ranges for current format:");
+                for (AVFrameRateRange* range in frameRateRanges)
+                {
+                    LOG_INFO("  " + std::to_string(range.minFrameRate) + " - " + 
+                             std::to_string(range.maxFrameRate) + " fps");
+                }
+                
+                // Configurar framerate no device
+                AVFrameRateRange* bestRange = nil;
+                for (AVFrameRateRange* range in frameRateRanges)
+                {
+                    if (fps >= range.minFrameRate && fps <= range.maxFrameRate)
+                    {
+                        bestRange = range;
+                        break;
+                    }
+                }
+                
+                if (bestRange)
+                {
+                    // IMPORTANT: Use high timescale to avoid rounding issues
+                    // For exact fps like 30, use CMTime(value: 1, timescale: 30)
+                    CMTimeScale timescale = static_cast<CMTimeScale>(fps);
+                    CMTime frameDuration = CMTimeMake(1, timescale);
+                    
+                    m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                    m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                    LOG_INFO("Device framerate configured: " + std::to_string(fps) + " fps (timescale: " + std::to_string(timescale) + ")");
+                    
+                    // Verificar se foi aplicado corretamente
+                    CMTime actualMinDuration = m_captureDevice.activeVideoMinFrameDuration;
+                    CMTime actualMaxDuration = m_captureDevice.activeVideoMaxFrameDuration;
+                    double actualMinFps = 1.0 / (CMTimeGetSeconds(actualMinDuration));
+                    double actualMaxFps = 1.0 / (CMTimeGetSeconds(actualMaxDuration));
+                    LOG_INFO("Actual device framerate range: " + std::to_string(actualMinFps) + " - " + 
+                             std::to_string(actualMaxFps) + " fps");
+                    
+                    if (std::abs(actualMinFps - fps) > 0.1 || std::abs(actualMaxFps - fps) > 0.1)
+                    {
+                        LOG_WARN("Device framerate may not have been applied correctly!");
+                        LOG_WARN("Requested: " + std::to_string(fps) + " fps");
+                        LOG_WARN("Actual: " + std::to_string(actualMinFps) + " - " + std::to_string(actualMaxFps) + " fps");
+                    }
+                }
+                else
+                {
+                    LOG_WARN("Framerate " + std::to_string(fps) + " fps não suportado pelo formato atual");
+                    LOG_WARN("Usando padrão do dispositivo");
+                    
+                    // Tentar usar o framerate máximo suportado mais próximo
+                    double bestFps = 0.0;
+                    for (AVFrameRateRange* range in frameRateRanges)
+                    {
+                        if (range.maxFrameRate > bestFps)
+                        {
+                            bestFps = range.maxFrameRate;
+                        }
+                    }
+                    
+                    if (bestFps > 0.0)
+                    {
+                        uint32_t targetFps = static_cast<uint32_t>(bestFps);
+                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                        CMTime frameDuration = CMTimeMake(1, timescale);
+                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                        LOG_INFO("Usando framerate máximo suportado: " + std::to_string(targetFps) + " fps");
+                    }
+                }
+                
+                LOG_INFO("==============================");
+                
+                [m_captureDevice unlockForConfiguration];
+                
+                // IMPORTANT: Also configure framerate on the connection
+                // Many devices (especially UVC capture cards) require framerate to be set on the connection
+                // in addition to the device, otherwise the effective framerate may be stuck
+                if (m_videoOutput)
+                {
+                    AVCaptureConnection* conn = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
+                    if (conn && [conn respondsToSelector:@selector(setVideoMinFrameDuration:)])
+                    {
+                        uint32_t targetFps = fps;
+                        if (bestRange)
+                        {
+                            targetFps = fps;
+                        }
+                        else
+                        {
+                            // Use max supported if requested not supported
+                            double bestFps = 0.0;
+                            for (AVFrameRateRange* range in frameRateRanges)
+                            {
+                                if (range.maxFrameRate > bestFps)
+                                {
+                                    bestFps = range.maxFrameRate;
+                                }
+                            }
+                            if (bestFps > 0.0)
+                            {
+                                targetFps = static_cast<uint32_t>(bestFps);
+                            }
+                        }
+                        
+                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                        CMTime frameDuration = CMTimeMake(1, timescale);
+                        conn.videoMinFrameDuration = frameDuration;
+                        conn.videoMaxFrameDuration = frameDuration;
+                        LOG_INFO("Connection framerate configured: " + std::to_string(targetFps) + " fps");
+                    }
+                }
+            }
+            else
+            {
+                LOG_ERROR("Falha ao bloquear dispositivo para configuração de framerate: " + 
+                         std::string([[error localizedDescription] UTF8String]));
+            }
+        }
+    }
+#endif
+
+    return true;
+}
+
+bool VideoCaptureAVFoundation::captureFrame(Frame &frame)
+{
+    return captureLatestFrame(frame);
+}
+
+bool VideoCaptureAVFoundation::captureLatestFrame(Frame &frame)
+{
+    if (m_dummyMode)
+    {
+        generateDummyFrame(frame);
+        return true;
+    }
+
+    if (!m_isOpen || !m_isCapturing)
+    {
+        return false;
+    }
+
+#ifdef __APPLE__
+    CVPixelBufferRef pb = nullptr;
+    
+    // IMPORTANT: Get the buffer pointer quickly (short lock)
+    // Do NOT hold the lock during conversion - this blocks the delegate!
+    {
+    std::lock_guard<std::mutex> lock(m_bufferMutex);
+        pb = m_latestPixelBuffer;
+        if (pb)
+        {
+            CVPixelBufferRetain(pb);
+        }
+    }
+    
+    // Convert outside the lock (doesn't block the delegate)
+    bool ok = false;
+    if (pb)
+    {
+        // Measure conversion time to diagnose performance issues
+        auto startTime = std::chrono::high_resolution_clock::now();
+        ok = convertPixelBufferToFrame(pb, frame);
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+        
+        // Log conversion time (only occasionally to avoid spam)
+        static int conversionLogCount = 0;
+        if (conversionLogCount++ % 150 == 0) // Log every 150 frames (~5 seconds at 30fps)
+        {
+            LOG_INFO("=== CONVERSION PERFORMANCE ===");
+            LOG_INFO("BGRA→YUYV conversion time: " + std::to_string(duration) + " ms");
+            LOG_INFO("Frame size: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+            if (duration > 33) // More than 1 frame at 30fps
+            {
+                LOG_WARN("Conversion is taking too long! This will limit framerate.");
+                LOG_WARN("At " + std::to_string(duration) + " ms per frame, max FPS is ~" + 
+                         std::to_string(1000 / duration) + " fps");
+            }
+            LOG_INFO("=============================");
+        }
+        
+        CVPixelBufferRelease(pb);
+    }
+    return ok;
+#else
+    return false;
+#endif
+}
+
+bool VideoCaptureAVFoundation::setControl(const std::string &controlName, int32_t value)
+{
+#ifdef __APPLE__
+    if (!m_captureDevice)
+    {
+        return false;
+    }
+    
+    @autoreleasepool {
+        NSError* error = nil;
+        if ([m_captureDevice lockForConfiguration:&error])
+        {
+            bool success = false;
+            
+            if (controlName == "Brightness" || controlName == "brightness")
+            {
+                // Brightness não é diretamente controlável via AVFoundation no macOS
+                // Alguns dispositivos podem ter extensões customizadas, mas não há API padrão
+                success = false;
+            }
+            else if (controlName == "Contrast" || controlName == "contrast")
+            {
+                // Contrast não é diretamente controlável via AVFoundation no macOS
+                success = false;
+            }
+            else if (controlName == "Saturation" || controlName == "saturation")
+            {
+                // Saturation não é diretamente controlável via AVFoundation no macOS
+                success = false;
+            }
+            else if (controlName == "Hue" || controlName == "hue")
+            {
+                // Hue não é diretamente controlável via AVFoundation no macOS
+                success = false;
+            }
+            else if (controlName == "Gain" || controlName == "gain")
+            {
+                // Gain pode estar disponível através de ISO em alguns dispositivos
+                // Mas não há API direta para gain no AVFoundation
+                success = false;
+            }
+            else if (controlName == "Exposure" || controlName == "exposure")
+            {
+                // Exposure controls não estão disponíveis no macOS via AVFoundation
+                // Apenas iOS/iPadOS suportam controle manual de exposição
+                success = false;
+            }
+            else if (controlName == "Sharpness" || controlName == "sharpness")
+            {
+                // Sharpness não é diretamente controlável via AVFoundation no macOS
+                success = false;
+            }
+            else if (controlName == "Gamma" || controlName == "gamma")
+            {
+                // Gamma não é diretamente controlável via AVFoundation no macOS
+                success = false;
+            }
+            else if (controlName == "White Balance" || controlName == "white balance" || controlName == "WhiteBalance")
+            {
+                // White Balance controls are NOT available on macOS via AVFoundation
+                // These APIs are only available on iOS/iPadOS
+                // macOS AVFoundation does not expose white balance controls
+                LOG_WARN("White Balance control is not available on macOS via AVFoundation");
+                success = false;
+            }
+            
+            [m_captureDevice unlockForConfiguration];
+            return success;
+        }
+        else if (error)
+        {
+            LOG_ERROR("Failed to lock device for configuration: " + std::string([[error localizedDescription] UTF8String]));
+        }
+    }
+#endif
+    
+    return false;
+}
+
+bool VideoCaptureAVFoundation::getControl(const std::string &controlName, int32_t &value)
+{
+#ifdef __APPLE__
+    if (!m_captureDevice)
+    {
+        return false;
+    }
+    
+    @autoreleasepool {
+        if (controlName == "White Balance" || controlName == "white balance" || controlName == "WhiteBalance")
+        {
+            // White Balance controls are NOT available on macOS via AVFoundation
+            // Return default value for UI consistency
+            value = 4000; // Default temperature
+            return false; // Indicate control is not available
+        }
+        // Outros controles não estão disponíveis no AVFoundation
+    }
+#endif
+    
+    return false;
+}
+
+bool VideoCaptureAVFoundation::getControlMin(const std::string &controlName, int32_t &minValue)
+{
+#ifdef __APPLE__
+    if (!m_captureDevice)
+    {
+        return false;
+    }
+    
+    @autoreleasepool {
+        if (controlName == "White Balance" || controlName == "white balance" || controlName == "WhiteBalance")
+        {
+            // Range típico de temperatura de white balance
+            minValue = 2800;
+            return true;
+        }
+        // Para outros controles, retornar valores padrão da UI
+        else if (controlName == "Brightness" || controlName == "brightness" ||
+                 controlName == "Contrast" || controlName == "contrast" ||
+                 controlName == "Saturation" || controlName == "saturation" ||
+                 controlName == "Hue" || controlName == "hue")
+        {
+            minValue = -100;
+            return true;
+        }
+        else if (controlName == "Gain" || controlName == "gain")
+        {
+            minValue = 0;
+            return true;
+        }
+        else if (controlName == "Exposure" || controlName == "exposure")
+        {
+            minValue = -13;
+            return true;
+        }
+        else if (controlName == "Sharpness" || controlName == "sharpness")
+        {
+            minValue = 0;
+            return true;
+        }
+        else if (controlName == "Gamma" || controlName == "gamma")
+        {
+            minValue = 100;
+            return true;
+        }
+    }
+#endif
+    
+    return false;
+}
+
+bool VideoCaptureAVFoundation::getControlMax(const std::string &controlName, int32_t &maxValue)
+{
+#ifdef __APPLE__
+    if (!m_captureDevice)
+    {
+        return false;
+    }
+    
+    @autoreleasepool {
+        if (controlName == "White Balance" || controlName == "white balance" || controlName == "WhiteBalance")
+        {
+            // Range típico de temperatura de white balance
+            maxValue = 6500;
+            return true;
+        }
+        // Para outros controles, retornar valores padrão da UI
+        else if (controlName == "Brightness" || controlName == "brightness" ||
+                 controlName == "Contrast" || controlName == "contrast" ||
+                 controlName == "Saturation" || controlName == "saturation" ||
+                 controlName == "Hue" || controlName == "hue")
+        {
+            maxValue = 100;
+            return true;
+        }
+        else if (controlName == "Gain" || controlName == "gain")
+        {
+            maxValue = 100;
+            return true;
+        }
+        else if (controlName == "Exposure" || controlName == "exposure")
+        {
+            maxValue = 1;
+            return true;
+        }
+        else if (controlName == "Sharpness" || controlName == "sharpness")
+        {
+            maxValue = 6;
+            return true;
+        }
+        else if (controlName == "Gamma" || controlName == "gamma")
+        {
+            maxValue = 300;
+            return true;
+        }
+    }
+#endif
+    
+    return false;
+}
+
+bool VideoCaptureAVFoundation::getControlDefault(const std::string &controlName, int32_t &defaultValue)
+{
+#ifdef __APPLE__
+    if (!m_captureDevice)
+    {
+        return false;
+    }
+    
+    @autoreleasepool {
+        if (controlName == "White Balance" || controlName == "white balance" || controlName == "WhiteBalance")
+        {
+            defaultValue = 4000; // Temperatura padrão
+            return true;
+        }
+        // Para outros controles, retornar valores padrão da UI
+        else if (controlName == "Brightness" || controlName == "brightness" ||
+                 controlName == "Contrast" || controlName == "contrast" ||
+                 controlName == "Saturation" || controlName == "saturation" ||
+                 controlName == "Hue" || controlName == "hue")
+        {
+            defaultValue = 0;
+            return true;
+        }
+        else if (controlName == "Gain" || controlName == "gain")
+        {
+            defaultValue = 0;
+            return true;
+        }
+        else if (controlName == "Exposure" || controlName == "exposure")
+        {
+            defaultValue = 0;
+            return true;
+        }
+        else if (controlName == "Sharpness" || controlName == "sharpness")
+        {
+            defaultValue = 0;
+            return true;
+        }
+        else if (controlName == "Gamma" || controlName == "gamma")
+        {
+            defaultValue = 100;
+            return true;
+        }
+    }
+#endif
+    
+    return false;
+}
+
+std::vector<DeviceInfo> VideoCaptureAVFoundation::listDevices()
+{
+    std::vector<DeviceInfo> devices;
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        // Sempre listar dispositivos reais, mesmo em dummy mode
+        // Isso permite que o usuário selecione um dispositivo mesmo quando está em dummy mode
+        // Nota: UltraWide e Telephoto são apenas iOS, não macOS
+        AVCaptureDeviceDiscoverySession* discoverySession = [AVCaptureDeviceDiscoverySession 
+            discoverySessionWithDeviceTypes:@[
+                AVCaptureDeviceTypeBuiltInWideAngleCamera,
+                AVCaptureDeviceTypeExternalUnknown
+            ]
+            mediaType:AVMediaTypeVideo
+            position:AVCaptureDevicePositionUnspecified];
+        NSArray* videoDevices = [discoverySession devices];
+        
+        LOG_INFO("Encontrados " + std::to_string([videoDevices count]) + " dispositivos AVFoundation");
+        
+        for (AVCaptureDevice* device in videoDevices)
+        {
+            DeviceInfo info;
+            NSString* uniqueID = [device uniqueID];
+            NSString* localizedName = [device localizedName];
+            
+            info.id = std::string([uniqueID UTF8String]);
+            info.name = std::string([localizedName UTF8String]);
+            info.available = [device isConnected];
+            info.driver = "AVFoundation";
+            devices.push_back(info);
+            
+            LOG_INFO("Dispositivo encontrado: " + info.name + " (ID: " + info.id + ", Connected: " + (info.available ? "sim" : "não") + ")");
+        }
+        
+        // Se não encontrou dispositivos, pode ser problema de permissões
+        if ([videoDevices count] == 0)
+        {
+            LOG_WARN("Nenhum dispositivo de vídeo encontrado. Verifique as permissões da câmera nas Preferências do Sistema.");
+        }
+    }
+#endif
+
+    return devices;
+}
+
+void VideoCaptureAVFoundation::setDummyMode(bool enabled)
+{
+    if (m_isOpen && !enabled)
+    {
+        close();
+    }
+    m_dummyMode = enabled;
+    LOG_INFO("Modo dummy: " + std::string(enabled ? "ativado" : "desativado"));
+}
+
+bool VideoCaptureAVFoundation::isDummyMode() const
+{
+    return m_dummyMode;
+}
+
+bool VideoCaptureAVFoundation::startCapture()
+{
+    if (m_dummyMode)
+    {
+        m_isCapturing = true;
+        return true;
+    }
+
+    if (!m_isOpen)
+    {
+        LOG_ERROR("Dispositivo não aberto");
+        return false;
+    }
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        if (m_captureSession && ![m_captureSession isRunning])
+        {
+            // IMPORTANT: Verify format is set before starting session
+            // This ensures the session uses the correct format
+            if (m_captureDevice)
+            {
+                CMVideoDimensions activeDims = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                LOG_INFO("=== BEFORE STARTING SESSION ===");
+                LOG_INFO("ActiveFormat: " + std::to_string(activeDims.width) + "x" + std::to_string(activeDims.height));
+                LOG_INFO("Requested: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+                NSString* preset = m_captureSession.sessionPreset;
+                LOG_INFO("Session preset: " + std::string([preset UTF8String]));
+                
+                // CRITICAL: Do NOT set sessionPreset - leave it as default
+                // Even Low preset can interfere with activeFormat on some devices
+                // Just log if a preset is found (shouldn't happen, but log for debugging)
+                if (![preset isEqualToString:@""] && preset != nil)
+                {
+                    LOG_WARN("Session preset is set to: " + std::string([preset UTF8String]) + 
+                             " - this may override activeFormat!");
+                    LOG_WARN("Note: We are NOT setting any preset to allow manual format control");
+                    // Do NOT change the preset - just log it
+                }
+                
+                // CRITICAL: Verify format matches requested dimensions BEFORE starting
+                // If format doesn't match, try to fix it using beginConfiguration/commitConfiguration
+                if (m_width > 0 && m_height > 0)
+                {
+                    if ((int32_t)activeDims.width != (int32_t)m_width || (int32_t)activeDims.height != (int32_t)m_height)
+                    {
+                        LOG_WARN("ActiveFormat dimensions (" + std::to_string(activeDims.width) + "x" + std::to_string(activeDims.height) + 
+                                 ") differ from requested (" + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                                 ") - attempting to fix before starting session...");
+                        
+                        // IMPORTANT: Fix format BEFORE starting session (OBS Studio approach)
+                        // CRITICAL: Do NOT set sessionPreset - leave it as default
+                        [m_captureSession beginConfiguration];
+                        
+                        NSError* fixError = nil;
+                        if ([m_captureDevice lockForConfiguration:&fixError])
+                        {
+                            // IMPORTANT: OBS Studio approach - prefer native formats (NV12/YUY2)
+                            AVCaptureDeviceFormat* exactFormat = nil;
+                            AVCaptureDeviceFormat* exactFormatNative = nil;
+                            
+                            for (AVCaptureDeviceFormat* format in [m_captureDevice formats])
+                            {
+                                CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+                                if (dims.width == static_cast<int32_t>(m_width) && 
+                                    dims.height == static_cast<int32_t>(m_height))
+                                {
+                                    // Check pixel format - prefer native formats (NV12, YUY2)
+                                    CMFormatDescriptionRef formatDesc = [format formatDescription];
+                                    FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                                    
+                                    // IMPORTANT: OBS Studio approach - prefer native formats
+                                    // NV12 (420v) = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+                                    // YUY2 (yuvs) = kCVPixelFormatType_422YpCbCr8_yuvs
+                                    if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+                                        pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs ||
+                                        pixelFormat == kCVPixelFormatType_422YpCbCr8 ||
+                                        pixelFormat == 0x79757673 || // 'yuvs' (YUY2)
+                                        pixelFormat == 0x34323076)   // '420v' (NV12)
+                                    {
+                                        exactFormatNative = format;
+                                    }
+                                    else if (!exactFormat)
+                                    {
+                                        exactFormat = format;
+                                    }
+                                }
+                            }
+                            
+                            if (exactFormatNative)
+                            {
+                                exactFormat = exactFormatNative;
+                            }
+                            
+                            if (exactFormat)
+                            {
+                                m_captureDevice.activeFormat = exactFormat;
+                                LOG_INFO("Fixed activeFormat to: " + std::to_string(m_width) + "x" + std::to_string(m_height) + " before starting");
+                                
+                                // Also reconfigure framerate if needed
+                                if (m_fps > 0)
+                                {
+                                    NSArray* frameRateRanges = [exactFormat videoSupportedFrameRateRanges];
+                                    if (frameRateRanges && [frameRateRanges count] > 0)
+                                    {
+                                        uint32_t targetFps = m_fps;
+                                        bool foundRequestedFps = false;
+                                        double maxFps = 0.0;
+                                        
+                                        for (AVFrameRateRange* range in frameRateRanges)
+                                        {
+                                            if (range.maxFrameRate > maxFps)
+                                            {
+                                                maxFps = range.maxFrameRate;
+                                            }
+                                            if (m_fps >= range.minFrameRate && m_fps <= range.maxFrameRate)
+                                            {
+                                                targetFps = m_fps;
+                                                foundRequestedFps = true;
+                                                break;
+                                            }
+                                        }
+                                        
+                                        if (!foundRequestedFps && maxFps > 0.0)
+                                        {
+                                            targetFps = static_cast<uint32_t>(maxFps);
+                                        }
+                                        
+                                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                                        CMTime frameDuration = CMTimeMake(1, timescale);
+                                        m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                                        m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                LOG_WARN("Could not find exact format " + std::to_string(m_width) + "x" + std::to_string(m_height) + 
+                                         " - format may not be supported");
+                            }
+                            
+                            [m_captureDevice unlockForConfiguration];
+                        }
+                        
+                        [m_captureSession commitConfiguration];
+                        
+                        // Verify again after fix
+                        CMVideoDimensions activeDimsAfterFix = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                        if (activeDimsAfterFix.width == (int32_t)m_width && activeDimsAfterFix.height == (int32_t)m_height)
+                        {
+                            LOG_INFO("Format fixed successfully - ActiveFormat now matches requested: " + 
+                                     std::to_string(m_width) + "x" + std::to_string(m_height));
+                        }
+                        else
+                        {
+                            LOG_WARN("Format fix failed - ActiveFormat is still: " + 
+                                     std::to_string(activeDimsAfterFix.width) + "x" + std::to_string(activeDimsAfterFix.height) + 
+                                     " (requested: " + std::to_string(m_width) + "x" + std::to_string(m_height) + ")");
+                            LOG_WARN("Aspect ratio will use requested dimensions");
+                        }
+                    }
+                    else
+                    {
+                        LOG_INFO("ActiveFormat matches requested dimensions - format should be respected");
+                    }
+                }
+            }
+            
+            // IMPORTANT: Ensure framerate is configured on connection before starting
+            // This MUST be done AFTER the output is added to the session
+            // and BEFORE starting the session, with the device locked
+            if (m_videoOutput && m_fps > 0)
+            {
+                AVCaptureConnection* conn = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
+                if (conn && [conn respondsToSelector:@selector(setVideoMinFrameDuration:)])
+                {
+                    // Find best framerate for current format
+                    uint32_t targetFps = m_fps;
+                    NSArray* frameRateRanges = [m_captureDevice.activeFormat videoSupportedFrameRateRanges];
+                    if (frameRateRanges && [frameRateRanges count] > 0)
+                    {
+                        bool foundRequestedFps = false;
+                        double maxFps = 0.0;
+                        
+                        for (AVFrameRateRange* range in frameRateRanges)
+                        {
+                            if (range.maxFrameRate > maxFps)
+                            {
+                                maxFps = range.maxFrameRate;
+                            }
+                            if (m_fps >= range.minFrameRate && m_fps <= range.maxFrameRate)
+                            {
+                                targetFps = m_fps;
+                                foundRequestedFps = true;
+                                break;
+                            }
+                        }
+                        
+                        if (!foundRequestedFps && maxFps > 0.0)
+                        {
+                            targetFps = static_cast<uint32_t>(maxFps);
+                        }
+                    }
+                    
+                    // IMPORTANT: Lock the device before configuring connection framerate
+                    // This ensures the framerate is set atomically with the device configuration
+                    // OBS and other professional software do this
+                    NSError* error = nil;
+                    if ([m_captureDevice lockForConfiguration:&error])
+                    {
+                        CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                        CMTime frameDuration = CMTimeMake(1, timescale);
+                        conn.videoMinFrameDuration = frameDuration;
+                        conn.videoMaxFrameDuration = frameDuration;
+                        [m_captureDevice unlockForConfiguration];
+                        
+                        // Verify connection framerate
+                        CMTime connMin = conn.videoMinFrameDuration;
+                        CMTime connMax = conn.videoMaxFrameDuration;
+                        double connMinFps = 1.0 / CMTimeGetSeconds(connMin);
+                        double connMaxFps = 1.0 / CMTimeGetSeconds(connMax);
+                        
+                        LOG_INFO("=== FRAMERATE BEFORE START ===");
+                        LOG_INFO("Requested: " + std::to_string(m_fps) + " fps");
+                        LOG_INFO("Connection configured: " + std::to_string(targetFps) + " fps");
+                        LOG_INFO("Connection actual: " + std::to_string(connMinFps) + " - " + std::to_string(connMaxFps) + " fps");
+                        
+                        // Also check device framerate
+                        CMTime devMin = m_captureDevice.activeVideoMinFrameDuration;
+                        CMTime devMax = m_captureDevice.activeVideoMaxFrameDuration;
+                        double devMinFps = 1.0 / CMTimeGetSeconds(devMin);
+                        double devMaxFps = 1.0 / CMTimeGetSeconds(devMax);
+                        LOG_INFO("Device framerate: " + std::to_string(devMinFps) + " - " + std::to_string(devMaxFps) + " fps");
+                        LOG_INFO("==============================");
+                    }
+                    else
+                    {
+                        LOG_WARN("Could not lock device to configure connection framerate: " + 
+                                 std::string([[error localizedDescription] UTF8String]));
+                    }
+                }
+            }
+            
+            [m_captureSession startRunning];
+            
+            // Verificar activeFormat DEPOIS de iniciar (alguns dispositivos podem mudar)
+            usleep(100000); // 100ms delay para sessão estabilizar
+            if (m_captureDevice && m_width > 0 && m_height > 0)
+            {
+                CMVideoDimensions activeDimsAfter = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                LOG_INFO("=== AFTER STARTING SESSION ===");
+                LOG_INFO("ActiveFormat: " + std::to_string(activeDimsAfter.width) + "x" + std::to_string(activeDimsAfter.height));
+                
+                // IMPORTANT: Verify framerate after starting session
+                if (m_videoOutput)
+                {
+                    AVCaptureConnection* conn = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
+                    if (conn)
+                    {
+                        CMTime connMin = conn.videoMinFrameDuration;
+                        CMTime connMax = conn.videoMaxFrameDuration;
+                        double connMinFps = 1.0 / CMTimeGetSeconds(connMin);
+                        double connMaxFps = 1.0 / CMTimeGetSeconds(connMax);
+                        LOG_INFO("Connection framerate after start: " + std::to_string(connMinFps) + " - " + std::to_string(connMaxFps) + " fps");
+                    }
+                    
+                    CMTime devMin = m_captureDevice.activeVideoMinFrameDuration;
+                    CMTime devMax = m_captureDevice.activeVideoMaxFrameDuration;
+                    double devMinFps = 1.0 / CMTimeGetSeconds(devMin);
+                    double devMaxFps = 1.0 / CMTimeGetSeconds(devMax);
+                    LOG_INFO("Device framerate after start: " + std::to_string(devMinFps) + " - " + std::to_string(devMaxFps) + " fps");
+                }
+                
+                // Se o formato mudou após iniciar, tentar corrigir usando a abordagem do OBS Studio
+                // OBS Studio: NÃO remove inputs/outputs, apenas reconfigura o formato diretamente
+                // dentro de beginConfiguration/commitConfiguration com o device locked
+                if (activeDimsAfter.width != (int32_t)m_width || activeDimsAfter.height != (int32_t)m_height)
+                {
+                    LOG_WARN("ActiveFormat changed after starting session!");
+                    LOG_WARN("Requested: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+                    LOG_WARN("Actual: " + std::to_string(activeDimsAfter.width) + "x" + std::to_string(activeDimsAfter.height));
+                    LOG_WARN("Attempting to fix using OBS Studio approach: reconfiguring format directly...");
+                    
+                    // IMPORTANT: Stop session BEFORE beginConfiguration
+                    // stopRunning cannot be called between beginConfiguration and commitConfiguration
+                    [m_captureSession stopRunning];
+                    usleep(50000); // 50ms delay
+                    
+                    // IMPORTANT: Use beginConfiguration/commitConfiguration for atomic changes (OBS Studio approach)
+                    [m_captureSession beginConfiguration];
+                    
+                    // IMPORTANT: Ensure sessionPreset is not interfering
+                    // CRITICAL: Do NOT set sessionPreset - leave it as default
+                    // Setting any preset can interfere with activeFormat
+                    
+                    // IMPORTANT: OBS Studio approach - configure format directly WITHOUT removing inputs/outputs
+                    // Lock device and configure format/framerate within the configuration block
+                    NSError* configError = nil;
+                    if ([m_captureDevice lockForConfiguration:&configError])
+                    {
+                        // IMPORTANT: OBS Studio approach - prefer native formats (NV12/YUY2)
+                        AVCaptureDeviceFormat* exactFormat = nil;
+                        AVCaptureDeviceFormat* exactFormatNative = nil;
+                        
+                        for (AVCaptureDeviceFormat* format in [m_captureDevice formats])
+                        {
+                            CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+                            if (dims.width == static_cast<int32_t>(m_width) && 
+                                dims.height == static_cast<int32_t>(m_height))
+                            {
+                                // Check pixel format - prefer native formats (NV12, YUY2)
+                                CMFormatDescriptionRef formatDesc = [format formatDescription];
+                                FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+                                
+                                // IMPORTANT: OBS Studio approach - prefer native formats
+                                // NV12 (420v) = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+                                // YUY2 (yuvs) = kCVPixelFormatType_422YpCbCr8_yuvs
+                                if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+                                    pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs ||
+                                    pixelFormat == kCVPixelFormatType_422YpCbCr8 ||
+                                    pixelFormat == 0x79757673 || // 'yuvs' (YUY2)
+                                    pixelFormat == 0x34323076)   // '420v' (NV12)
+                                {
+                                    exactFormatNative = format;
+                                }
+                                else if (!exactFormat)
+                                {
+                                    exactFormat = format;
+                                }
+                            }
+                        }
+                        
+                        if (exactFormatNative)
+                        {
+                            exactFormat = exactFormatNative;
+                        }
+                        
+                        if (exactFormat)
+                        {
+                            // OBS Studio approach: set format and framerate directly, atomically
+                            m_captureDevice.activeFormat = exactFormat;
+                            LOG_INFO("Reconfigured activeFormat to: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+                            
+                            // IMPORTANT: Reconfigure framerate after format change (OBS Studio approach)
+                            NSArray* frameRateRanges = [exactFormat videoSupportedFrameRateRanges];
+                            if (frameRateRanges && [frameRateRanges count] > 0 && m_fps > 0)
+                            {
+                                uint32_t targetFps = m_fps;
+                                double maxFps = 0.0;
+                                bool foundRequestedFps = false;
+                                
+                                for (AVFrameRateRange* range in frameRateRanges)
+                                {
+                                    if (range.maxFrameRate > maxFps)
+                                    {
+                                        maxFps = range.maxFrameRate;
+                                    }
+                                    if (m_fps >= range.minFrameRate && m_fps <= range.maxFrameRate)
+                                    {
+                                        targetFps = m_fps;
+                                        foundRequestedFps = true;
+                                        break;
+                                    }
+                                }
+                                
+                                if (!foundRequestedFps && maxFps > 0.0)
+                                {
+                                    targetFps = static_cast<uint32_t>(maxFps);
+                                }
+                                
+                                // OBS Studio approach: set framerate directly on device
+                                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                                CMTime frameDuration = CMTimeMake(1, timescale);
+                                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                                
+                                LOG_INFO("Reconfigured framerate to: " + std::to_string(targetFps) + " fps (requested: " + 
+                                         std::to_string(m_fps) + " fps, found requested: " + (foundRequestedFps ? "yes" : "no") + ")");
+                            }
+                        }
+                        else
+                        {
+                            LOG_WARN("Could not find exact format for reconfiguration");
+                        }
+                        
+                        [m_captureDevice unlockForConfiguration];
+                    }
+                    else
+                    {
+                        LOG_ERROR("Could not lock device for reconfiguration: " + 
+                                 std::string([[configError localizedDescription] UTF8String]));
+                    }
+                    
+                    // IMPORTANT: Commit configuration changes atomically (OBS Studio approach)
+                    [m_captureSession commitConfiguration];
+                    
+                    // Reiniciar a sessão
+                    usleep(100000); // 100ms delay - importante para o formato ser aplicado
+                    [m_captureSession startRunning];
+                    
+                    // Verificar novamente após reiniciar
+                    usleep(100000); // 100ms delay
+                    CMVideoDimensions activeDimsFinal = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                    LOG_INFO("=== AFTER RESTARTING SESSION ===");
+                    LOG_INFO("ActiveFormat: " + std::to_string(activeDimsFinal.width) + "x" + std::to_string(activeDimsFinal.height));
+                    
+                    // Verificar se o formato ainda não está correto
+                    if (activeDimsFinal.width != (int32_t)m_width || activeDimsFinal.height != (int32_t)m_height)
+                    {
+                        LOG_ERROR("ActiveFormat STILL does not match after restart!");
+                        LOG_ERROR("This device may not support the requested format, or the driver is forcing 1920x1080");
+                        LOG_ERROR("Aspect ratio will use requested dimensions (" + std::to_string(m_width) + "x" + std::to_string(m_height) + ")");
+                    }
+                }
+                else
+                {
+                    LOG_INFO("ActiveFormat matches requested dimensions after starting - format is correct!");
+                }
+            }
+            
+    m_isCapturing = true;
+            LOG_INFO("Captura iniciada");
+    return true;
+        }
+    }
+#endif
+
+    return false;
+}
+
+void VideoCaptureAVFoundation::stopCapture()
+{
+    m_isCapturing = false;
+#ifdef __APPLE__
+    @autoreleasepool {
+        if (m_captureSession && [m_captureSession isRunning])
+        {
+            [m_captureSession stopRunning];
+    LOG_INFO("Captura parada");
+        }
+    }
+#endif
+}
+
+void VideoCaptureAVFoundation::generateDummyFrame(Frame &frame)
+{
+    if (m_dummyFrameBuffer.empty())
+    {
+        frame.data = nullptr;
+        frame.size = 0;
+        return;
+    }
+
+    frame.data = m_dummyFrameBuffer.data();
+    frame.size = m_dummyFrameBuffer.size();
+    frame.width = m_width;
+    frame.height = m_height;
+    frame.format = m_pixelFormat;
+
+    // Gerar padrão de teste simples
+    static uint32_t frameCount = 0;
+    frameCount++;
+    for (size_t i = 0; i < m_dummyFrameBuffer.size(); i += 2)
+    {
+        m_dummyFrameBuffer[i] = (frameCount + i) % 256;
+        m_dummyFrameBuffer[i + 1] = ((frameCount + i) * 2) % 256;
+    }
+}
+
+bool VideoCaptureAVFoundation::convertPixelBufferToFrame(CVPixelBufferRef pixelBuffer, Frame &frame)
+{
+#ifdef __APPLE__
+    if (!pixelBuffer)
+    {
+        return false;
+    }
+
+    size_t width = CVPixelBufferGetWidth(pixelBuffer);
+    size_t height = CVPixelBufferGetHeight(pixelBuffer);
+    size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    
+    // IMPORTANT: Log dimensões reais do pixelBuffer para debug
+    // O pixelBuffer pode ter dimensões diferentes do que foi solicitado
+    static int dimensionLogCount = 0;
+    if (dimensionLogCount++ < 5)
+    {
+        LOG_INFO("=== PIXEL BUFFER DIMENSIONS ===");
+        LOG_INFO("PixelBuffer: " + std::to_string(width) + "x" + std::to_string(height));
+        LOG_INFO("Requested (m_width/m_height): " + std::to_string(m_width) + "x" + std::to_string(m_height));
+        if (m_width > 0 && m_height > 0)
+        {
+            float requestedAspect = static_cast<float>(m_width) / static_cast<float>(m_height);
+            float actualAspect = static_cast<float>(width) / static_cast<float>(height);
+            LOG_INFO("Requested aspect: " + std::to_string(requestedAspect));
+            LOG_INFO("Actual aspect: " + std::to_string(actualAspect));
+            if (std::abs(requestedAspect - actualAspect) > 0.01f)
+            {
+                LOG_WARN("Aspect ratio mismatch! Requested: " + std::to_string(requestedAspect) + 
+                         ", Actual: " + std::to_string(actualAspect));
+            }
+        }
+        LOG_INFO("==============================");
+    }
+    
+    // Converter BGRA para YUYV
+    // Alocar buffer se necessário
+    size_t yuyvSize = width * height * 2; // YUYV é 2 bytes por pixel
+    
+    if (!m_frameBuffer || m_frameBufferSize < yuyvSize)
+    {
+        if (m_frameBuffer)
+        {
+            delete[] m_frameBuffer;
+        }
+        m_frameBuffer = new uint8_t[yuyvSize];
+        m_frameBufferSize = yuyvSize;
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    uint8_t* baseAddress = (uint8_t*)CVPixelBufferGetBaseAddress(pixelBuffer);
+    
+    // OPTIMIZED: Converter BGRA para YUYV usando inteiros fixos para melhor performance
+    // Usar multiplicadores inteiros em vez de floats para evitar conversões custosas
+    // Y = (77*R + 150*G + 29*B) >> 8  (aproximação de 0.299, 0.587, 0.114)
+    // U = (-43*R - 85*G + 128*B) >> 8 + 128  (aproximação)
+    // V = (128*R - 107*G - 21*B) >> 8 + 128  (aproximação)
+    
+    for (size_t y = 0; y < height; ++y)
+    {
+        uint8_t* srcRow = baseAddress + y * bytesPerRow;
+        uint8_t* dstRow = m_frameBuffer + y * width * 2;
+        
+        for (size_t x = 0; x < width; x += 2)
+        {
+            // Ler 2 pixels BGRA
+            uint8_t b1 = srcRow[x * 4];
+            uint8_t g1 = srcRow[x * 4 + 1];
+            uint8_t r1 = srcRow[x * 4 + 2];
+            
+            uint8_t b2 = srcRow[(x + 1) * 4];
+            uint8_t g2 = srcRow[(x + 1) * 4 + 1];
+            uint8_t r2 = srcRow[(x + 1) * 4 + 2];
+            
+            // Converter RGB para YUV usando inteiros (muito mais rápido que float)
+            // Y = (77*R + 150*G + 29*B) >> 8
+            int y1 = (77 * r1 + 150 * g1 + 29 * b1) >> 8;
+            int y2 = (77 * r2 + 150 * g2 + 29 * b2) >> 8;
+            
+            // U e V calculados a partir do primeiro pixel (YUYV compartilha U/V entre 2 pixels)
+            // U = (-43*R - 85*G + 128*B) >> 8 + 128
+            int u = ((-43 * r1 - 85 * g1 + 128 * b1) >> 8) + 128;
+            // V = (128*R - 107*G - 21*B) >> 8 + 128
+            int v = ((128 * r1 - 107 * g1 - 21 * b1) >> 8) + 128;
+            
+            // Clamp valores (mais rápido que std::max/min)
+            y1 = (y1 < 0) ? 0 : ((y1 > 255) ? 255 : y1);
+            y2 = (y2 < 0) ? 0 : ((y2 > 255) ? 255 : y2);
+            u = (u < 0) ? 0 : ((u > 255) ? 255 : u);
+            v = (v < 0) ? 0 : ((v > 255) ? 255 : v);
+            
+            // YUYV: Y0 U Y1 V
+            dstRow[x * 2] = (uint8_t)y1;
+            dstRow[x * 2 + 1] = (uint8_t)u;
+            dstRow[x * 2 + 2] = (uint8_t)y2;
+            dstRow[x * 2 + 3] = (uint8_t)v;
+        }
+    }
+    
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+
+    frame.data = m_frameBuffer;
+    frame.size = yuyvSize;
+    // IMPORTANT: Use actual pixelBuffer dimensions, not requested dimensions
+    // This ensures aspect ratio is calculated correctly based on actual frame dimensions
+    frame.width = (uint32_t)width;
+    frame.height = (uint32_t)height;
+    frame.format = 0x56595559; // YUYV
+    
+    // IMPORTANT: Do NOT update m_width/m_height to match actual pixelBuffer dimensions
+    // m_width/m_height should remain as REQUESTED dimensions for aspect ratio calculation
+    // The actual frame dimensions (frame.width/height) are used for rendering,
+    // but requested dimensions (m_width/m_height) are used for aspect ratio
+    // This ensures maintainAspect uses the requested aspect ratio, not the actual device aspect ratio
+    if (m_width != (uint32_t)width || m_height != (uint32_t)height)
+    {
+        if (dimensionLogCount <= 5)
+        {
+            LOG_WARN("PixelBuffer dimensions differ from requested: " + 
+                     std::to_string(width) + "x" + std::to_string(height) + 
+                     " (requested: " + std::to_string(m_width) + "x" + std::to_string(m_height) + ")");
+            LOG_WARN("Using REQUESTED dimensions for aspect ratio calculation");
+        }
+        // Do NOT update m_width/m_height - keep requested dimensions for aspect ratio
+    }
+    
+    return true;
+#else
+    return false;
+#endif
+}
+
+#ifdef __APPLE__
+AVCaptureDevice* VideoCaptureAVFoundation::getCaptureDevice() const
+{
+    return m_captureDevice;
+}
+
+AVCaptureVideoDataOutput* VideoCaptureAVFoundation::getVideoOutput() const
+{
+    return m_videoOutput;
+}
+
+// Helper function to get pixel format name
+static std::string getPixelFormatName(FourCharCode pixelFormat)
+{
+    if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+        return "NV12 (420v)";
+    else if (pixelFormat == kCVPixelFormatType_422YpCbCr8_yuvs)
+        return "YUY2 (yuvs)";
+    else if (pixelFormat == kCVPixelFormatType_32BGRA)
+        return "BGRA";
+    else if (pixelFormat == kCVPixelFormatType_422YpCbCr8)
+        return "UYVY";
+    else
+        return "Unknown (0x" + std::to_string(pixelFormat) + ")";
+}
+
+// Helper function to get color space name
+static std::string getColorSpaceName(CMFormatDescriptionRef formatDesc)
+{
+    CFStringRef colorPrimaries = (CFStringRef)CMFormatDescriptionGetExtension(formatDesc, kCMFormatDescriptionExtension_ColorPrimaries);
+    if (colorPrimaries)
+    {
+        NSString* nsColorPrimaries = (__bridge NSString*)colorPrimaries;
+        if ([nsColorPrimaries isEqualToString:(__bridge NSString*)kCMFormatDescriptionColorPrimaries_ITU_R_709_2])
+            return "CS 709";
+        else if ([nsColorPrimaries isEqualToString:@"ITU_R_601_4"] || 
+                 [nsColorPrimaries isEqualToString:@"SMPTE_C"])
+            return "CS 601";
+    }
+    return "CS Unknown";
+}
+
+// Helper function to format aspect ratio
+static std::string formatAspectRatio(uint32_t width, uint32_t height)
+{
+    float aspect = static_cast<float>(width) / static_cast<float>(height);
+    if (std::abs(aspect - 16.0f/9.0f) < 0.01f)
+        return "16:9";
+    else if (std::abs(aspect - 4.0f/3.0f) < 0.01f)
+        return "4:3";
+    else if (std::abs(aspect - 5.0f/4.0f) < 0.01f)
+        return "5:4";
+    else
+    {
+        // Find GCD for aspect ratio
+        uint32_t a = width, b = height;
+        while (b != 0)
+        {
+            uint32_t temp = b;
+            b = a % b;
+            a = temp;
+        }
+        uint32_t gcd = a;
+        return std::to_string(width / gcd) + ":" + std::to_string(height / gcd);
+    }
+}
+
+std::vector<AVFoundationFormatInfo> VideoCaptureAVFoundation::listFormats(const std::string &deviceId)
+{
+    std::vector<AVFoundationFormatInfo> formats;
+    
+#ifdef __APPLE__
+    @autoreleasepool {
+        AVCaptureDevice* device = nil;
+        
+        // Find device by ID
+        if (!deviceId.empty())
+        {
+            device = [AVCaptureDevice deviceWithUniqueID:[NSString stringWithUTF8String:deviceId.c_str()]];
+        }
+        else if (m_captureDevice)
+        {
+            device = m_captureDevice;
+        }
+        else
+        {
+            // Use default device
+            device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+        }
+        
+        if (!device)
+        {
+            LOG_WARN("Device not found for format enumeration: " + deviceId);
+            return formats;
+        }
+        
+        NSArray* deviceFormats = [device formats];
+        LOG_INFO("Enumerating " + std::to_string([deviceFormats count]) + " formats for device: " + 
+                 std::string([[device localizedName] UTF8String]));
+        
+        for (AVCaptureDeviceFormat* format in deviceFormats)
+        {
+            CMFormatDescriptionRef formatDesc = [format formatDescription];
+            CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions(formatDesc);
+            FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+            
+            AVFoundationFormatInfo info;
+            info.width = dims.width;
+            info.height = dims.height;
+            
+            // Get FPS ranges
+            NSArray* frameRateRanges = [format videoSupportedFrameRateRanges];
+            if (frameRateRanges && [frameRateRanges count] > 0)
+            {
+                AVFrameRateRange* firstRange = frameRateRanges[0];
+                info.minFps = firstRange.minFrameRate;
+                info.maxFps = firstRange.maxFrameRate;
+                
+                // Check if there are multiple ranges
+                for (AVFrameRateRange* range in frameRateRanges)
+                {
+                    if (range.minFrameRate < info.minFps)
+                        info.minFps = range.minFrameRate;
+                    if (range.maxFrameRate > info.maxFps)
+                        info.maxFps = range.maxFrameRate;
+                }
+            }
+            
+            info.pixelFormat = getPixelFormatName(pixelFormat);
+            info.colorSpace = getColorSpaceName(formatDesc);
+            
+            // Create unique ID based on format properties (NOT object pointer)
+            // This ensures the ID is stable across reloads
+            // Format: widthxheight-pixelFormat-colorSpace-minFps-maxFps
+            NSString* formatDescStr = [NSString stringWithFormat:@"%dx%d-%@-%@-%.2f-%.2f",
+                dims.width, dims.height,
+                info.pixelFormat.c_str() ? [NSString stringWithUTF8String:info.pixelFormat.c_str()] : @"Unknown",
+                info.colorSpace.c_str() ? [NSString stringWithUTF8String:info.colorSpace.c_str()] : @"Unknown",
+                info.minFps, info.maxFps];
+            info.id = std::string([formatDescStr UTF8String]);
+            
+            // Create display name (similar to OBS Studio format)
+            std::string aspectRatio = formatAspectRatio(info.width, info.height);
+            std::string fpsStr;
+            if (std::abs(info.minFps - info.maxFps) < 0.01f)
+            {
+                fpsStr = std::to_string(static_cast<int>(info.minFps)) + " FPS";
+            }
+            else
+            {
+                fpsStr = std::to_string(static_cast<int>(info.minFps)) + "-" + 
+                        std::to_string(static_cast<int>(info.maxFps)) + " FPS";
+            }
+            
+            info.displayName = std::to_string(info.width) + "x" + std::to_string(info.height) + 
+                              " (" + aspectRatio + ") - " + fpsStr + " - " + 
+                              info.colorSpace + " - " + info.pixelFormat;
+            
+            formats.push_back(info);
+        }
+        
+        // Sort formats by resolution (largest first), then by pixel format preference
+        std::sort(formats.begin(), formats.end(), [](const AVFoundationFormatInfo& a, const AVFoundationFormatInfo& b) {
+            // First sort by total pixels (largest first)
+            uint32_t aPixels = a.width * a.height;
+            uint32_t bPixels = b.width * b.height;
+            if (aPixels != bPixels)
+                return aPixels > bPixels;
+            
+            // Then by pixel format preference (NV12/YUY2 first)
+            bool aIsNative = (a.pixelFormat.find("NV12") != std::string::npos || 
+                             a.pixelFormat.find("YUY2") != std::string::npos);
+            bool bIsNative = (b.pixelFormat.find("NV12") != std::string::npos || 
+                             b.pixelFormat.find("YUY2") != std::string::npos);
+            if (aIsNative != bIsNative)
+                return aIsNative;
+            
+            // Then by max FPS (highest first)
+            return a.maxFps > b.maxFps;
+        });
+    }
+#endif
+    
+    return formats;
+}
+
+bool VideoCaptureAVFoundation::setFormatByIndex(int formatIndex, const std::string &deviceId)
+{
+    auto formats = listFormats(deviceId);
+    if (formatIndex < 0 || formatIndex >= static_cast<int>(formats.size()))
+    {
+        LOG_ERROR("Invalid format index: " + std::to_string(formatIndex) + " (available: 0-" + 
+                 std::to_string(formats.size() - 1) + ")");
+        return false;
+    }
+    
+    return setFormatById(formats[formatIndex].id, deviceId);
+}
+
+bool VideoCaptureAVFoundation::setFormatById(const std::string &formatId, const std::string &deviceId)
+{
+#ifdef __APPLE__
+    @autoreleasepool {
+        AVCaptureDevice* device = nil;
+        
+        // Find device by ID
+        if (!deviceId.empty())
+        {
+            device = [AVCaptureDevice deviceWithUniqueID:[NSString stringWithUTF8String:deviceId.c_str()]];
+        }
+        else if (m_captureDevice)
+        {
+            device = m_captureDevice;
+        }
+        else
+        {
+            LOG_ERROR("No device available for format selection");
+            return false;
+        }
+        
+        if (!device)
+        {
+            LOG_ERROR("Device not found: " + deviceId);
+            return false;
+        }
+        
+        // Parse format ID to find matching format
+        // Format ID contains: width, height, pixel format, color space
+        // We'll search for a format that matches these properties
+        NSArray* deviceFormats = [device formats];
+        AVCaptureDeviceFormat* matchingFormat = nil;
+        
+        for (AVCaptureDeviceFormat* format in deviceFormats)
+        {
+            CMFormatDescriptionRef formatDesc = [format formatDescription];
+            CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions(formatDesc);
+            FourCharCode pixelFormat = CMFormatDescriptionGetMediaSubType(formatDesc);
+            
+            // Get FPS ranges (same logic as listFormats)
+            NSArray* frameRateRanges = [format videoSupportedFrameRateRanges];
+            float minFps = 0.0f;
+            float maxFps = 0.0f;
+            if (frameRateRanges && [frameRateRanges count] > 0)
+            {
+                AVFrameRateRange* firstRange = frameRateRanges[0];
+                minFps = firstRange.minFrameRate;
+                maxFps = firstRange.maxFrameRate;
+                
+                // Check if there are multiple ranges
+                for (AVFrameRateRange* range in frameRateRanges)
+                {
+                    if (range.minFrameRate < minFps)
+                        minFps = range.minFrameRate;
+                    if (range.maxFrameRate > maxFps)
+                        maxFps = range.maxFrameRate;
+                }
+            }
+            
+            // Generate format ID using same format as listFormats
+            NSString* formatDescStr = [NSString stringWithFormat:@"%dx%d-%@-%@-%.2f-%.2f",
+                dims.width, dims.height,
+                [NSString stringWithUTF8String:getPixelFormatName(pixelFormat).c_str()],
+                [NSString stringWithUTF8String:getColorSpaceName(formatDesc).c_str()],
+                minFps, maxFps];
+            std::string currentFormatId = std::string([formatDescStr UTF8String]);
+            
+            // Exact match on format ID
+            if (currentFormatId == formatId)
+            {
+                matchingFormat = format;
+                break;
+            }
+        }
+        
+        if (!matchingFormat)
+        {
+            LOG_ERROR("Format not found: " + formatId);
+            return false;
+        }
+        
+        // CRITICAL: Mark that a format was selected via UI
+        // This prevents setFormat() from overwriting the user's selection
+        m_formatSelectedViaUI = true;
+        m_selectedFormatId = formatId;
+        
+        // Set the format
+        CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([matchingFormat formatDescription]);
+        m_width = dims.width;
+        m_height = dims.height;
+        
+        // If device is open, apply format immediately with proper session reconfiguration
+        if (m_isOpen && m_captureDevice == device)
+        {
+            // Use centralized method to apply format and framerate atomically
+            return applyFormatAndFramerate(matchingFormat, m_fps, true);
+        }
+        else
+        {
+            // Format will be applied when device is opened
+            LOG_INFO("Format will be applied when device is opened: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+            return true;
+        }
+    }
+#else
+    (void)formatId;
+    (void)deviceId;
+    return false;
+#endif
+}
+
+// Centralized method to apply format and framerate atomically
+// This ensures format and framerate are always configured together, preventing conflicts
+bool VideoCaptureAVFoundation::applyFormatAndFramerate(AVCaptureDeviceFormat* format, uint32_t fps, bool stopSessionIfRunning)
+{
+#ifdef __APPLE__
+    if (!format || !m_captureDevice || !m_captureSession)
+    {
+        LOG_ERROR("applyFormatAndFramerate: Invalid parameters");
+        return false;
+    }
+    
+    @autoreleasepool {
+        // Stop session if requested and running
+        bool wasRunning = [m_captureSession isRunning];
+        if (stopSessionIfRunning && wasRunning)
+        {
+            [m_captureSession stopRunning];
+            usleep(50000); // 50ms delay for session to stabilize
+        }
+        
+        // CRITICAL: Use beginConfiguration/commitConfiguration for atomic changes
+        [m_captureSession beginConfiguration];
+        
+        NSError* error = nil;
+        if ([m_captureDevice lockForConfiguration:&error])
+        {
+            // Step 1: Set the format
+            m_captureDevice.activeFormat = format;
+            
+            // Step 2: Get framerate ranges for the NEW format
+            NSArray* frameRateRanges = [format videoSupportedFrameRateRanges];
+            if (frameRateRanges && [frameRateRanges count] > 0)
+            {
+                // Find best framerate (requested if supported, otherwise max)
+                AVFrameRateRange* bestRange = nil;
+                float maxFps = 0.0f;
+                float targetFps = static_cast<float>(fps);
+                
+                for (AVFrameRateRange* range in frameRateRanges)
+                {
+                    if (range.maxFrameRate > maxFps)
+                    {
+                        maxFps = range.maxFrameRate;
+                        if (!bestRange)
+                            bestRange = range;
+                    }
+                    
+                    // If requested FPS is within this range, use it
+                    if (fps > 0 && fps >= range.minFrameRate && fps <= range.maxFrameRate)
+                    {
+                        bestRange = range;
+                        targetFps = static_cast<float>(fps);
+                        break;
+                    }
+                }
+                
+                // If requested FPS not supported, use max
+                if (fps > 0 && bestRange && (fps < bestRange.minFrameRate || fps > bestRange.maxFrameRate))
+                {
+                    targetFps = maxFps;
+                }
+                
+                // Step 3: Configure framerate on DEVICE (while still locked)
+                CMTimeScale timescale = static_cast<CMTimeScale>(targetFps);
+                CMTime frameDuration = CMTimeMake(1, timescale);
+                m_captureDevice.activeVideoMinFrameDuration = frameDuration;
+                m_captureDevice.activeVideoMaxFrameDuration = frameDuration;
+                
+                LOG_INFO("=== APPLYING FORMAT AND FRAMERATE ATOMICALLY ===");
+                CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+                LOG_INFO("Format: " + std::to_string(dims.width) + "x" + std::to_string(dims.height));
+                LOG_INFO("Framerate: " + std::to_string(targetFps) + " fps (requested: " + std::to_string(fps) + 
+                        ", supported: " + std::to_string(bestRange.minFrameRate) + " - " + 
+                        std::to_string(bestRange.maxFrameRate) + " fps)");
+                
+                // Step 4: Configure framerate on CONNECTION (while device is still locked)
+                if (m_videoOutput)
+                {
+                    AVCaptureConnection* conn = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
+                    if (conn)
+                    {
+                        conn.videoMinFrameDuration = frameDuration;
+                        conn.videoMaxFrameDuration = frameDuration;
+                        LOG_INFO("Connection framerate configured: " + std::to_string(targetFps) + " fps");
+                    }
+                }
+                
+                LOG_INFO("================================================");
+            }
+            
+            [m_captureDevice unlockForConfiguration];
+        }
+        else
+        {
+            [m_captureSession commitConfiguration];
+            LOG_ERROR("Failed to lock device: " + std::string([[error localizedDescription] UTF8String]));
+            if (wasRunning)
+            {
+                [m_captureSession startRunning];
+            }
+            return false;
+        }
+        
+        // CRITICAL: Commit all changes atomically
+        [m_captureSession commitConfiguration];
+        
+        // Restart session if it was running
+        if (wasRunning)
+        {
+            // Small delay before restarting to ensure configuration is committed
+            usleep(50000); // 50ms delay
+            [m_captureSession startRunning];
+            
+            // CRITICAL: Wait for session to start and verify format was applied
+            usleep(100000); // 100ms delay for session to stabilize
+            
+            // Verify format was actually applied after restart
+            CMVideoDimensions actualDimsAfter = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+            CMVideoDimensions requestedDims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+            
+            if (actualDimsAfter.width != requestedDims.width || actualDimsAfter.height != requestedDims.height)
+            {
+                LOG_WARN("Format changed after restarting session in applyFormatAndFramerate!");
+                LOG_WARN("Requested: " + std::to_string(requestedDims.width) + "x" + std::to_string(requestedDims.height));
+                LOG_WARN("Actual: " + std::to_string(actualDimsAfter.width) + "x" + std::to_string(actualDimsAfter.height));
+                LOG_WARN("Attempting to reapply format...");
+                
+                // Try to reapply format one more time
+                [m_captureSession stopRunning];
+                usleep(50000); // 50ms delay
+                
+                [m_captureSession beginConfiguration];
+                NSError* retryError = nil;
+                if ([m_captureDevice lockForConfiguration:&retryError])
+                {
+                    m_captureDevice.activeFormat = format;
+                    [m_captureDevice unlockForConfiguration];
+                }
+                [m_captureSession commitConfiguration];
+                
+                usleep(50000); // 50ms delay
+                [m_captureSession startRunning];
+                usleep(100000); // 100ms delay
+                
+                // Verify again
+                CMVideoDimensions finalDims = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+                if (finalDims.width != requestedDims.width || finalDims.height != requestedDims.height)
+                {
+                    LOG_ERROR("Format STILL does not match after retry!");
+                    LOG_ERROR("Requested: " + std::to_string(requestedDims.width) + "x" + std::to_string(requestedDims.height));
+                    LOG_ERROR("Actual: " + std::to_string(finalDims.width) + "x" + std::to_string(finalDims.height));
+                    LOG_ERROR("Device may need to be reopened to apply format change");
+                    // Return false to indicate format was not applied correctly
+                    // This will trigger device reopening if needed
+                    return false;
+                }
+                else
+                {
+                    LOG_INFO("Format successfully applied after retry: " + std::to_string(finalDims.width) + "x" + std::to_string(finalDims.height));
+                }
+            }
+            else
+            {
+                LOG_INFO("Format correctly applied after restart: " + std::to_string(actualDimsAfter.width) + "x" + std::to_string(actualDimsAfter.height));
+            }
+        }
+        
+        // Update internal state
+        CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions([format formatDescription]);
+        m_width = dims.width;
+        m_height = dims.height;
+        
+        // Verify what was actually applied
+        CMVideoDimensions actualDims = CMVideoFormatDescriptionGetDimensions([m_captureDevice.activeFormat formatDescription]);
+        FourCharCode actualPixelFormat = CMFormatDescriptionGetMediaSubType([m_captureDevice.activeFormat formatDescription]);
+        LOG_INFO("Format applied: " + std::to_string(actualDims.width) + "x" + std::to_string(actualDims.height) + 
+                " (pixel format: " + getPixelFormatName(actualPixelFormat) + ")");
+        
+        return true;
+    }
+#else
+    (void)format;
+    (void)fps;
+    (void)stopSessionIfRunning;
+    return false;
+#endif
+}
+
+#ifdef __APPLE__
+void VideoCaptureAVFoundation::onAudioSampleBuffer(CMSampleBufferRef sampleBuffer)
+{
+    // CRITICAL: Check if device is closing - if so, ignore this callback
+    // This prevents accessing freed resources during device change
+    if (m_isClosing || !sampleBuffer || !m_hasAudio)
+    {
+        return;
+    }
+    
+    // Get audio format from sample buffer
+    CMFormatDescriptionRef formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer);
+    if (!formatDescription)
+    {
+        return;
+    }
+    
+    // Get audio stream basic description
+    const AudioStreamBasicDescription* asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription);
+    if (!asbd)
+    {
+        return;
+    }
+    
+    // Update audio format info (first time only)
+    if (m_audioSampleRate == 44100 && m_audioChannels == 2) // Default values
+    {
+        m_audioSampleRate = static_cast<uint32_t>(asbd->mSampleRate);
+        m_audioChannels = static_cast<uint32_t>(asbd->mChannelsPerFrame);
+        LOG_INFO("Audio format detected: " + std::to_string(m_audioSampleRate) + "Hz, " + 
+                 std::to_string(m_audioChannels) + " channels, format: 0x" + 
+                 std::to_string(asbd->mFormatID) + ", flags: 0x" + std::to_string(asbd->mFormatFlags));
+    }
+    
+    // Get CMBlockBuffer from sample buffer
+    CMBlockBufferRef blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer);
+    if (!blockBuffer)
+    {
+        return;
+    }
+    
+    // Get data length
+    size_t dataLength = CMBlockBufferGetDataLength(blockBuffer);
+    if (dataLength == 0)
+    {
+        return;
+    }
+    
+    // Get number of frames in the sample buffer
+    CMItemCount numSamples = CMSampleBufferGetNumSamples(sampleBuffer);
+    if (numSamples == 0)
+    {
+        return;
+    }
+    
+    // Calculate number of audio samples (frames * channels)
+    size_t numAudioSamples = numSamples * m_audioChannels;
+    
+    // Allocate temporary buffer for audio data
+    std::vector<int16_t> tempBuffer(numAudioSamples);
+    
+    // Check audio format and convert accordingly
+    if (asbd->mFormatID == kAudioFormatLinearPCM)
+    {
+        // Check if it's already int16_t
+        if (asbd->mBitsPerChannel == 16 && 
+            (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger))
+        {
+            // Direct copy if format matches
+            OSStatus status = CMBlockBufferCopyDataBytes(blockBuffer, 0, dataLength, tempBuffer.data());
+            if (status != noErr)
+            {
+                return;
+            }
+        }
+        else if (asbd->mBitsPerChannel == 24)
+        {
+            // Convert from 24-bit signed integer to int16_t
+            // 24-bit audio is typically stored as 3 bytes per sample
+            size_t bytesPerSample = 3;
+            size_t totalBytes = numAudioSamples * bytesPerSample;
+            
+            // Allocate buffer for raw 24-bit data
+            std::vector<uint8_t> raw24Buffer(totalBytes);
+            OSStatus status = CMBlockBufferCopyDataBytes(blockBuffer, 0, totalBytes, raw24Buffer.data());
+            if (status != noErr)
+            {
+                LOG_WARN("Failed to copy 24-bit audio data: " + std::to_string(status));
+                return;
+            }
+            
+            // Convert 24-bit samples to 16-bit
+            // 24-bit samples are stored as little-endian signed integers
+            for (size_t i = 0; i < numAudioSamples; ++i)
+            {
+                size_t byteOffset = i * bytesPerSample;
+                // Read 24-bit signed integer (little-endian)
+                int32_t sample24 = 0;
+                sample24 |= static_cast<int32_t>(raw24Buffer[byteOffset + 0]) << 0;
+                sample24 |= static_cast<int32_t>(raw24Buffer[byteOffset + 1]) << 8;
+                sample24 |= static_cast<int32_t>(raw24Buffer[byteOffset + 2]) << 16;
+                
+                // Sign extend from 24-bit to 32-bit
+                if (sample24 & 0x800000)
+                {
+                    sample24 |= 0xFF000000; // Sign extend
+                }
+                
+                // Scale down to 16-bit (divide by 256)
+                tempBuffer[i] = static_cast<int16_t>(sample24 >> 8);
+            }
+        }
+        else if (asbd->mBitsPerChannel == 32 && 
+                 (asbd->mFormatFlags & kAudioFormatFlagIsFloat))
+        {
+            // Convert from float32 to int16_t
+            size_t floatBufferSize = numAudioSamples * sizeof(float);
+            // Process available data even if less than expected (partial buffer)
+            size_t actualSamples = std::min(numAudioSamples, dataLength / sizeof(float));
+            if (actualSamples == 0)
+            {
+                LOG_WARN("Audio data length too small: expected at least " + std::to_string(sizeof(float)) + 
+                         " bytes, got " + std::to_string(dataLength));
+                return;
+            }
+            
+            if (dataLength < floatBufferSize)
+            {
+                static int logCount = 0;
+                if (logCount < 5)
+                {
+                    LOG_WARN("Audio data length mismatch: expected " + std::to_string(floatBufferSize) + 
+                             " bytes (" + std::to_string(numAudioSamples) + " samples), got " + 
+                             std::to_string(dataLength) + " bytes (" + std::to_string(actualSamples) + " samples). Processing available data.");
+                    logCount++;
+                }
+            }
+            
+            std::vector<float> floatBuffer(actualSamples);
+            size_t actualBytes = actualSamples * sizeof(float);
+            OSStatus status = CMBlockBufferCopyDataBytes(blockBuffer, 0, actualBytes, floatBuffer.data());
+            if (status != noErr)
+            {
+                LOG_WARN("Failed to copy float32 audio data: " + std::to_string(status));
+                return;
+            }
+            
+            // Convert float to int16_t
+            for (size_t i = 0; i < actualSamples; ++i)
+            {
+                float sample = floatBuffer[i];
+                // Clamp to [-1.0, 1.0] range
+                sample = std::max(-1.0f, std::min(1.0f, sample));
+                tempBuffer[i] = static_cast<int16_t>(sample * 32767.0f);
+            }
+            
+            // Adjust numAudioSamples to actual processed samples
+            numAudioSamples = actualSamples;
+        }
+        else if (asbd->mBitsPerChannel == 32 && 
+                 (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger))
+        {
+            // Convert from int32_t to int16_t
+            size_t int32BufferSize = numAudioSamples * sizeof(int32_t);
+            // Process available data even if less than expected (partial buffer)
+            size_t actualSamples = std::min(numAudioSamples, dataLength / sizeof(int32_t));
+            if (actualSamples == 0)
+            {
+                LOG_WARN("Audio data length too small: expected at least " + std::to_string(sizeof(int32_t)) + 
+                         " bytes, got " + std::to_string(dataLength));
+                return;
+            }
+            
+            if (dataLength < int32BufferSize)
+            {
+                static int logCount = 0;
+                if (logCount < 5)
+                {
+                    LOG_WARN("Audio data length mismatch: expected " + std::to_string(int32BufferSize) + 
+                             " bytes (" + std::to_string(numAudioSamples) + " samples), got " + 
+                             std::to_string(dataLength) + " bytes (" + std::to_string(actualSamples) + " samples). Processing available data.");
+                    logCount++;
+                }
+            }
+            
+            std::vector<int32_t> int32Buffer(actualSamples);
+            size_t actualBytes = actualSamples * sizeof(int32_t);
+            OSStatus status = CMBlockBufferCopyDataBytes(blockBuffer, 0, actualBytes, int32Buffer.data());
+            if (status != noErr)
+            {
+                LOG_WARN("Failed to copy int32 audio data: " + std::to_string(status));
+                return;
+            }
+            
+            // Convert int32_t to int16_t (scale down)
+            for (size_t i = 0; i < actualSamples; ++i)
+            {
+                tempBuffer[i] = static_cast<int16_t>(int32Buffer[i] >> 16);
+            }
+            
+            // Adjust numAudioSamples to actual processed samples
+            numAudioSamples = actualSamples;
+        }
+        else
+        {
+            // Unsupported format - log and skip
+            LOG_WARN("Unsupported audio format: bits=" + std::to_string(asbd->mBitsPerChannel) + 
+                     ", flags=0x" + std::to_string(asbd->mFormatFlags) + 
+                     ", formatID=0x" + std::to_string(asbd->mFormatID));
+            return; // Don't try to copy unsupported formats
+        }
+    }
+    else
+    {
+        // Non-PCM format - log and skip
+        LOG_WARN("Non-PCM audio format: 0x" + std::to_string(asbd->mFormatID) + 
+                 ", cannot convert to int16_t");
+        return; // Don't try to copy non-PCM formats
+    }
+    
+    // Add audio data to buffer (thread-safe)
+    // Only add if we have samples to add
+    if (numAudioSamples > 0)
+    {
+        std::lock_guard<std::mutex> lock(m_audioBufferMutex);
+        // Double-check after acquiring lock (device might have started closing)
+        if (m_isClosing)
+        {
+            return;
+        }
+        m_audioBuffer.insert(m_audioBuffer.end(), tempBuffer.begin(), tempBuffer.begin() + numAudioSamples);
+        
+        // Limit buffer size to prevent excessive memory usage (keep last 1 second of audio)
+        size_t maxSamples = m_audioSampleRate * m_audioChannels;
+        if (m_audioBuffer.size() > maxSamples)
+        {
+            m_audioBuffer.erase(m_audioBuffer.begin(), m_audioBuffer.begin() + (m_audioBuffer.size() - maxSamples));
+        }
+        
+        // Debug: log occasionally to verify audio is being captured
+        static size_t totalSamplesCaptured = 0;
+        totalSamplesCaptured += numAudioSamples;
+        if (totalSamplesCaptured % (m_audioSampleRate * m_audioChannels) < numAudioSamples) // Log once per second
+        {
+            LOG_INFO("Audio captured: " + std::to_string(m_audioBuffer.size()) + " samples in buffer, " +
+                     std::to_string(totalSamplesCaptured) + " total samples captured");
+        }
+    }
+}
+
+bool VideoCaptureAVFoundation::hasAudio() const
+{
+#ifdef __APPLE__
+    return m_hasAudio;
+#else
+    return false;
+#endif
+}
+
+size_t VideoCaptureAVFoundation::getAudioSamples(int16_t* buffer, size_t maxSamples)
+{
+#ifdef __APPLE__
+    // CRITICAL: Check if device is closing or closed before accessing audio buffer
+    // This prevents crash if called during device change
+    if (!buffer || maxSamples == 0 || !m_hasAudio || m_isClosing || !m_isOpen)
+    {
+        return 0;
+    }
+    
+    std::lock_guard<std::mutex> lock(m_audioBufferMutex);
+    
+    // Double-check after acquiring lock (device might have started closing)
+    if (m_isClosing || m_audioBuffer.empty())
+    {
+        return 0;
+    }
+    
+    size_t samplesToCopy = std::min(maxSamples, m_audioBuffer.size());
+    std::copy(m_audioBuffer.begin(), m_audioBuffer.begin() + samplesToCopy, buffer);
+    m_audioBuffer.erase(m_audioBuffer.begin(), m_audioBuffer.begin() + samplesToCopy);
+    
+    return samplesToCopy;
+#else
+    (void)buffer;
+    (void)maxSamples;
+    return 0;
+#endif
+}
+
+uint32_t VideoCaptureAVFoundation::getAudioSampleRate() const
+{
+#ifdef __APPLE__
+    return m_audioSampleRate;
+#else
+    return 0;
+#endif
+}
+
+uint32_t VideoCaptureAVFoundation::getAudioChannels() const
+{
+#ifdef __APPLE__
+    return m_audioChannels;
+#else
+    return 0;
+#endif
+}
+
+std::vector<DeviceInfo> VideoCaptureAVFoundation::listAudioDevices()
+{
+    std::vector<DeviceInfo> devices;
+
+#ifdef __APPLE__
+    @autoreleasepool {
+        // Get all audio devices (using modern API)
+        AVCaptureDeviceDiscoverySession* audioDiscoverySession = [AVCaptureDeviceDiscoverySession 
+            discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInMicrophone, AVCaptureDeviceTypeExternalUnknown]
+            mediaType:AVMediaTypeAudio
+            position:AVCaptureDevicePositionUnspecified];
+        NSArray* audioDevices = audioDiscoverySession.devices;
+        
+        LOG_INFO("Encontrados " + std::to_string([audioDevices count]) + " dispositivos de áudio AVFoundation");
+        
+        for (AVCaptureDevice* device in audioDevices)
+        {
+            DeviceInfo info;
+            NSString* uniqueID = [device uniqueID];
+            NSString* localizedName = [device localizedName];
+            
+            info.id = std::string([uniqueID UTF8String]);
+            info.name = std::string([localizedName UTF8String]);
+            info.available = [device isConnected];
+            info.driver = "AVFoundation";
+            devices.push_back(info);
+            
+            LOG_INFO("Dispositivo de áudio encontrado: " + info.name + " (ID: " + info.id + ", Connected: " + (info.available ? "sim" : "não") + ")");
+        }
+        
+        // Se não encontrou dispositivos, pode ser problema de permissões
+        if ([audioDevices count] == 0)
+        {
+            LOG_WARN("Nenhum dispositivo de áudio encontrado. Verifique as permissões do microfone nas Preferências do Sistema.");
+        }
+    }
+#endif
+
+    return devices;
+}
+
+bool VideoCaptureAVFoundation::setAudioDevice(const std::string &audioDeviceId)
+{
+#ifdef __APPLE__
+    m_selectedAudioDeviceId = audioDeviceId;
+    
+    // If device is already open, we need to reopen it to apply the new audio device
+    // This will be handled by the caller (Application) if needed
+    if (m_isOpen)
+    {
+        LOG_INFO("Audio device changed to: " + (audioDeviceId.empty() ? "auto-detect" : audioDeviceId));
+        LOG_INFO("Device will be reopened to apply new audio device selection");
+    }
+    
+    return true;
+#else
+    (void)audioDeviceId;
+    return false;
+#endif
+}
+
+std::string VideoCaptureAVFoundation::getCurrentAudioDevice() const
+{
+#ifdef __APPLE__
+    return m_selectedAudioDeviceId;
+#else
+    return "";
+#endif
+}
+#endif
+#endif

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -273,13 +273,27 @@ bool VideoCaptureAVFoundation::open(const std::string &device)
     return false;
         }
         
-        // IMPORTANT: OBS Studio approach - do NOT set sessionPreset when using manual format control
-        // The activeFormat of the device will determine the resolution
-        // Setting a preset (even Low) can interfere with activeFormat on some devices
-        // We'll configure the format explicitly via activeFormat within beginConfiguration/commitConfiguration
-        // Note: AVCaptureSessionPresetInputPriority is NOT available on macOS (iOS/iPadOS only)
-        // OBS Studio does not set sessionPreset when using manual format configuration
-        LOG_INFO("Session created - format will be controlled via activeFormat (no preset)");
+        // AVCaptureSession defaults to `AVCaptureSessionPresetHigh` as
+        // soon as an input is added, which on macOS *overrides* whatever
+        // `activeFormat` we set on the device — that's exactly why
+        // earlier attempts to apply 160x120 / 640x480 / 1600x1200 etc.
+        // silently reverted to 1280x720 / 1920x1080 after
+        // `startRunning`. The fix is to explicitly opt into
+        // `AVCaptureSessionPresetInputPriority`, which tells
+        // AVFoundation "honor the device's activeFormat, do not
+        // impose any preset of your own". This preset has been
+        // available on macOS since 10.7 (the old comment in this
+        // file claimed it was iOS-only — incorrect).
+        if ([m_captureSession canSetSessionPreset:AVCaptureSessionPresetInputPriority])
+        {
+            m_captureSession.sessionPreset = AVCaptureSessionPresetInputPriority;
+            LOG_INFO("Session preset: InputPriority (activeFormat honored)");
+        }
+        else
+        {
+            LOG_WARN("Session does not accept InputPriority preset — activeFormat "
+                     "may be overridden by the default preset.");
+        }
         
         // Selecionar dispositivo
         AVCaptureDevice* deviceObj = nil;

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -1488,10 +1488,59 @@ std::vector<DeviceInfo> VideoCaptureAVFoundation::listDevices()
 
 #ifdef __APPLE__
     @autoreleasepool {
-        // Sempre listar dispositivos reais, mesmo em dummy mode
-        // Isso permite que o usuário selecione um dispositivo mesmo quando está em dummy mode
-        // Nota: UltraWide e Telephoto são apenas iOS, não macOS
-        AVCaptureDeviceDiscoverySession* discoverySession = [AVCaptureDeviceDiscoverySession 
+        // macOS 10.14+ guards AVFoundation camera enumeration behind
+        // the per-app camera privacy setting. Without an explicit
+        // grant, AVCaptureDeviceDiscoverySession returns an empty
+        // array silently — no error, no prompt. Surface the current
+        // authorization state in the log, and synchronously request
+        // access on first run so the user gets the consent prompt
+        // (the binary must live in an .app bundle with an Info.plist
+        // carrying NSCameraUsageDescription for the prompt to actually
+        // appear — running as a raw command-line binary may simply
+        // record the deny without UI).
+        AVAuthorizationStatus authStatus =
+            [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+        const char *statusStr = "unknown";
+        switch (authStatus)
+        {
+            case AVAuthorizationStatusNotDetermined: statusStr = "NotDetermined"; break;
+            case AVAuthorizationStatusRestricted:    statusStr = "Restricted";    break;
+            case AVAuthorizationStatusDenied:        statusStr = "Denied";        break;
+            case AVAuthorizationStatusAuthorized:    statusStr = "Authorized";    break;
+        }
+        LOG_INFO(std::string("AVFoundation camera authorization: ") + statusStr);
+
+        if (authStatus == AVAuthorizationStatusNotDetermined)
+        {
+            __block bool grantedFlag = false;
+            __block bool finishedFlag = false;
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                     completionHandler:^(BOOL granted) {
+                grantedFlag  = granted;
+                finishedFlag = true;
+            }];
+            // Wait up to ~3 s for the user to respond to the prompt
+            // (synchronous wait so this listDevices() call returns the
+            // post-grant list rather than the empty pre-grant one).
+            const NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+            while (!finishedFlag &&
+                   [(NSDate *)[NSDate date] compare:deadline] == NSOrderedAscending)
+            {
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                         beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+            }
+            LOG_INFO(std::string("AVFoundation camera prompt result: ") +
+                     (grantedFlag ? "granted" : "denied/timeout"));
+        }
+        else if (authStatus == AVAuthorizationStatusDenied ||
+                 authStatus == AVAuthorizationStatusRestricted)
+        {
+            LOG_WARN("AVFoundation camera access denied — open System Settings → "
+                     "Privacy & Security → Camera and enable RetroCapture (or the "
+                     "binary's parent process if running uncodesigned).");
+        }
+
+        AVCaptureDeviceDiscoverySession* discoverySession = [AVCaptureDeviceDiscoverySession
             discoverySessionWithDeviceTypes:@[
                 AVCaptureDeviceTypeBuiltInWideAngleCamera,
                 AVCaptureDeviceTypeExternalUnknown
@@ -1499,7 +1548,7 @@ std::vector<DeviceInfo> VideoCaptureAVFoundation::listDevices()
             mediaType:AVMediaTypeVideo
             position:AVCaptureDevicePositionUnspecified];
         NSArray* videoDevices = [discoverySession devices];
-        
+
         LOG_INFO("Encontrados " + std::to_string([videoDevices count]) + " dispositivos AVFoundation");
         
         for (AVCaptureDevice* device in videoDevices)

--- a/src/capture/VideoCaptureAVFoundationFactory.mm
+++ b/src/capture/VideoCaptureAVFoundationFactory.mm
@@ -1,0 +1,9 @@
+// Helper file para criar VideoCaptureAVFoundation sem incluir header Objective-C em arquivo C++
+#include "VideoCaptureAVFoundation.h"
+#include "IVideoCapture.h"
+#include <memory>
+
+std::unique_ptr<IVideoCapture> createVideoCaptureAVFoundation()
+{
+    return std::make_unique<VideoCaptureAVFoundation>();
+}

--- a/src/capture/VideoCaptureFactory.cpp
+++ b/src/capture/VideoCaptureFactory.cpp
@@ -4,6 +4,11 @@
 #include "VideoCaptureV4L2.h"
 #elif defined(_WIN32)
 #include "VideoCaptureDS.h"
+#elif defined(__APPLE__)
+// Para macOS, precisamos incluir o header Objective-C++
+// Mas isso só funciona se o arquivo for compilado como Objective-C++
+// Como este arquivo é .cpp, vamos criar uma função helper no .mm
+extern std::unique_ptr<IVideoCapture> createVideoCaptureAVFoundation();
 #endif
 
 std::unique_ptr<IVideoCapture> VideoCaptureFactory::create()
@@ -12,6 +17,8 @@ std::unique_ptr<IVideoCapture> VideoCaptureFactory::create()
     return std::make_unique<VideoCaptureV4L2>();
 #elif defined(_WIN32)
     return std::make_unique<VideoCaptureDS>();
+#elif defined(__APPLE__)
+    return createVideoCaptureAVFoundation();
 #else
     #error "Unsupported platform"
 #endif

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -5,6 +5,8 @@
 #include "../audio/AudioPlaybackPulse.h"
 #elif defined(_WIN32)
 #include "../audio/AudioPlaybackWASAPI.h"
+#elif defined(__APPLE__)
+#include "../audio/AudioPlaybackCoreAudio.h"
 #endif
 
 extern "C"
@@ -268,6 +270,8 @@ bool VideoCaptureRemote::initDecoder()
                 m_audioPlayback = std::make_unique<AudioPlaybackPulse>();
 #elif defined(_WIN32)
                 m_audioPlayback = std::make_unique<AudioPlaybackWASAPI>();
+#elif defined(__APPLE__)
+                m_audioPlayback = std::make_unique<AudioPlaybackCoreAudio>();
 #endif
                 const uint32_t rate     = static_cast<uint32_t>(m_audioCodecCtx->sample_rate);
                 // Channel count compat: AVCodecContext.channels was

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -41,10 +41,6 @@
 #ifdef __linux__
 #include "../audio/AudioCapturePulse.h"
 #endif
-#ifdef __APPLE__
-#include "../audio/IAudioOutput.h"
-#include "../audio/AudioOutputCoreAudio.h"
-#endif
 #include "../recording/RecordingManager.h"
 #include "../recording/RecordingSettings.h"
 #include "../recording/RecordingMetadata.h"
@@ -3236,68 +3232,16 @@ bool Application::initAudioCapture()
         m_ui->setAudioCapture(m_audioCapture.get());
     }
 
-#ifdef __APPLE__
-    // Host-side monitor playback for macOS. On Linux this lives inside
-    // AudioCapturePulse (MonitorPlayback); Core Audio doesn't bundle a
-    // playback path with capture, so we open it at the Application
-    // layer and feed it from the main loop's getSamples calls.
-    if (!initAudioOutput())
-    {
-        LOG_WARN("Failed to initialize macOS audio output — user will not "
-                 "hear the input through the default device");
-    }
-#endif
+    // Host-side monitor playback: on Linux it lives inside
+    // AudioCapturePulse (MonitorPlayback), on macOS inside
+    // AudioCaptureCoreAudio (also called MonitorPlayback there). The
+    // capture class spins up its own monitor in open() — no Application-
+    // level wiring needed.
 
     // Audio format for RecordingManager is already set in init() after audio capture starts
 
     return true;
 }
-
-#ifdef __APPLE__
-bool Application::initAudioOutput()
-{
-    if (!m_audioCapture)
-    {
-        LOG_WARN("initAudioOutput called before audio capture is up");
-        return false;
-    }
-
-    m_audioOutput = std::make_unique<AudioOutputCoreAudio>();
-    if (!m_audioOutput)
-    {
-        LOG_ERROR("Failed to allocate AudioOutputCoreAudio");
-        return false;
-    }
-
-    const uint32_t sampleRate = m_audioCapture->getSampleRate();
-    const uint32_t channels   = m_audioCapture->getChannels();
-    if (sampleRate == 0 || channels == 0)
-    {
-        LOG_WARN("Audio capture format not ready; postponing audio output init");
-        m_audioOutput.reset();
-        return false;
-    }
-
-    if (!m_audioOutput->open("", sampleRate, channels))
-    {
-        LOG_ERROR("AudioOutputCoreAudio: open failed");
-        m_audioOutput.reset();
-        return false;
-    }
-    if (!m_audioOutput->start())
-    {
-        LOG_ERROR("AudioOutputCoreAudio: start failed");
-        m_audioOutput->close();
-        m_audioOutput.reset();
-        return false;
-    }
-    m_audioOutput->setEnabled(true);
-    LOG_INFO("Audio output (monitor) started: " +
-             std::to_string(m_audioOutput->getSampleRate()) + "Hz, " +
-             std::to_string(m_audioOutput->getChannels()) + " channels");
-    return true;
-}
-#endif
 
 void Application::restoreAudioDeviceConnections()
 {
@@ -3448,12 +3392,6 @@ void Application::run()
                         {
                             m_recordingManager->pushAudio(audioBuffer.data(), samplesRead);
                         }
-#ifdef __APPLE__
-                        if (m_audioOutput && m_audioOutput->isOpen() && m_audioOutput->isEnabled())
-                        {
-                            m_audioOutput->write(audioBuffer.data(), samplesRead);
-                        }
-#endif
 
                         // If we read less than expected, no more samples available
                         if (samplesRead < samplesPerVideoFrame)
@@ -3501,12 +3439,6 @@ void Application::run()
                     if (samplesRead > 0)
                     {
                         m_recordingManager->pushAudio(audioBuffer.data(), samplesRead);
-#ifdef __APPLE__
-                        if (m_audioOutput && m_audioOutput->isOpen() && m_audioOutput->isEnabled())
-                        {
-                            m_audioOutput->write(audioBuffer.data(), samplesRead);
-                        }
-#endif
                         if (samplesRead < samplesPerVideoFrame)
                         {
                             break;
@@ -3523,22 +3455,14 @@ void Application::run()
             {
                 // Neither streaming nor recording active, but we still need to process mainloop
                 // to prevent PulseAudio from freezing system audio
-                // Read and discard samples to keep buffer clean
-                const size_t maxSamples = 4096; // Temporary buffer
+                // Read and discard samples to keep the capture buffer
+                // from backing up. The host-side monitor (Linux:
+                // MonitorPlayback inside AudioCapturePulse; macOS:
+                // monitor inside AudioCaptureCoreAudio) has its own
+                // tap on the bus, so the user still hears the input.
+                const size_t maxSamples = 4096;
                 std::vector<int16_t> tempBuffer(maxSamples);
-                size_t samplesRead = m_audioCapture->getSamples(tempBuffer.data(), maxSamples);
-#ifdef __APPLE__
-                // Still feed the monitor so the user can hear the
-                // capture even when neither streaming nor recording
-                // is running.
-                if (samplesRead > 0 && m_audioOutput && m_audioOutput->isOpen() &&
-                    m_audioOutput->isEnabled())
-                {
-                    m_audioOutput->write(tempBuffer.data(), samplesRead);
-                }
-#else
-                (void)samplesRead;
-#endif
+                m_audioCapture->getSamples(tempBuffer.data(), maxSamples);
             }
         }
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2320,6 +2320,27 @@ bool Application::initUI()
                                      }
 #endif
 
+#ifdef __APPLE__
+                                     if (sourceType == UIManager::SourceType::AVFoundation)
+                                     {
+                                         LOG_INFO("AVFoundation source selected");
+                                         // Re-arm the UI's capture pointer (the None
+                                         // branch above clears it as a side effect of
+                                         // setCaptureControls(nullptr)) so the Source
+                                         // tab can call listDevices() / setFormatById().
+                                         if (m_ui && m_capture)
+                                         {
+                                             m_ui->setCaptureControls(m_capture.get());
+                                         }
+                                         // Stay in dummy mode until the user explicitly
+                                         // picks a device from the AVFoundation dropdown.
+                                         // listDevices() will fire on the first render
+                                         // of UIConfigurationSource's AVFoundation
+                                         // section and trigger the camera-permission
+                                         // probe if needed.
+                                     }
+#endif
+
                                      // Phase 5b/#47: switching INTO Remote — close the
                                      // current capture (V4L2/DS/None) and stand up an
                                      // empty VideoCaptureRemote that waits for the

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2332,12 +2332,45 @@ bool Application::initUI()
                                          {
                                              m_ui->setCaptureControls(m_capture.get());
                                          }
-                                         // Stay in dummy mode until the user explicitly
-                                         // picks a device from the AVFoundation dropdown.
-                                         // listDevices() will fire on the first render
-                                         // of UIConfigurationSource's AVFoundation
-                                         // section and trigger the camera-permission
-                                         // probe if needed.
+
+                                         // Auto-open the saved device (or the first
+                                         // available one) instead of leaving the user
+                                         // in dummy mode with the dropdown showing a
+                                         // device that is not actually active. Without
+                                         // this, the user has to pick another device
+                                         // and come back just to make AVFoundation
+                                         // actually capture.
+                                         if (m_capture && m_capture->isDummyMode())
+                                         {
+                                             const auto devices = m_capture->listDevices();
+                                             if (!devices.empty())
+                                             {
+                                                 const std::string saved = m_ui
+                                                     ? m_ui->getAVFoundationDeviceId()
+                                                     : std::string();
+                                                 std::string target;
+                                                 if (!saved.empty())
+                                                 {
+                                                     for (const auto &d : devices)
+                                                     {
+                                                         if (d.id == saved)
+                                                         {
+                                                             target = saved;
+                                                             break;
+                                                         }
+                                                     }
+                                                 }
+                                                 if (target.empty())
+                                                 {
+                                                     target = devices.front().id;
+                                                 }
+                                                 LOG_INFO("Auto-opening AVFoundation device: " + target);
+                                                 if (m_ui)
+                                                 {
+                                                     m_ui->triggerDeviceChange(target);
+                                                 }
+                                             }
+                                         }
                                      }
 #endif
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -65,7 +65,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
 #include <unistd.h>
 #endif
 #include "../utils/FilesystemCompat.h"
@@ -333,7 +333,7 @@ bool Application::initRenderer()
                         appPtr->m_shaderEngine->setViewport(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
                     }
 // Small delay to ensure ShaderEngine finished recreating framebuffers
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                     usleep(10000); // 10ms
 #else
                     Sleep(10); // 10ms
@@ -695,7 +695,7 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
 
     // Small delay to ensure any ongoing frame processing completes
     // This prevents race conditions where processFrame is accessing the device
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     usleep(50000); // 50ms to let current frame processing finish
 #else
     Sleep(50); // 50ms to let current frame processing finish
@@ -721,7 +721,7 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
     m_capture->close();
 
 // Small delay to ensure device was released
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     usleep(100000); // 100ms
 #else
     Sleep(100); // 100ms
@@ -742,7 +742,7 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
         LOG_ERROR("Failed to configure new capture format");
         // Try rollback: reopen with previous format
         m_capture->close();
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
         usleep(100000); // 100ms
 #else
         Sleep(100); // 100ms
@@ -776,7 +776,7 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
         // Tentar rollback
         m_capture->stopCapture();
         m_capture->close();
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
         usleep(100000); // 100ms
 #else
         Sleep(100); // 100ms
@@ -804,7 +804,7 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
     for (int i = 0; i < 5; ++i)
     {
         m_capture->captureLatestFrame(dummyFrame);
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
         usleep(10000); // 10ms entre tentativas
 #else
         Sleep(10); // 10ms entre tentativas
@@ -3556,7 +3556,7 @@ void Application::run()
                     }
                     if (attempt < maxAttempts - 1)
                     {
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                         usleep(5000); // 5ms between attempts
 #else
                         Sleep(5); // 5ms between attempts
@@ -4701,7 +4701,7 @@ void Application::run()
                     // Hidden / backgrounded — sleep a frame's worth so
                     // captureLatestFrame still drains the queue at a
                     // reasonable rate without spinning the CPU.
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                     usleep(16000);
 #else
                     Sleep(16);
@@ -4723,7 +4723,7 @@ void Application::run()
                     if (elapsedUs < targetIntervalUs)
                     {
                         const int64_t sleepUs = targetIntervalUs - elapsedUs;
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                         usleep(static_cast<useconds_t>(sleepUs));
 #else
                         Sleep(static_cast<DWORD>(sleepUs / 1000));
@@ -4798,7 +4798,7 @@ void Application::run()
                 if (elapsedUs < targetIntervalUs)
                 {
                     const int64_t sleepUs = targetIntervalUs - elapsedUs;
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                     usleep(static_cast<useconds_t>(sleepUs));
 #else
                     Sleep(static_cast<DWORD>(sleepUs / 1000));
@@ -4829,7 +4829,7 @@ void Application::run()
                     if (elapsedUs < targetIntervalUs)
                     {
                         const int64_t sleepUs = targetIntervalUs - elapsedUs;
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                         usleep(static_cast<useconds_t>(sleepUs));
 #else
                         Sleep(static_cast<DWORD>(sleepUs / 1000));
@@ -4839,7 +4839,7 @@ void Application::run()
                 }
                 else
                 {
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
                     usleep(1000);
 #else
                     Sleep(1);

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2369,6 +2369,26 @@ bool Application::initUI()
                                                  {
                                                      m_ui->triggerDeviceChange(target);
                                                  }
+
+                                                 // Restore the format the user had
+                                                 // selected on this device in a previous
+                                                 // session, if any and if the device is
+                                                 // the saved one (don't carry a format
+                                                 // across devices — different cards
+                                                 // expose different format IDs).
+                                                 const std::string savedFormatId = m_ui
+                                                     ? m_ui->getAVFoundationFormatId()
+                                                     : std::string();
+                                                 if (!savedFormatId.empty() && target == saved &&
+                                                     m_capture)
+                                                 {
+                                                     LOG_INFO("Restoring AVFoundation format: " + savedFormatId);
+                                                     if (!m_capture->setFormatById(savedFormatId, target))
+                                                     {
+                                                         LOG_WARN("Saved AVFoundation format id no longer matches a "
+                                                                  "format on this device — leaving device at default");
+                                                     }
+                                                 }
                                              }
                                          }
                                      }

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5587,7 +5587,18 @@ void Application::applyPendingRemoteMeta()
     }
 
     // Master pipeline toggle: mirror the host's "Apply shader pipeline".
+    // Log every time it changes vs the local state, so a "shader vanishes
+    // after N seconds" symptom can be traced back to whichever snapshot
+    // flipped the value.
+    const bool prevPipelineEnabled = m_ui->getShaderPipelineEnabled();
     m_ui->setShaderPipelineEnabled(pipelineEnabled);
+    if (prevPipelineEnabled != pipelineEnabled)
+    {
+        LOG_INFO(std::string("RemoteMetaSync: pipelineEnabled changed ") +
+                 (prevPipelineEnabled ? "true" : "false") + " → " +
+                 (pipelineEnabled ? "true" : "false") +
+                 " (preset='" + preset + "' hash=" + presetHash + ")");
+    }
 
     // Parameter overrides apply on top of whatever preset is now active.
     // After a preset reload, the engine's parameters are at their preset

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -41,6 +41,10 @@
 #ifdef __linux__
 #include "../audio/AudioCapturePulse.h"
 #endif
+#ifdef __APPLE__
+#include "../audio/IAudioOutput.h"
+#include "../audio/AudioOutputCoreAudio.h"
+#endif
 #include "../recording/RecordingManager.h"
 #include "../recording/RecordingSettings.h"
 #include "../recording/RecordingMetadata.h"
@@ -3154,10 +3158,68 @@ bool Application::initAudioCapture()
         m_ui->setAudioCapture(m_audioCapture.get());
     }
 
+#ifdef __APPLE__
+    // Host-side monitor playback for macOS. On Linux this lives inside
+    // AudioCapturePulse (MonitorPlayback); Core Audio doesn't bundle a
+    // playback path with capture, so we open it at the Application
+    // layer and feed it from the main loop's getSamples calls.
+    if (!initAudioOutput())
+    {
+        LOG_WARN("Failed to initialize macOS audio output — user will not "
+                 "hear the input through the default device");
+    }
+#endif
+
     // Audio format for RecordingManager is already set in init() after audio capture starts
 
     return true;
 }
+
+#ifdef __APPLE__
+bool Application::initAudioOutput()
+{
+    if (!m_audioCapture)
+    {
+        LOG_WARN("initAudioOutput called before audio capture is up");
+        return false;
+    }
+
+    m_audioOutput = std::make_unique<AudioOutputCoreAudio>();
+    if (!m_audioOutput)
+    {
+        LOG_ERROR("Failed to allocate AudioOutputCoreAudio");
+        return false;
+    }
+
+    const uint32_t sampleRate = m_audioCapture->getSampleRate();
+    const uint32_t channels   = m_audioCapture->getChannels();
+    if (sampleRate == 0 || channels == 0)
+    {
+        LOG_WARN("Audio capture format not ready; postponing audio output init");
+        m_audioOutput.reset();
+        return false;
+    }
+
+    if (!m_audioOutput->open("", sampleRate, channels))
+    {
+        LOG_ERROR("AudioOutputCoreAudio: open failed");
+        m_audioOutput.reset();
+        return false;
+    }
+    if (!m_audioOutput->start())
+    {
+        LOG_ERROR("AudioOutputCoreAudio: start failed");
+        m_audioOutput->close();
+        m_audioOutput.reset();
+        return false;
+    }
+    m_audioOutput->setEnabled(true);
+    LOG_INFO("Audio output (monitor) started: " +
+             std::to_string(m_audioOutput->getSampleRate()) + "Hz, " +
+             std::to_string(m_audioOutput->getChannels()) + " channels");
+    return true;
+}
+#endif
 
 void Application::restoreAudioDeviceConnections()
 {
@@ -3308,6 +3370,12 @@ void Application::run()
                         {
                             m_recordingManager->pushAudio(audioBuffer.data(), samplesRead);
                         }
+#ifdef __APPLE__
+                        if (m_audioOutput && m_audioOutput->isOpen() && m_audioOutput->isEnabled())
+                        {
+                            m_audioOutput->write(audioBuffer.data(), samplesRead);
+                        }
+#endif
 
                         // If we read less than expected, no more samples available
                         if (samplesRead < samplesPerVideoFrame)
@@ -3355,6 +3423,12 @@ void Application::run()
                     if (samplesRead > 0)
                     {
                         m_recordingManager->pushAudio(audioBuffer.data(), samplesRead);
+#ifdef __APPLE__
+                        if (m_audioOutput && m_audioOutput->isOpen() && m_audioOutput->isEnabled())
+                        {
+                            m_audioOutput->write(audioBuffer.data(), samplesRead);
+                        }
+#endif
                         if (samplesRead < samplesPerVideoFrame)
                         {
                             break;
@@ -3374,7 +3448,19 @@ void Application::run()
                 // Read and discard samples to keep buffer clean
                 const size_t maxSamples = 4096; // Temporary buffer
                 std::vector<int16_t> tempBuffer(maxSamples);
-                m_audioCapture->getSamples(tempBuffer.data(), maxSamples);
+                size_t samplesRead = m_audioCapture->getSamples(tempBuffer.data(), maxSamples);
+#ifdef __APPLE__
+                // Still feed the monitor so the user can hear the
+                // capture even when neither streaming nor recording
+                // is running.
+                if (samplesRead > 0 && m_audioOutput && m_audioOutput->isOpen() &&
+                    m_audioOutput->isEnabled())
+                {
+                    m_audioOutput->write(tempBuffer.data(), samplesRead);
+                }
+#else
+                (void)samplesRead;
+#endif
             }
         }
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -404,9 +404,13 @@ bool Application::initCapture()
     // If it fails, activate dummy mode (generates black frames)
     if (m_devicePath.empty())
     {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
+        // Windows (DirectShow) and macOS (AVFoundation) both pick a
+        // capture device by enumeration at the backend layer — there
+        // is no filesystem path. Without a device explicitly chosen,
+        // start in dummy mode and let the user pick a device via the
+        // Source tab.
         LOG_INFO("No device specified - activating dummy mode directly");
-        // Go directly to dummy mode without trying to open device
         m_capture->setDummyMode(true);
         if (!m_capture->setFormat(m_captureWidth, m_captureHeight, 0))
         {

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -254,8 +254,10 @@ private:
     // Configuração
     std::string m_shaderPath;
     std::string m_presetPath;
-#ifdef _WIN32
-    std::string m_devicePath = ""; // Windows: vazio por padrão (DirectShow usa índices)
+#if defined(_WIN32) || defined(__APPLE__)
+    // Windows (DirectShow) and macOS (AVFoundation) both pick a
+    // device by enumeration, not by filesystem path.
+    std::string m_devicePath = "";
 #else
     std::string m_devicePath = "/dev/video0"; // Linux: padrão V4L2
 #endif

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -19,6 +19,9 @@ struct RecordingMetadata;
 
 class IVideoCapture;
 class IAudioCapture;
+#ifdef __APPLE__
+class IAudioOutput;
+#endif
 class WindowManager;
 #ifdef USE_SDL2
 class WindowManagerSDL;
@@ -137,6 +140,7 @@ public:
     UIManager *getUIManager() { return m_ui.get(); }
     RecordingManager *getRecordingManager() { return m_recordingManager.get(); }
     IAudioCapture* getAudioCapture() const { return m_audioCapture.get(); }
+    IVideoCapture* getVideoCapture() const { return m_capture.get(); }
 
     // Preset management
     void applyPreset(const std::string& presetName);
@@ -185,6 +189,14 @@ private:
     // waiting for an app restart.
     std::string m_publishedDirectoryUrl;
     std::unique_ptr<IAudioCapture> m_audioCapture;
+#ifdef __APPLE__
+    // Host-side audio monitor on macOS. Counterpart to Linux's
+    // MonitorPlayback (which lives inside AudioCapturePulse). Owned at
+    // the Application level because AudioCaptureCoreAudio does not
+    // bundle a playback path. Polymorphic so the platform can swap in
+    // a different output implementation if needed.
+    std::unique_ptr<IAudioOutput> m_audioOutput;
+#endif
     std::unique_ptr<PBOManager> m_pboManager; // PBO para leitura assíncrona de pixels
     std::unique_ptr<RecordingManager> m_recordingManager;
 
@@ -419,5 +431,13 @@ private:
     void stopWebPortal();
     bool initAudioCapture();
     void restoreAudioDeviceConnections();
+#ifdef __APPLE__
+    // Construct + open the IAudioOutput (Core Audio) for monitor
+    // playback. Called from initAudioCapture() so format matches the
+    // capture's sample rate / channel count. No-op on non-Apple
+    // platforms — Linux uses MonitorPlayback inside AudioCapturePulse,
+    // Windows currently has no host-side monitor.
+    bool initAudioOutput();
+#endif
     void handleKeyInput();
 };

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -19,9 +19,6 @@ struct RecordingMetadata;
 
 class IVideoCapture;
 class IAudioCapture;
-#ifdef __APPLE__
-class IAudioOutput;
-#endif
 class WindowManager;
 #ifdef USE_SDL2
 class WindowManagerSDL;
@@ -189,14 +186,6 @@ private:
     // waiting for an app restart.
     std::string m_publishedDirectoryUrl;
     std::unique_ptr<IAudioCapture> m_audioCapture;
-#ifdef __APPLE__
-    // Host-side audio monitor on macOS. Counterpart to Linux's
-    // MonitorPlayback (which lives inside AudioCapturePulse). Owned at
-    // the Application level because AudioCaptureCoreAudio does not
-    // bundle a playback path. Polymorphic so the platform can swap in
-    // a different output implementation if needed.
-    std::unique_ptr<IAudioOutput> m_audioOutput;
-#endif
     std::unique_ptr<PBOManager> m_pboManager; // PBO para leitura assíncrona de pixels
     std::unique_ptr<RecordingManager> m_recordingManager;
 
@@ -433,13 +422,5 @@ private:
     void stopWebPortal();
     bool initAudioCapture();
     void restoreAudioDeviceConnections();
-#ifdef __APPLE__
-    // Construct + open the IAudioOutput (Core Audio) for monitor
-    // playback. Called from initAudioCapture() so format matches the
-    // capture's sample rate / channel count. No-op on non-Apple
-    // platforms — Linux uses MonitorPlayback inside AudioCapturePulse,
-    // Windows currently has no host-side monitor.
-    bool initAudioOutput();
-#endif
     void handleKeyInput();
 };

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -882,6 +882,25 @@ bool MediaEncoder::convertRGBToYUV(const uint8_t *rgbData, uint32_t width, uint3
         return false;
     }
 
+    // sws_scale's AVX2-fastpath on macOS (libswscale 9.x from Homebrew
+    // FFmpeg 7) crashes with EXC_BAD_ACCESS when the source height is
+    // odd — it reads 32 bytes past the last row through `vinserti128`.
+    // The window framebuffer on a macOS host can easily be 1920x953
+    // (1080 minus the menu bar / title bar), which trips this. Clamp
+    // source height to even before any sws_getContext / sws_scale call;
+    // the lost row is one pixel at the bottom edge, negligible. We
+    // don't touch width because the source row stride is derived from
+    // the caller's allocation, and changing width here would desync
+    // it from the actual buffer layout.
+    if (height & 1u)
+    {
+        --height;
+    }
+    if (height == 0)
+    {
+        return false;
+    }
+
     uint32_t dstWidth = m_videoConfig.width;
     uint32_t dstHeight = m_videoConfig.height;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,6 +141,8 @@ int main(int argc, char *argv[])
     sourceType = "v4l2"; // Linux usa V4L2
 #elif defined(_WIN32)
     sourceType = "ds"; // Windows usa DirectShow
+#elif defined(__APPLE__)
+    sourceType = "avfoundation"; // macOS usa AVFoundation
 #else
     sourceType = "none"; // Outras plataformas sem suporte
 #endif
@@ -237,6 +239,8 @@ int main(int argc, char *argv[])
             if (sourceType != "none" && sourceType != "v4l2" && sourceType != "remote")
 #elif defined(_WIN32)
             if (sourceType != "none" && sourceType != "ds" && sourceType != "remote")
+#elif defined(__APPLE__)
+            if (sourceType != "none" && sourceType != "avfoundation" && sourceType != "remote")
 #else
             if (sourceType != "none" && sourceType != "remote")
 #endif
@@ -245,6 +249,8 @@ int main(int argc, char *argv[])
                 LOG_ERROR("Invalid source type. Use 'none', 'v4l2' or 'remote'");
 #elif defined(_WIN32)
                 LOG_ERROR("Invalid source type. Use 'none', 'ds' or 'remote'");
+#elif defined(__APPLE__)
+                LOG_ERROR("Invalid source type. Use 'none', 'avfoundation' or 'remote'");
 #else
                 LOG_ERROR("Invalid source type. Use 'none' or 'remote'");
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,9 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
+#ifdef __APPLE__
+#include <signal.h>
+#endif
 
 void printUsage(const char *programName)
 {
@@ -109,6 +112,21 @@ void printUsage(const char *programName)
 int main(int argc, char *argv[])
 {
     Logger::init();
+
+#ifdef __APPLE__
+    // macOS has no MSG_NOSIGNAL on send(); without ignoring SIGPIPE
+    // globally, a peer disconnecting mid-write would terminate the
+    // whole process. Linux uses MSG_NOSIGNAL per-send and Windows
+    // doesn't generate SIGPIPE in the first place, so this is needed
+    // on macOS specifically.
+    {
+        struct sigaction sa{};
+        sa.sa_handler = SIG_IGN;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        sigaction(SIGPIPE, &sa, nullptr);
+    }
+#endif
 
     LOG_INFO(std::string("RetroCapture ") + RETROCAPTURE_VERSION);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,8 @@ void printUsage(const char *programName)
     std::cout << "  --source <type>        Source type: none, v4l2, remote (default: v4l2)\n";
 #elif defined(_WIN32)
     std::cout << "  --source <type>        Source type: none, ds, remote (default: ds)\n";
+#elif defined(__APPLE__)
+    std::cout << "  --source <type>        Source type: none, avfoundation, remote (default: avfoundation)\n";
 #else
     std::cout << "  --source <type>        Source type: none, remote (default: none)\n";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -976,6 +976,9 @@ int main(int argc, char *argv[])
 #elif defined(_WIN32)
     if (sourceType == "ds")
         sourceTypeEnum = UIManager::SourceType::DS;
+#elif defined(__APPLE__)
+    if (sourceType == "avfoundation")
+        sourceTypeEnum = UIManager::SourceType::AVFoundation;
 #endif
     if (sourceType == "remote")
         sourceTypeEnum = UIManager::SourceType::Remote;

--- a/src/renderer/glad_loader.h
+++ b/src/renderer/glad_loader.h
@@ -166,6 +166,7 @@ extern void (*glGetIntegerv)(GLenum pname, GLint* params);
 #define GL_VERSION 0x1F02
 #define GL_SHADING_LANGUAGE_VERSION 0x8B8C
 #define GL_MAJOR_VERSION 0x821B
+#define GL_EXTENSIONS 0x1F03
 
 // Funções básicas do OpenGL que podem estar disponíveis estaticamente
 // glGetString está disponível desde OpenGL 1.0, então pode ser linkado estaticamente

--- a/src/shader/ShaderPreprocessor.cpp
+++ b/src/shader/ShaderPreprocessor.cpp
@@ -128,25 +128,63 @@ ShaderPreprocessor::PreprocessResult ShaderPreprocessor::preprocess(
     
     // Verificar se estamos usando OpenGL ES
     bool isES = isOpenGLES();
-    
+
+    // Probe whether GL_ARB_shading_language_420pack is actually
+    // exposed by this GL context. Some macOS GPUs (Intel Iris under
+    // OpenGL 4.1) do not expose it even though shaders ship with a
+    // `#extension ... : require` line — requiring it then fails
+    // compile. Default to not requiring it; only emit the
+    // `#extension : require` line when the driver actually has it,
+    // and strip stray `#extension` lines from shader sources
+    // otherwise (same code path as the OpenGL ES branch).
+    auto checkExtension = [](const char *name) -> bool {
+        const GLubyte *raw = glGetString(GL_EXTENSIONS);
+        if (!raw)
+        {
+            return false;
+        }
+        const std::string extStr = reinterpret_cast<const char *>(raw);
+        const std::string needle = name;
+        size_t pos = 0;
+        while ((pos = extStr.find(needle, pos)) != std::string::npos)
+        {
+            const bool startOk = (pos == 0) || (extStr[pos - 1] == ' ');
+            const size_t endPos = pos + needle.size();
+            const bool endOk = (endPos == extStr.size()) || (extStr[endPos] == ' ');
+            if (startOk && endOk)
+            {
+                return true;
+            }
+            pos = endPos;
+        }
+        return false;
+    };
+    const bool has420Pack = !isES && checkExtension("GL_ARB_shading_language_420pack");
+
     // Adicionar extensão para inicialização estilo C (GL_ARB_shading_language_420pack)
     // Isso permite inicialização de arrays e estruturas estilo C
-    // IMPORTANTE: Esta extensão NÃO é suportada em OpenGL ES, então só adicionar em Desktop
+    // IMPORTANTE: Esta extensão NÃO é suportada em OpenGL ES e nem
+    // em alguns drivers macOS, então só adicionar quando o driver
+    // expõe explicitamente.
     std::string extensionLine = "";
-    if (!isES) {
+    if (has420Pack) {
         extensionLine = "#extension GL_ARB_shading_language_420pack : require\n";
     }
-    
-    // Remover extensões não suportadas do código fonte se for OpenGL ES
+
+    // Remover extensões não suportadas do código fonte se o driver
+    // não expõe a extensão (OpenGL ES ou desktop sem 420pack — macOS
+    // Intel Iris).
     std::string processedCodeAfterVersion = codeAfterVersion;
-    if (isES) {
+    if (!has420Pack) {
         // Remover todas as extensões GL_ARB_shading_language_420pack do código fonte
         std::regex extensionRegex(R"(#extension\s+GL_ARB_shading_language_420pack\s*:?\s*\w*\s*\n?)");
         processedCodeAfterVersion = std::regex_replace(processedCodeAfterVersion, extensionRegex, "");
-        
-        // Remover outras extensões problemáticas comuns em ES
-        std::regex arbExtensionRegex(R"(#extension\s+GL_ARB_[^\n]*\n?)");
-        processedCodeAfterVersion = std::regex_replace(processedCodeAfterVersion, arbExtensionRegex, "");
+
+        if (isES) {
+            // Remover outras extensões problemáticas comuns em ES
+            std::regex arbExtensionRegex(R"(#extension\s+GL_ARB_[^\n]*\n?)");
+            processedCodeAfterVersion = std::regex_replace(processedCodeAfterVersion, arbExtensionRegex, "");
+        }
     }
 
     std::string vertexCode = processedCodeAfterVersion;

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -511,6 +511,21 @@ bool APIController::handleGET(int clientFd, const std::string &path, const std::
     {
         return handleGETAudioStatus(clientFd);
     }
+#ifdef __APPLE__
+    else if (path == "/api/v1/avfoundation/devices")
+    {
+        return handleGETAVFoundationDevices(clientFd);
+    }
+    else if (path.rfind("/api/v1/avfoundation/formats/", 0) == 0)
+    {
+        return handleGETAVFoundationFormats(clientFd,
+                path.substr(std::string("/api/v1/avfoundation/formats/").size()));
+    }
+    else if (path == "/api/v1/avfoundation/audio-devices")
+    {
+        return handleGETAVFoundationAudioDevices(clientFd);
+    }
+#endif
     else if (path == "/api/v1/recording/profiles")
     {
         return handleGETRecordingProfiles(clientFd);
@@ -615,6 +630,20 @@ bool APIController::handlePOST(int clientFd, const std::string &path, const std:
     {
         return handleResyncAudioMonitor(clientFd);
     }
+#ifdef __APPLE__
+    else if (path == "/api/v1/avfoundation/device")
+    {
+        return handleSetAVFoundationDevice(clientFd, body);
+    }
+    else if (path == "/api/v1/avfoundation/format")
+    {
+        return handleSetAVFoundationFormat(clientFd, body);
+    }
+    else if (path == "/api/v1/avfoundation/audio-device")
+    {
+        return handleSetAVFoundationAudioDevice(clientFd, body);
+    }
+#endif
     else if (path == "/api/v1/source/overscan")
     {
         return handleSetSourceOverscan(clientFd, body);
@@ -3144,4 +3173,242 @@ bool APIController::handleResyncAudioMonitor(int clientFd)
     return true;
 #endif
 }
+
+#ifdef __APPLE__
+// AVFoundation endpoints (macOS). The video capture instance is asked
+// for the listings; on macOS that's VideoCaptureAVFoundation, which
+// implements the optional methods on IVideoCapture with real data.
+// The device-mutation endpoints go through IVideoCapture so we don't
+// need to dynamic_cast against the AVFoundation type here.
+
+bool APIController::handleGETAVFoundationDevices(int clientFd)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    IVideoCapture *vc = m_application->getVideoCapture();
+    if (!vc)
+    {
+        nlohmann::json r;
+        r["devices"] = nlohmann::json::array();
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    nlohmann::json r;
+    r["devices"] = nlohmann::json::array();
+    for (const auto &d : vc->listDevices())
+    {
+        r["devices"].push_back({
+            {"id",        d.id},
+            {"name",      d.name},
+            {"driver",    d.driver},
+            {"available", d.available}
+        });
+    }
+    sendJSONResponse(clientFd, 200, r.dump());
+    return true;
+}
+
+bool APIController::handleGETAVFoundationFormats(int clientFd, const std::string &deviceId)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    IVideoCapture *vc = m_application->getVideoCapture();
+    if (!vc)
+    {
+        nlohmann::json r;
+        r["formats"] = nlohmann::json::array();
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    nlohmann::json r;
+    r["deviceId"] = deviceId;
+    r["formats"]  = nlohmann::json::array();
+    for (const auto &f : vc->listFormats(deviceId))
+    {
+        r["formats"].push_back({
+            {"id",          f.id},
+            {"width",       f.width},
+            {"height",      f.height},
+            {"minFps",      f.minFps},
+            {"maxFps",      f.maxFps},
+            {"pixelFormat", f.pixelFormat},
+            {"colorSpace",  f.colorSpace},
+            {"displayName", f.displayName}
+        });
+    }
+    sendJSONResponse(clientFd, 200, r.dump());
+    return true;
+}
+
+bool APIController::handleGETAVFoundationAudioDevices(int clientFd)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    IVideoCapture *vc = m_application->getVideoCapture();
+    if (!vc)
+    {
+        nlohmann::json r;
+        r["devices"] = nlohmann::json::array();
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    nlohmann::json r;
+    r["current"]   = vc->getCurrentAudioDevice();
+    r["devices"]   = nlohmann::json::array();
+    for (const auto &d : vc->listAudioDevices())
+    {
+        r["devices"].push_back({
+            {"id",        d.id},
+            {"name",      d.name},
+            {"available", d.available}
+        });
+    }
+    sendJSONResponse(clientFd, 200, r.dump());
+    return true;
+}
+
+bool APIController::handleSetAVFoundationDevice(int clientFd, const std::string &body)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    try
+    {
+        const nlohmann::json j = nlohmann::json::parse(body);
+        const std::string deviceId = j.value("deviceId", "");
+        if (deviceId.empty())
+        {
+            sendErrorResponse(clientFd, 400, "deviceId is required");
+            return true;
+        }
+        IVideoCapture *vc = m_application->getVideoCapture();
+        if (!vc)
+        {
+            sendErrorResponse(clientFd, 400, "No video capture active");
+            return true;
+        }
+        // Route through UIManager.triggerDeviceChange so config
+        // persistence and capture reconfig stay synchronized with
+        // whatever the native UI does when a user picks a device.
+        if (!m_uiManager)
+        {
+            sendErrorResponse(clientFd, 500, "UI manager not available");
+            return true;
+        }
+        m_uiManager->triggerDeviceChange(deviceId);
+        if (m_uiManager)
+        {
+            m_uiManager->setAVFoundationDeviceId(deviceId);
+            m_uiManager->saveConfig();
+        }
+        nlohmann::json r;
+        r["success"]  = true;
+        r["deviceId"] = deviceId;
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        sendErrorResponse(clientFd, 400, std::string("Invalid JSON: ") + e.what());
+        return true;
+    }
+}
+
+bool APIController::handleSetAVFoundationFormat(int clientFd, const std::string &body)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    try
+    {
+        const nlohmann::json j = nlohmann::json::parse(body);
+        const std::string formatId = j.value("formatId", "");
+        const std::string deviceId = j.value("deviceId", "");
+        if (formatId.empty())
+        {
+            sendErrorResponse(clientFd, 400, "formatId is required");
+            return true;
+        }
+        IVideoCapture *vc = m_application->getVideoCapture();
+        if (!vc)
+        {
+            sendErrorResponse(clientFd, 400, "No video capture active");
+            return true;
+        }
+        if (!vc->setFormatById(formatId, deviceId))
+        {
+            sendErrorResponse(clientFd, 500, "Failed to apply AVFoundation format");
+            return true;
+        }
+        if (m_uiManager)
+        {
+            m_uiManager->setAVFoundationFormatId(formatId);
+            m_uiManager->saveConfig();
+        }
+        nlohmann::json r;
+        r["success"]  = true;
+        r["formatId"] = formatId;
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        sendErrorResponse(clientFd, 400, std::string("Invalid JSON: ") + e.what());
+        return true;
+    }
+}
+
+bool APIController::handleSetAVFoundationAudioDevice(int clientFd, const std::string &body)
+{
+    if (!m_application)
+    {
+        sendErrorResponse(clientFd, 500, "Application not available");
+        return true;
+    }
+    try
+    {
+        const nlohmann::json j = nlohmann::json::parse(body);
+        const std::string audioDeviceId = j.value("audioDeviceId", "");
+        IVideoCapture *vc = m_application->getVideoCapture();
+        if (!vc)
+        {
+            sendErrorResponse(clientFd, 400, "No video capture active");
+            return true;
+        }
+        if (!vc->setAudioDevice(audioDeviceId))
+        {
+            sendErrorResponse(clientFd, 500, "Failed to set AVFoundation audio device");
+            return true;
+        }
+        if (m_uiManager)
+        {
+            m_uiManager->setAVFoundationAudioDeviceId(audioDeviceId);
+            m_uiManager->saveConfig();
+        }
+        nlohmann::json r;
+        r["success"]       = true;
+        r["audioDeviceId"] = audioDeviceId;
+        sendJSONResponse(clientFd, 200, r.dump());
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        sendErrorResponse(clientFd, 400, std::string("Invalid JSON: ") + e.what());
+        return true;
+    }
+}
+#endif // __APPLE__
 

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -12,6 +12,9 @@
 #ifdef __linux__
 #include "../audio/AudioCapturePulse.h"
 #endif
+#ifdef __APPLE__
+#include "../audio/AudioCaptureCoreAudio.h"
+#endif
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <iomanip>
@@ -3166,10 +3169,23 @@ bool APIController::handleResyncAudioMonitor(int clientFd)
         sendJSONResponse(clientFd, 200, response.dump());
         return true;
     }
-    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux");
+    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux/macOS");
+    return true;
+#elif defined(__APPLE__)
+    AudioCaptureCoreAudio *caCapture = dynamic_cast<AudioCaptureCoreAudio *>(audioCapture);
+    if (caCapture)
+    {
+        caCapture->resyncMonitor();
+        nlohmann::json response;
+        response["success"] = true;
+        response["message"] = "Monitor resync requested";
+        sendJSONResponse(clientFd, 200, response.dump());
+        return true;
+    }
+    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux/macOS");
     return true;
 #else
-    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux");
+    sendErrorResponse(clientFd, 400, "Monitor resync only available on Linux/macOS");
     return true;
 #endif
 }

--- a/src/streaming/APIController.h
+++ b/src/streaming/APIController.h
@@ -162,6 +162,15 @@ private:
     bool handleSetSourceOverscan(int clientFd, const std::string& body);
     bool handleGETAudioInputSources(int clientFd);
     bool handleGETAudioStatus(int clientFd);
+#ifdef __APPLE__
+    // AVFoundation device + format endpoints (macOS only). The format
+    // dropdown follows OBS's "pick a (resolution, fps range, pixel
+    // format) tuple atomically" pattern instead of independent
+    // resolution/FPS sliders.
+    bool handleGETAVFoundationDevices(int clientFd);
+    bool handleGETAVFoundationFormats(int clientFd, const std::string &deviceId);
+    bool handleGETAVFoundationAudioDevices(int clientFd);
+#endif
 
     // Endpoints POST/PUT (escrita)
     bool handlePOST(int clientFd, const std::string &path, const std::string &body);
@@ -190,6 +199,11 @@ private:
     bool handleSetAudioInputSource(int clientFd, const std::string &body);
     bool handleDisconnectAudioInput(int clientFd);
     bool handleResyncAudioMonitor(int clientFd);
+#ifdef __APPLE__
+    bool handleSetAVFoundationDevice(int clientFd, const std::string &body);
+    bool handleSetAVFoundationFormat(int clientFd, const std::string &body);
+    bool handleSetAVFoundationAudioDevice(int clientFd, const std::string &body);
+#endif
 
     // Recording profiles (saved snapshots of recording configuration)
     bool handleGETRecordingProfiles(int clientFd);

--- a/src/streaming/HTTPServer.cpp
+++ b/src/streaming/HTTPServer.cpp
@@ -1,6 +1,6 @@
 #include "HTTPServer.h"
 #include "../utils/Logger.h"
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -204,7 +204,7 @@ bool HTTPServer::createServer(int port)
 #endif
 
     // Criar socket
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     m_serverSocket = socket(AF_INET, SOCK_STREAM, 0);
     if (m_serverSocket < 0)
     {
@@ -223,7 +223,7 @@ bool HTTPServer::createServer(int port)
 
     // Configurar opções do socket
     int opt = 1;
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     setsockopt(m_serverSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 #else
     setsockopt(m_serverSocket, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt));
@@ -261,13 +261,13 @@ bool HTTPServer::createServer(int port)
 int HTTPServer::acceptClient()
 {
     struct sockaddr_in clientAddr;
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     socklen_t clientLen = sizeof(clientAddr);
 #else
     int clientLen = sizeof(clientAddr);
 #endif
 
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     int clientFd = accept(m_serverSocket, (struct sockaddr *)&clientAddr, &clientLen);
     if (clientFd < 0)
     {
@@ -452,7 +452,7 @@ ssize_t HTTPServer::sendData(int clientFd, const void *data, size_t size)
         }
     }
 #endif
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     // MSG_DONTWAIT keeps us non-blocking on a per-call basis without
     // having to flip the socket itself. On EAGAIN/EWOULDBLOCK we return
     // 0 (matching the Windows WSAEWOULDBLOCK path) so the streamer
@@ -497,7 +497,7 @@ ssize_t HTTPServer::receiveData(int clientFd, void *buffer, size_t size)
         }
     }
 #endif
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     return recv(clientFd, buffer, size, 0);
 #else
     return recv(clientFd, (char *)buffer, (int)size, 0);
@@ -534,7 +534,7 @@ void HTTPServer::closeClient(int clientFd)
     // we're not going to act on it, just keep the kernel from
     // resorting to RST), then close() emits the normal FIN/ACK
     // exchange.
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     ::shutdown(clientFd, SHUT_WR);
     char drain[1024];
     int spins = 0;

--- a/src/streaming/HTTPServer.h
+++ b/src/streaming/HTTPServer.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <map>
 #include <cstddef>
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
 #include <sys/types.h>
 #endif
 

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -3,7 +3,7 @@
 #include "../utils/Logger.h"
 #include "../utils/Paths.h"
 
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -724,7 +724,7 @@ void HTTPTSStreamer::cleanup()
 void HTTPTSStreamer::handleClient(int clientFd)
 {
 // Configurar socket para baixa latência
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
     int flag = 1;
     setsockopt(clientFd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 #elif defined(_WIN32)

--- a/src/streaming/WebPortal.cpp
+++ b/src/streaming/WebPortal.cpp
@@ -3,7 +3,7 @@
 #include "../utils/LanCheck.h"
 #include "../utils/Logger.h"
 #include "../utils/Paths.h"
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -766,11 +766,18 @@ ssize_t WebPortal::sendData(int clientFd, const void *data, size_t size) const
     {
         return m_httpServer->sendData(clientFd, data, size);
     }
-    // Fallback para send() direto se HTTPServer não estiver configurado
+    // Fallback para send() direto se HTTPServer não estiver configurado.
+    // MSG_NOSIGNAL exists on Linux only — macOS uses the SO_NOSIGPIPE
+    // socket option (set once at accept time, not here) and Windows
+    // has no equivalent flag. We pass MSG_NOSIGNAL only on Linux; on
+    // the other platforms the caller is expected to have set up
+    // SIGPIPE handling elsewhere (e.g. signal(SIGPIPE, SIG_IGN) at
+    // startup, or per-socket SO_NOSIGPIPE on macOS).
     #ifdef PLATFORM_LINUX
     return send(clientFd, data, size, MSG_NOSIGNAL);
+    #elif defined(PLATFORM_MACOS)
+    return send(clientFd, data, size, 0);
     #else
-    // Windows não tem MSG_NOSIGNAL, usar send() normal
     return send(clientFd, (const char*)data, size, 0);
     #endif
 }

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -43,6 +43,12 @@ void UIConfigurationAudio::render()
     }
 
     renderInputSourceSelection();
+#ifdef __APPLE__
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    renderAVFoundationAudioDeviceSelection();
+#endif
 
     ImGui::End();
 }
@@ -227,4 +233,73 @@ void UIConfigurationAudio::renderInputSourceSelection()
     }
 #endif
 }
+
+#ifdef __APPLE__
+
+void UIConfigurationAudio::renderAVFoundationAudioDeviceSelection()
+{
+    ui_section_header("AVFoundation audio source",
+                      "Some capture devices carry audio alongside video "
+                      "(UVC HDMI grabbers). Use this dropdown to pick "
+                      "between the bundled stream and any other "
+                      "AVFoundation audio source on the system.");
+
+    if (!m_uiManager) return;
+
+    // Listing the AVFoundation audio devices goes through the video
+    // capture instance — AVFoundation owns the audio enumeration since
+    // the audio is bundled with the video device descriptor.
+    IVideoCapture *vc = m_uiManager->getCapture();
+    if (!vc)
+    {
+        ImGui::TextWrapped("No AVFoundation capture active.");
+        return;
+    }
+
+    if (m_avfAudioDevicesNeedRefresh)
+    {
+        m_avfAudioDevices = vc->listAudioDevices();
+        m_avfAudioDevicesNeedRefresh = false;
+    }
+
+    if (m_avfAudioDevices.empty())
+    {
+        ImGui::TextWrapped("No AVFoundation audio devices found.");
+        if (ImGui::Button("Refresh##avfAudioDevices"))
+        {
+            m_avfAudioDevicesNeedRefresh = true;
+        }
+        return;
+    }
+
+    const std::string current = vc->getCurrentAudioDevice();
+    std::vector<const char *> names;
+    int idx = -1;
+    names.reserve(m_avfAudioDevices.size());
+    for (size_t i = 0; i < m_avfAudioDevices.size(); ++i)
+    {
+        names.push_back(m_avfAudioDevices[i].name.c_str());
+        if (m_avfAudioDevices[i].id == current) idx = static_cast<int>(i);
+    }
+    if (idx < 0) idx = 0;
+
+    if (ImGui::Combo("##avfAudioDevices", &idx,
+                     names.data(), static_cast<int>(names.size())))
+    {
+        const auto &picked = m_avfAudioDevices[idx];
+        if (vc->setAudioDevice(picked.id))
+        {
+            m_uiManager->setAVFoundationAudioDeviceId(picked.id);
+            m_uiManager->saveConfig();
+        }
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Refresh##avfAudioDevices"))
+    {
+        m_avfAudioDevicesNeedRefresh = true;
+    }
+}
+
+#endif // __APPLE__
 

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -6,6 +6,9 @@
 #ifdef __linux__
 #include "../audio/AudioCapturePulse.h"
 #endif
+#ifdef __APPLE__
+#include "../audio/AudioCaptureCoreAudio.h"
+#endif
 #include <imgui.h>
 #include <algorithm>
 
@@ -90,7 +93,7 @@ void UIConfigurationAudio::refreshInputSources()
                 }
             }
         }
-        
+
         // If no active connection found, check saved configuration from UIManager
         if (m_selectedInputSourceIndex == -1 && m_uiManager)
         {
@@ -105,6 +108,31 @@ void UIConfigurationAudio::refreshInputSources()
                         break;
                     }
                 }
+            }
+        }
+    }
+#elif defined(__APPLE__)
+    // Core Audio devices via IAudioCapture::listDevices — same listing
+    // used elsewhere. On macOS the saved id comes from
+    // `getAudioInputSourceId()`, same field reused.
+    const auto devices = m_audioCapture->listDevices();
+    for (const auto &d : devices)
+    {
+        m_inputSourceNames.push_back(d.name);
+        m_inputSourceIds.push_back(d.id);
+    }
+
+    const std::string saved = m_uiManager
+        ? m_uiManager->getAudioInputSourceId()
+        : std::string();
+    if (!saved.empty())
+    {
+        for (size_t i = 0; i < m_inputSourceIds.size(); ++i)
+        {
+            if (m_inputSourceIds[i] == saved)
+            {
+                m_selectedInputSourceIndex = static_cast<int>(i);
+                break;
             }
         }
     }
@@ -230,6 +258,62 @@ void UIConfigurationAudio::renderInputSourceSelection()
         ImGui::TextWrapped("Pick a device above to start capturing. "
                            "RetroCapture will record from it and publish "
                            "the audio as the 'RetroCapture' source.");
+    }
+#elif defined(__APPLE__)
+    if (m_inputSourceNames.empty())
+    {
+        ImGui::TextWrapped("No Core Audio input devices found.");
+        return;
+    }
+
+    std::vector<const char *> namesCStr;
+    namesCStr.reserve(m_inputSourceNames.size());
+    for (const auto &n : m_inputSourceNames) namesCStr.push_back(n.c_str());
+
+    const int prev = m_selectedInputSourceIndex;
+    int        idx = (m_selectedInputSourceIndex >= 0)
+                     ? m_selectedInputSourceIndex : 0;
+    if (ImGui::Combo("Input device", &idx,
+                     namesCStr.data(), static_cast<int>(namesCStr.size())))
+    {
+        if (idx >= 0 && idx < static_cast<int>(m_inputSourceIds.size()))
+        {
+            const std::string pickedId = m_inputSourceIds[idx];
+            m_audioCapture->close();
+            if (m_audioCapture->open(pickedId))
+            {
+                m_audioCapture->startCapture();
+                m_selectedInputSourceIndex = idx;
+                if (m_uiManager)
+                {
+                    m_uiManager->setAudioInputSourceId(pickedId);
+                    m_uiManager->saveConfig();
+                }
+            }
+            else
+            {
+                ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+                                   "Failed to open Core Audio device");
+                m_selectedInputSourceIndex = prev;
+            }
+        }
+    }
+
+    ImGui::Spacing();
+    if (m_audioCapture->isOpen())
+    {
+        ImGui::Text("Format: %u Hz, %u channel%s",
+                    m_audioCapture->getSampleRate(),
+                    m_audioCapture->getChannels(),
+                    m_audioCapture->getChannels() == 1 ? "" : "s");
+
+        if (ImGui::Button("Resync monitor"))
+        {
+            if (auto *caCapture = dynamic_cast<AudioCaptureCoreAudio *>(m_audioCapture))
+            {
+                caCapture->resyncMonitor();
+            }
+        }
     }
 #endif
 }

--- a/src/ui/UIConfigurationAudio.h
+++ b/src/ui/UIConfigurationAudio.h
@@ -3,6 +3,10 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+#include "../capture/IVideoCapture.h"
+#endif
+
 // Forward declarations
 class UIManager;
 class IAudioCapture;
@@ -33,4 +37,15 @@ private:
     
     void renderInputSourceSelection();
     void refreshInputSources();
+#ifdef __APPLE__
+    // AVFoundation device-bundled audio device picker. AVFoundation
+    // capture devices (UVC HDMI grabbers) carry their own audio
+    // streams; this dropdown lets the user choose between the device's
+    // bundled audio and any other AVFoundation audio source on the
+    // system. Independent of the IAudioCapture (CoreAudio) path that
+    // the encoder/recorder consume.
+    void renderAVFoundationAudioDeviceSelection();
+    std::vector<DeviceInfo> m_avfAudioDevices;
+    bool m_avfAudioDevicesNeedRefresh = true;
+#endif
 };

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -68,6 +68,15 @@ void UIConfigurationSource::render()
     {
         ImGui::TextWrapped("No source selected. Pick a source type above.");
     }
+#elif defined(__APPLE__)
+    if (sourceType == UIManager::SourceType::AVFoundation)
+    {
+        renderAVFoundationControls();
+    }
+    else if (sourceType == UIManager::SourceType::None)
+    {
+        ImGui::TextWrapped("No source selected. Pick a source type above.");
+    }
 #else
     if (sourceType == UIManager::SourceType::None)
     {
@@ -99,6 +108,11 @@ void UIConfigurationSource::renderSourceTypeSelection()
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
         UIManager::SourceType::DS};
+#elif defined(__APPLE__)
+    const char *sourceTypeNames[] = {"None", "AVFoundation"};
+    UIManager::SourceType sourceTypeMap[] = {
+        UIManager::SourceType::None,
+        UIManager::SourceType::AVFoundation};
 #else
     const char *sourceTypeNames[] = {"None"};
     UIManager::SourceType sourceTypeMap[] = {
@@ -733,3 +747,160 @@ void UIConfigurationSource::renderRemoteControls()
         ImGui::TextDisabled("not connected");
     }
 }
+
+#ifdef __APPLE__
+
+void UIConfigurationSource::renderAVFoundationControls()
+{
+    if (!m_capture || !m_capture->isOpen())
+    {
+        ImGui::TextWrapped("No AVFoundation device connected. Pick a device below "
+                           "to start capture.");
+        ImGui::Separator();
+    }
+
+    renderAVFoundationDeviceSelection();
+    ImGui::Separator();
+    renderAVFoundationFormatSelection();
+    // AVFoundation on macOS does not surface per-device hardware
+    // controls (brightness, gain, etc.) the way V4L2 / DirectShow do,
+    // so there is no hardware-controls section here. See
+    // docs/MACOS_PORT_STRATEGY.md.
+}
+
+void UIConfigurationSource::renderAVFoundationDeviceSelection()
+{
+    ui_section_header("AVFoundation device",
+                      "macOS capture device. The list is sourced from "
+                      "AVCaptureDevice — UVC HDMI grabbers, webcams, and "
+                      "any virtual camera installed on the system show up here.");
+
+    if (m_avfDevicesNeedRefresh && m_capture)
+    {
+        m_avfDevices = m_capture->listDevices();
+        m_avfDevicesNeedRefresh = false;
+    }
+
+    if (m_avfDevices.empty())
+    {
+        ImGui::TextWrapped("No AVFoundation devices found.");
+        if (ImGui::Button("Refresh##avfDevices"))
+        {
+            m_avfDevicesNeedRefresh = true;
+        }
+        return;
+    }
+
+    const std::string currentId = m_uiManager
+        ? m_uiManager->getAVFoundationDeviceId()
+        : std::string();
+
+    std::vector<const char *> names;
+    int currentIndex = -1;
+    names.reserve(m_avfDevices.size());
+    for (size_t i = 0; i < m_avfDevices.size(); ++i)
+    {
+        names.push_back(m_avfDevices[i].name.c_str());
+        if (m_avfDevices[i].id == currentId)
+        {
+            currentIndex = static_cast<int>(i);
+        }
+    }
+    if (currentIndex < 0) currentIndex = 0;
+
+    if (ImGui::Combo("##avfDeviceCombo", &currentIndex,
+                     names.data(), static_cast<int>(names.size())))
+    {
+        const auto &picked = m_avfDevices[currentIndex];
+        if (m_uiManager)
+        {
+            m_uiManager->triggerDeviceChange(picked.id);
+            m_uiManager->setAVFoundationDeviceId(picked.id);
+            m_uiManager->saveConfig();
+        }
+        // Force a format-list refresh against the new device.
+        m_avfFormatsNeedRefresh = true;
+        m_avfFormatsForDeviceId.clear();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Refresh##avfDevices"))
+    {
+        m_avfDevicesNeedRefresh = true;
+    }
+}
+
+void UIConfigurationSource::renderAVFoundationFormatSelection()
+{
+    ui_section_header("Format",
+                      "Each AVFoundation device exposes a fixed set of "
+                      "(resolution, FPS range, pixel format) tuples. "
+                      "Picking a format applies all three atomically — "
+                      "no separate resolution / FPS sliders, OBS-style.");
+
+    if (!m_capture)
+    {
+        ImGui::TextWrapped("No capture instance available.");
+        return;
+    }
+
+    const std::string deviceId = m_uiManager
+        ? m_uiManager->getAVFoundationDeviceId()
+        : std::string();
+
+    if (m_avfFormatsNeedRefresh || m_avfFormatsForDeviceId != deviceId)
+    {
+        m_avfFormats = m_capture->listFormats(deviceId);
+        m_avfFormatsForDeviceId = deviceId;
+        m_avfFormatsNeedRefresh = false;
+    }
+
+    if (m_avfFormats.empty())
+    {
+        ImGui::TextWrapped("No formats available for the selected device.");
+        if (ImGui::Button("Refresh##avfFormats"))
+        {
+            m_avfFormatsNeedRefresh = true;
+        }
+        return;
+    }
+
+    const std::string currentFormatId = m_uiManager
+        ? m_uiManager->getAVFoundationFormatId()
+        : std::string();
+
+    std::vector<const char *> displayNames;
+    int currentIndex = -1;
+    displayNames.reserve(m_avfFormats.size());
+    for (size_t i = 0; i < m_avfFormats.size(); ++i)
+    {
+        displayNames.push_back(m_avfFormats[i].displayName.c_str());
+        if (m_avfFormats[i].id == currentFormatId)
+        {
+            currentIndex = static_cast<int>(i);
+        }
+    }
+    if (currentIndex < 0) currentIndex = 0;
+
+    if (ImGui::Combo("##avfFormatCombo", &currentIndex,
+                     displayNames.data(), static_cast<int>(displayNames.size())))
+    {
+        const auto &picked = m_avfFormats[currentIndex];
+        if (m_capture->setFormatById(picked.id, deviceId))
+        {
+            if (m_uiManager)
+            {
+                m_uiManager->setAVFoundationFormatId(picked.id);
+                m_uiManager->saveConfig();
+            }
+        }
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Refresh##avfFormats"))
+    {
+        m_avfFormatsNeedRefresh = true;
+    }
+}
+
+#endif // __APPLE__

--- a/src/ui/UIConfigurationSource.h
+++ b/src/ui/UIConfigurationSource.h
@@ -4,6 +4,13 @@
 #include <cstdint>
 #include <vector>
 
+#ifdef __APPLE__
+// Pulled in (not forward-declared) because m_avfDevices and
+// m_avfFormats below are std::vector instantiations and need the
+// complete type for size/destructor.
+#include "../capture/IVideoCapture.h"
+#endif
+
 // Forward declarations
 class UIManager;
 class IVideoCapture;
@@ -36,6 +43,22 @@ private:
 #ifdef _WIN32
     void renderDSControls();
     void renderDSDeviceSelection();
+#endif
+#ifdef __APPLE__
+    // macOS / AVFoundation: device dropdown + format dropdown
+    // (OBS-style — picking a format selects width/height/fps/pixfmt
+    // atomically since AVFoundation exposes them as fixed tuples).
+    void renderAVFoundationControls();
+    void renderAVFoundationDeviceSelection();
+    void renderAVFoundationFormatSelection();
+
+    // Per-frame cache of the device + format list so we don't hit
+    // AVFoundation every frame from inside render().
+    std::vector<DeviceInfo> m_avfDevices;
+    std::vector<AVFoundationFormatInfo> m_avfFormats;
+    bool m_avfDevicesNeedRefresh = true;
+    bool m_avfFormatsNeedRefresh = true;
+    std::string m_avfFormatsForDeviceId; // tracks which device's formats we cached
 #endif
     void renderCaptureSettings();
     void renderQuickResolutions();

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -71,7 +71,7 @@ UIManager::~UIManager()
     m_streamingWindow.reset();
     m_recordingWindow.reset();
     m_webPortalWindow.reset();
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     m_audioWindow.reset();
 #endif
     m_infoWindow.reset();
@@ -593,7 +593,7 @@ void UIManager::render()
         if (m_streamingWindow) m_streamingWindow->setVisible(false);
         // Recording window stays openable in client mode (#68).
         if (m_webPortalWindow) m_webPortalWindow->setVisible(false);
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
         if (m_audioWindow)     m_audioWindow->setVisible(false);
 #endif
     }
@@ -606,7 +606,7 @@ void UIManager::render()
     if (m_streamingWindow)   m_streamingWindow->render();
     if (m_recordingWindow)   m_recordingWindow->render();
     if (m_webPortalWindow)   m_webPortalWindow->render();
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     if (m_audioWindow)       m_audioWindow->render();
 #endif
     if (m_infoWindow)        m_infoWindow->render();

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -5,7 +5,7 @@
 #include "UIConfigurationStreaming.h"
 #include "UIConfigurationRecording.h"
 #include "UIConfigurationWebPortal.h"
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #  include "UIConfigurationAudio.h"
 #endif
 #include "UIInfoPanel.h"
@@ -228,7 +228,7 @@ bool UIManager::init(void *window)
     m_streamingWindow   = std::make_unique<UIConfigurationStreaming>(this);
     m_recordingWindow   = std::make_unique<UIConfigurationRecording>(this);
     m_webPortalWindow   = std::make_unique<UIConfigurationWebPortal>(this);
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     m_audioWindow       = std::make_unique<UIConfigurationAudio>(this);
 #endif
     m_infoWindow        = std::make_unique<UIInfoPanel>(this);
@@ -465,7 +465,7 @@ void UIManager::render()
                 toggleItem(T("menu.configurations.source"),     m_sourceWindow.get());
                 toggleItem(T("menu.configurations.streaming"),  m_streamingWindow.get());
                 toggleItem(T("menu.configurations.webportal"),  m_webPortalWindow.get());
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
                 toggleItem(T("menu.configurations.audio"),      m_audioWindow.get());
 #endif
             }

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -2762,7 +2762,29 @@ void UIManager::loadConfig()
             if (source.contains("type"))
             {
                 int sourceTypeInt = source["type"].get<int>();
-                m_sourceType = static_cast<SourceType>(sourceTypeInt);
+                SourceType loaded  = static_cast<SourceType>(sourceTypeInt);
+                // Coerce platform-foreign source types to the local
+                // platform's native one: a config saved on Linux
+                // with V4L2 shouldn't try to instantiate V4L2 on
+                // macOS, and so on. Remote and None always travel.
+                const bool isPlatformNative =
+                    loaded == SourceType::None ||
+                    loaded == SourceType::Remote ||
+#ifdef __linux__
+                    loaded == SourceType::V4L2;
+#elif defined(_WIN32)
+                    loaded == SourceType::DS;
+#elif defined(__APPLE__)
+                    loaded == SourceType::AVFoundation;
+#else
+                    false;
+#endif
+                if (isPlatformNative)
+                {
+                    m_sourceType = loaded;
+                }
+                // else: keep the platform-default that the
+                // constructor / default-init set.
             }
         }
 

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -2796,6 +2796,27 @@ void UIManager::loadConfig()
             }
         }
 
+        // AVFoundation persistence (macOS device + format selection).
+        // Loaded on every platform so the JSON round-trips cleanly;
+        // ignored on non-macOS builds where the fields don't drive
+        // anything.
+        if (config.contains("avfoundation"))
+        {
+            auto &avf = config["avfoundation"];
+            if (avf.contains("deviceId") && !avf["deviceId"].is_null())
+            {
+                m_avfDeviceId = avf["deviceId"].get<std::string>();
+            }
+            if (avf.contains("formatId") && !avf["formatId"].is_null())
+            {
+                m_avfFormatId = avf["formatId"].get<std::string>();
+            }
+            if (avf.contains("audioDeviceId") && !avf["audioDeviceId"].is_null())
+            {
+                m_avfAudioDeviceId = avf["audioDeviceId"].get<std::string>();
+            }
+        }
+
         // Carregar configurações de gravação
         if (config.contains("recording"))
         {
@@ -2979,6 +3000,12 @@ void UIManager::saveConfig()
         // Salvar configurações de áudio
         config["audio"] = {
             {"inputSourceId", m_audioInputSourceId.empty() ? "" : m_audioInputSourceId}};
+
+        // AVFoundation device + format selection (macOS).
+        config["avfoundation"] = {
+            {"deviceId",      m_avfDeviceId},
+            {"formatId",      m_avfFormatId},
+            {"audioDeviceId", m_avfAudioDeviceId}};
 
         // Salvar configurações de gravação
         config["recording"] = {

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -857,7 +857,7 @@ private:
     std::unique_ptr<class UIConfigurationStreaming> m_streamingWindow;
     std::unique_ptr<class UIConfigurationRecording> m_recordingWindow;
     std::unique_ptr<class UIConfigurationWebPortal> m_webPortalWindow;
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     std::unique_ptr<class UIConfigurationAudio>     m_audioWindow;
 #endif
     std::unique_ptr<class UIInfoPanel>              m_infoWindow;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -162,8 +162,9 @@ public:
     {
         None = 0,
         V4L2 = 1,
-        DS = 2, // DirectShow (Windows)
-        Remote = 3 // Remote /raw MPEG-TS from another RetroCapture (Phase 3 of #47)
+        DS = 2,           // DirectShow (Windows)
+        Remote = 3,       // Remote /raw MPEG-TS from another RetroCapture (Phase 3 of #47)
+        AVFoundation = 4  // AVFoundation (macOS)
     };
 
     // Source type setter (para uso pelas classes de abas)
@@ -489,6 +490,16 @@ public:
     // Audio device configuration
     void setAudioInputSourceId(const std::string &sourceId) { m_audioInputSourceId = sourceId; }
     std::string getAudioInputSourceId() const { return m_audioInputSourceId; }
+
+    // AVFoundation device + format persistence (macOS only). Stored
+    // regardless of platform so a config saved on macOS round-trips
+    // through Linux/Windows without losing data — they just ignore it.
+    void setAVFoundationDeviceId(const std::string &id) { m_avfDeviceId = id; }
+    std::string getAVFoundationDeviceId() const { return m_avfDeviceId; }
+    void setAVFoundationFormatId(const std::string &id) { m_avfFormatId = id; }
+    std::string getAVFoundationFormatId() const { return m_avfFormatId; }
+    void setAVFoundationAudioDeviceId(const std::string &id) { m_avfAudioDeviceId = id; }
+    std::string getAVFoundationAudioDeviceId() const { return m_avfAudioDeviceId; }
 
     // Streaming status getters
     bool getStreamingActive() const { return m_streamingActive; }
@@ -924,12 +935,19 @@ private:
     
     // Audio device configuration (saved/loaded from config)
     std::string m_audioInputSourceId;
+    // AVFoundation persistence (macOS). Stored on all platforms so
+    // configs round-trip cleanly between machines.
+    std::string m_avfDeviceId;
+    std::string m_avfFormatId;
+    std::string m_avfAudioDeviceId;
     std::vector<V4L2Control> m_v4l2Controls;
     std::function<void(const std::string &, int32_t)> m_onV4L2ControlChanged;
 
     // Source selection
 #ifdef _WIN32
     SourceType m_sourceType = SourceType::DS; // Padrão: DirectShow no Windows
+#elif defined(__APPLE__)
+    SourceType m_sourceType = SourceType::AVFoundation; // Padrão: AVFoundation no macOS
 #else
     SourceType m_sourceType = SourceType::V4L2; // Padrão: V4L2 no Linux
 #endif

--- a/src/utils/FFmpegCompat.h
+++ b/src/utils/FFmpegCompat.h
@@ -34,6 +34,26 @@ extern "C"
 #define FFMPEG_USE_NEW_CHANNEL_LAYOUT 0
 #endif
 
+// Profile constant naming: FFmpeg 7+ renamed FF_PROFILE_* to
+// AV_PROFILE_* (and dropped the old aliases). Older versions only
+// expose FF_PROFILE_*. Map whichever side is missing onto the other
+// so the rest of the codebase can keep using FF_PROFILE_*.
+#if !defined(FF_PROFILE_HEVC_MAIN) && defined(AV_PROFILE_HEVC_MAIN)
+#define FF_PROFILE_HEVC_MAIN AV_PROFILE_HEVC_MAIN
+#endif
+#if !defined(FF_PROFILE_HEVC_MAIN_10) && defined(AV_PROFILE_HEVC_MAIN_10)
+#define FF_PROFILE_HEVC_MAIN_10 AV_PROFILE_HEVC_MAIN_10
+#endif
+#if !defined(FF_PROFILE_H264_BASELINE) && defined(AV_PROFILE_H264_BASELINE)
+#define FF_PROFILE_H264_BASELINE AV_PROFILE_H264_BASELINE
+#endif
+#if !defined(FF_PROFILE_H264_MAIN) && defined(AV_PROFILE_H264_MAIN)
+#define FF_PROFILE_H264_MAIN AV_PROFILE_H264_MAIN
+#endif
+#if !defined(FF_PROFILE_H264_HIGH) && defined(AV_PROFILE_H264_HIGH)
+#define FF_PROFILE_H264_HIGH AV_PROFILE_H264_HIGH
+#endif
+
 // Compatibility macros for AVIO write callback
 // FFmpeg 6.1+ (libavformat 61+) uses const uint8_t* for write_packet callback
 // FFmpeg 6.0 (libavformat 60) still uses uint8_t* (non-const)

--- a/src/utils/Paths.cpp
+++ b/src/utils/Paths.cpp
@@ -211,6 +211,31 @@ std::string Paths::getReadOnlyAssetsDir()
     // Último recurso: assume layout NSIS relativo ao .exe mesmo que os
     // arquivos não estejam lá ainda — alguns callers gravam por baixo.
     return installShared.string();
+#elif defined(__APPLE__)
+    // macOS .app bundle layout:
+    //   RetroCapture.app/
+    //     Contents/
+    //       MacOS/retrocapture          ← exeDir
+    //       Resources/shaders/...       ← assets sit here
+    //       Resources/web/...
+    //       Resources/ssl/...
+    // Probe `<exeDir>/../Resources` for the canonical bundle layout
+    // before falling back to the Linux-style lookups (so a developer
+    // running the raw binary from `build-macos-x86_64/bin/` still gets
+    // assets resolved via the CWD probe at the top of this function).
+    {
+        fs::path exeDir(getExecutableDir());
+        fs::path resources = exeDir.parent_path() / "Resources";
+        if (fs::exists(resources / "shaders" / "shaders_glsl"))
+        {
+            return resources.string();
+        }
+        fs::path siblingShare = exeDir.parent_path() / "share" / "retrocapture";
+        if (fs::exists(siblingShare)) return siblingShare.string();
+        fs::path portable = exeDir / "assets";
+        if (fs::exists(portable)) return portable.string();
+        return portable.string();
+    }
 #else
     // Linux: $XDG_DATA_DIRS é uma lista separada por ':'. Procura por
     // retrocapture/ em cada uma. Fallback /usr/local/share, /usr/share,

--- a/src/web/api.js
+++ b/src/web/api.js
@@ -286,6 +286,33 @@ class RetroCaptureAPI {
     async resyncAudioMonitor() {
         return await this.request('POST', '/audio/resync');
     }
+
+    // AVFoundation (macOS) — the backend gates these endpoints by
+    // platform, so calling them on Linux/Windows returns 404 (which
+    // the UI uses as a "hide the AVFoundation cards" signal).
+    async getAVFoundationDevices() {
+        return await this.request('GET', '/avfoundation/devices');
+    }
+
+    async getAVFoundationFormats(deviceId) {
+        return await this.request('GET', `/avfoundation/formats/${encodeURIComponent(deviceId || '')}`);
+    }
+
+    async getAVFoundationAudioDevices() {
+        return await this.request('GET', '/avfoundation/audio-devices');
+    }
+
+    async setAVFoundationDevice(deviceId) {
+        return await this.request('POST', '/avfoundation/device', { deviceId });
+    }
+
+    async setAVFoundationFormat(formatId, deviceId) {
+        return await this.request('POST', '/avfoundation/format', { formatId, deviceId });
+    }
+
+    async setAVFoundationAudioDevice(audioDeviceId) {
+        return await this.request('POST', '/avfoundation/audio-device', { audioDeviceId });
+    }
 }
 
 // Instância global da API

--- a/src/web/config.html
+++ b/src/web/config.html
@@ -422,6 +422,36 @@
                                             </div>
                                         </div>
                                         
+                                        <!-- AVFoundation Controls (macOS only — backend gates by platform) -->
+                                        <div id="avfoundationControlsContainer" style="display: none;">
+                                            <div class="col-12">
+                                                <hr>
+                                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                                    <h6 class="mb-0">AVFoundation device</h6>
+                                                    <button class="btn btn-sm btn-secondary" onclick="refreshAVFoundationDevices()">
+                                                        <i class="bi bi-arrow-clockwise me-1"></i>Refresh
+                                                    </button>
+                                                </div>
+                                                <select class="form-select" id="avfoundationDevice">
+                                                    <option value="">Loading...</option>
+                                                </select>
+                                                <small class="form-text text-muted mt-1">macOS capture device sourced from AVCaptureDevice — UVC HDMI grabbers, webcams, virtual cameras.</small>
+                                            </div>
+
+                                            <div class="col-12 mt-3" id="avfoundationFormatBlock">
+                                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                                    <h6 class="mb-0">Format</h6>
+                                                    <button class="btn btn-sm btn-secondary" onclick="refreshAVFoundationFormats()">
+                                                        <i class="bi bi-arrow-clockwise me-1"></i>Refresh
+                                                    </button>
+                                                </div>
+                                                <select class="form-select" id="avfoundationFormat">
+                                                    <option value="">Pick a device first…</option>
+                                                </select>
+                                                <small class="form-text text-muted mt-1">AVFoundation devices expose fixed (resolution, FPS range, pixel format) tuples — picking one applies all three atomically.</small>
+                                            </div>
+                                        </div>
+
                                         <!-- None Source Message -->
                                         <div id="noneSourceMessage" class="col-12">
                                             <div class="alert alert-info">
@@ -828,6 +858,31 @@
                                                     </div>
                                                     <div class="mt-1">
                                                         <small class="text-muted" id="currentInputFormat"></small>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- AVFoundation audio device (macOS) -->
+                                        <div class="col-12" id="avfoundationAudioDeviceContainer" style="display: none;">
+                                            <div class="card">
+                                                <div class="card-header">
+                                                    <h6 class="mb-0">
+                                                        <i class="bi bi-soundwave me-2"></i>AVFoundation audio source
+                                                    </h6>
+                                                </div>
+                                                <div class="card-body">
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Audio source</label>
+                                                        <div class="input-group">
+                                                            <select class="form-select" id="avfoundationAudioDevice">
+                                                                <option value="">Loading...</option>
+                                                            </select>
+                                                            <button class="btn btn-outline-secondary" type="button" onclick="refreshAVFoundationAudioDevices()" title="Refresh">
+                                                                <i class="bi bi-arrow-clockwise"></i>
+                                                            </button>
+                                                        </div>
+                                                        <small class="form-text text-muted">Some AVFoundation devices (UVC HDMI grabbers) bundle audio with video — this picker lets you choose between the bundled stream and any other AVFoundation audio source.</small>
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/web/control.js
+++ b/src/web/control.js
@@ -2813,3 +2813,158 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 });
+
+// =============================================================
+// AVFoundation (macOS) — device + format selection
+// =============================================================
+// Endpoints are gated on the backend; calling them on Linux/Windows
+// returns 404 and the corresponding cards stay hidden.
+
+const avfState = {
+    devices: [],
+    formats: [],
+    audioDevices: [],
+    formatsForDeviceId: '',
+    supported: null  // null until first probe; true/false thereafter
+};
+
+async function probeAVFoundationSupport() {
+    if (avfState.supported !== null) return avfState.supported;
+    try {
+        await api.getAVFoundationDevices();
+        avfState.supported = true;
+    } catch (err) {
+        avfState.supported = false;
+    }
+    // Show / hide the AVFoundation cards based on platform support.
+    const sourceContainer = document.getElementById('avfoundationControlsContainer');
+    const audioContainer  = document.getElementById('avfoundationAudioDeviceContainer');
+    if (avfState.supported) {
+        if (sourceContainer) sourceContainer.style.display = '';
+        if (audioContainer)  audioContainer.style.display  = '';
+    }
+    return avfState.supported;
+}
+
+async function refreshAVFoundationDevices() {
+    if (!(await probeAVFoundationSupport())) return;
+    try {
+        const resp = await api.getAVFoundationDevices();
+        avfState.devices = resp.devices || [];
+    } catch (err) {
+        console.error('AVFoundation: getAVFoundationDevices failed:', err);
+        avfState.devices = [];
+    }
+    const sel = document.getElementById('avfoundationDevice');
+    if (!sel) return;
+    sel.innerHTML = '';
+    if (avfState.devices.length === 0) {
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'No AVFoundation devices found';
+        sel.appendChild(opt);
+        return;
+    }
+    avfState.devices.forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d.id;
+        opt.textContent = d.name || d.id;
+        sel.appendChild(opt);
+    });
+}
+
+async function refreshAVFoundationFormats() {
+    if (!(await probeAVFoundationSupport())) return;
+    const sel = document.getElementById('avfoundationDevice');
+    const deviceId = sel ? sel.value : '';
+    try {
+        const resp = await api.getAVFoundationFormats(deviceId);
+        avfState.formats = resp.formats || [];
+        avfState.formatsForDeviceId = deviceId;
+    } catch (err) {
+        console.error('AVFoundation: getAVFoundationFormats failed:', err);
+        avfState.formats = [];
+    }
+    const formatSel = document.getElementById('avfoundationFormat');
+    if (!formatSel) return;
+    formatSel.innerHTML = '';
+    if (avfState.formats.length === 0) {
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'No formats available';
+        formatSel.appendChild(opt);
+        return;
+    }
+    avfState.formats.forEach(f => {
+        const opt = document.createElement('option');
+        opt.value = f.id;
+        opt.textContent = f.displayName || `${f.width}x${f.height}`;
+        formatSel.appendChild(opt);
+    });
+}
+
+async function refreshAVFoundationAudioDevices() {
+    if (!(await probeAVFoundationSupport())) return;
+    try {
+        const resp = await api.getAVFoundationAudioDevices();
+        avfState.audioDevices = resp.devices || [];
+        const sel = document.getElementById('avfoundationAudioDevice');
+        if (!sel) return;
+        sel.innerHTML = '';
+        avfState.audioDevices.forEach(d => {
+            const opt = document.createElement('option');
+            opt.value = d.id;
+            opt.textContent = d.name || d.id;
+            if (d.id === resp.current) opt.selected = true;
+            sel.appendChild(opt);
+        });
+    } catch (err) {
+        console.error('AVFoundation: getAVFoundationAudioDevices failed:', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const deviceSel = document.getElementById('avfoundationDevice');
+    if (deviceSel) {
+        deviceSel.addEventListener('change', async () => {
+            try {
+                await api.setAVFoundationDevice(deviceSel.value);
+                await refreshAVFoundationFormats();
+                showAlert('AVFoundation device updated', 'success');
+            } catch (err) {
+                showAlert('Failed to switch AVFoundation device: ' + err.message, 'danger');
+            }
+        });
+    }
+    const formatSel = document.getElementById('avfoundationFormat');
+    if (formatSel) {
+        formatSel.addEventListener('change', async () => {
+            const dev = document.getElementById('avfoundationDevice');
+            try {
+                await api.setAVFoundationFormat(formatSel.value, dev ? dev.value : '');
+                showAlert('AVFoundation format applied', 'success');
+            } catch (err) {
+                showAlert('Failed to apply AVFoundation format: ' + err.message, 'danger');
+            }
+        });
+    }
+    const audioSel = document.getElementById('avfoundationAudioDevice');
+    if (audioSel) {
+        audioSel.addEventListener('change', async () => {
+            try {
+                await api.setAVFoundationAudioDevice(audioSel.value);
+                showAlert('AVFoundation audio device updated', 'success');
+            } catch (err) {
+                showAlert('Failed to switch AVFoundation audio device: ' + err.message, 'danger');
+            }
+        });
+    }
+    // First-load probe — populates the dropdowns and reveals the cards
+    // on macOS.
+    probeAVFoundationSupport().then(supported => {
+        if (supported) {
+            refreshAVFoundationDevices().then(refreshAVFoundationFormats);
+            refreshAVFoundationAudioDevices();
+        }
+    });
+});

--- a/tools/build-macos-bundle.sh
+++ b/tools/build-macos-bundle.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Build a `.app` bundle for macOS and a tarball for distribution.
+#
+# Equivalent of the AppImage / installer scripts for Linux / Windows:
+# produces `dist/RetroCapture-<version>-alpha-macos-x86_64.tar.gz`
+# containing `RetroCapture.app/` with binary, Info.plist (with camera /
+# microphone permission descriptions so the consent prompts actually
+# appear), shaders, web assets, ssl certs.
+#
+# Does NOT codesign or notarise — that's a follow-up. Bundle is good
+# enough to install on the maintainer's Mac and trigger the macOS
+# privacy prompts. Does NOT relocate Homebrew dylibs into the bundle
+# either; running on a different Mac requires the same Homebrew
+# prefix. That's also a follow-up.
+#
+# Usage:
+#   tools/build-macos-bundle.sh [--clean] [Release|Debug]
+
+set -euo pipefail
+
+CLEAN_BUILD=false
+BUILD_TYPE="Release"
+
+for arg in "$@"; do
+    case "$arg" in
+        --clean|-c) CLEAN_BUILD=true ;;
+        Release|Debug) BUILD_TYPE="$arg" ;;
+        --help|-h)
+            cat <<EOF
+Usage: $0 [--clean|-c] [Release|Debug]
+  --clean, -c   Wipe the build dir before building
+  Release       Optimised build (default)
+  Debug         Debug-symbol build
+
+Produces dist/RetroCapture-<version>-alpha-macos-<arch>.tar.gz with
+a runnable .app bundle inside.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "❌ Unknown argument: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "❌ build-macos-bundle.sh only runs on macOS" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -f "CMakeLists.txt" ]; then
+    echo "❌ Run this from the repo root" >&2
+    exit 1
+fi
+
+ARCH="$(uname -m)"
+VERSION=$(grep -E "^project\(RetroCapture VERSION" CMakeLists.txt | sed -E 's/.*VERSION ([0-9.]+[^ ]*).*/\1/')
+RELEASE_VERSION="${VERSION}-alpha"
+
+echo "🍎 RetroCapture macOS bundle"
+echo "   Version : $RELEASE_VERSION"
+echo "   Arch    : $ARCH"
+echo "   Type    : $BUILD_TYPE"
+echo ""
+
+# Step 1 — produce the binary via the existing build script. That
+# script handles dependency checks, the cmake configure, and the
+# parallel build. We just consume the binary it leaves at
+# build-macos-<arch>/bin/retrocapture.
+if [ "$CLEAN_BUILD" = true ]; then
+    bash "$SCRIPT_DIR/build-macos.sh" --clean "$BUILD_TYPE"
+else
+    bash "$SCRIPT_DIR/build-macos.sh" "$BUILD_TYPE"
+fi
+
+BUILD_DIR="build-macos-${ARCH}"
+BIN="$REPO_ROOT/$BUILD_DIR/bin/retrocapture"
+if [ ! -x "$BIN" ]; then
+    echo "❌ Expected binary at $BIN but it isn't there" >&2
+    exit 1
+fi
+
+# Step 2 — assemble the .app bundle in a temp staging dir.
+STAGE="$REPO_ROOT/$BUILD_DIR/bundle-stage"
+APP_NAME="RetroCapture.app"
+APP_DIR="$STAGE/$APP_NAME"
+
+rm -rf "$STAGE"
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+echo "📦 Assembling $APP_NAME ..."
+
+# 2a — binary
+cp "$BIN" "$APP_DIR/Contents/MacOS/retrocapture"
+chmod +x "$APP_DIR/Contents/MacOS/retrocapture"
+
+# 2b — Info.plist (substitute @RETROCAPTURE_VERSION@)
+sed -e "s/@RETROCAPTURE_VERSION@/$RELEASE_VERSION/g" \
+    "$SCRIPT_DIR/macos/Info.plist.in" \
+    > "$APP_DIR/Contents/Info.plist"
+
+# 2c — read-only assets that Paths::getReadOnlyAssetsDir() expects to
+# find under <exe>/../Resources/ when running from the bundle.
+for d in shaders web; do
+    if [ -d "$REPO_ROOT/$d" ]; then
+        cp -R "$REPO_ROOT/$d" "$APP_DIR/Contents/Resources/"
+    fi
+done
+if [ -d "$REPO_ROOT/assets/i18n" ]; then
+    mkdir -p "$APP_DIR/Contents/Resources/assets"
+    cp -R "$REPO_ROOT/assets/i18n" "$APP_DIR/Contents/Resources/assets/"
+fi
+# ssl/ ships templates for the optional HTTPS web portal. Include if
+# present (developer dirs only — not always populated).
+if [ -d "$REPO_ROOT/ssl" ]; then
+    cp -R "$REPO_ROOT/ssl" "$APP_DIR/Contents/Resources/"
+fi
+
+echo "   binary  : Contents/MacOS/retrocapture"
+echo "   plist   : Contents/Info.plist"
+echo "   assets  : Contents/Resources/{shaders,web,assets/i18n,ssl}"
+echo ""
+
+# Step 3 — tarball the bundle for distribution.
+mkdir -p "$REPO_ROOT/dist"
+TARBALL_NAME="RetroCapture-${RELEASE_VERSION}-macos-${ARCH}.tar.gz"
+TARBALL="$REPO_ROOT/dist/$TARBALL_NAME"
+
+echo "🗜️  Packaging $TARBALL_NAME ..."
+tar -czf "$TARBALL" -C "$STAGE" "$APP_NAME"
+SIZE=$(du -h "$TARBALL" | cut -f1)
+
+echo ""
+echo "✅ Bundle ready"
+echo "   App     : $STAGE/$APP_NAME"
+echo "   Tarball : $TARBALL ($SIZE)"
+echo ""
+echo "🚀 To run the bundle locally:"
+echo "   open \"$STAGE/$APP_NAME\""
+echo ""
+echo "📤 To distribute:"
+echo "   The tarball under dist/ contains a runnable .app — the receiver"
+echo "   extracts it and double-clicks. The first launch will trigger the"
+echo "   camera/microphone permission prompts (the NSCameraUsageDescription"
+echo "   / NSMicrophoneUsageDescription strings in Info.plist drive these)."
+echo ""
+echo "⚠️  Known limitations (follow-up issues):"
+echo "   - Not codesigned: first launch needs right-click → Open to bypass Gatekeeper."
+echo "   - Homebrew dylibs (libavcodec, glfw, libpng) are linked from /opt/homebrew"
+echo "     or /usr/local — the bundle works on any Mac with the same Homebrew setup,"
+echo "     but a proper redistributable bundle needs install_name_tool relocation."

--- a/tools/build-macos.sh
+++ b/tools/build-macos.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -e
+
+# Parse arguments
+CLEAN_BUILD=false
+BUILD_TYPE="Release"
+
+for arg in "$@"; do
+    case $arg in
+        --clean|-c)
+            CLEAN_BUILD=true
+            shift
+            ;;
+        Release|Debug)
+            BUILD_TYPE="$arg"
+            shift
+            ;;
+        *)
+            echo "❌ Argumento inválido: $arg"
+            echo ""
+            echo "Uso: $0 [--clean|-c] [Release|Debug]"
+            echo "  --clean, -c  - Limpa o diretório de build antes de compilar"
+            echo "  Release      - Build otimizado para produção (padrão)"
+            echo "  Debug        - Build com símbolos de debug"
+            exit 1
+            ;;
+    esac
+done
+
+# Validar build type
+if [ "$BUILD_TYPE" != "Release" ] && [ "$BUILD_TYPE" != "Debug" ]; then
+    echo "❌ Build type inválido: $BUILD_TYPE"
+    echo ""
+    echo "Uso: $0 [--clean|-c] [Release|Debug]"
+    echo "  --clean, -c  - Limpa o diretório de build antes de compilar"
+    echo "  Release      - Build otimizado para produção (padrão)"
+    echo "  Debug        - Build com símbolos de debug"
+    exit 1
+fi
+
+echo "🍎 RetroCapture - Build para macOS"
+echo "=================================="
+echo "📦 Build type: $BUILD_TYPE"
+if [ "$CLEAN_BUILD" = true ]; then
+    echo "🧹 Build limpa: Sim (diretório será limpo)"
+fi
+echo "🏗️  Arquitetura: $(uname -m)"
+echo "🖥️  Sistema: $(sw_vers -productName) $(sw_vers -productVersion)"
+echo ""
+
+# Verificar se estamos no macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "❌ Este script só funciona no macOS!"
+    exit 1
+fi
+
+# Verificar dependências
+echo "🔍 Verificando dependências..."
+echo ""
+
+MISSING_DEPS=()
+
+if ! command -v cmake &> /dev/null; then
+    MISSING_DEPS+=("cmake")
+fi
+
+if ! command -v brew &> /dev/null; then
+    MISSING_DEPS+=("homebrew")
+fi
+
+if [ ${#MISSING_DEPS[@]} -gt 0 ]; then
+    echo "❌ Dependências faltando:"
+    for dep in "${MISSING_DEPS[@]}"; do
+        echo "   - $dep"
+    done
+    echo ""
+    echo "   Execute primeiro: ./tools/install-deps-macos.sh"
+    exit 1
+fi
+
+# Configurar PKG_CONFIG_PATH para incluir caminhos do Homebrew
+BREW_PREFIX=$(brew --prefix 2>/dev/null || echo "/usr/local")
+if [ -d "$BREW_PREFIX/lib/pkgconfig" ]; then
+    export PKG_CONFIG_PATH="$BREW_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+fi
+
+# Verificar bibliotecas via pkg-config
+echo "   Verificando bibliotecas..."
+MISSING_LIBS=()
+
+if ! pkg-config --exists glfw3 2>/dev/null; then
+    MISSING_LIBS+=("glfw3")
+fi
+
+if ! pkg-config --exists libavcodec 2>/dev/null; then
+    MISSING_LIBS+=("libavcodec (FFmpeg)")
+fi
+
+if ! pkg-config --exists libpng 2>/dev/null; then
+    MISSING_LIBS+=("libpng")
+fi
+
+if [ ${#MISSING_LIBS[@]} -gt 0 ]; then
+    echo "❌ Bibliotecas faltando:"
+    for lib in "${MISSING_LIBS[@]}"; do
+        echo "   - $lib"
+    done
+    echo ""
+    echo "   Execute: ./tools/install-deps-macos.sh"
+    exit 1
+fi
+
+echo "✅ Todas as dependências estão instaladas"
+echo ""
+
+# Diretório de build
+BUILD_DIR="build-macos-$(uname -m)"
+echo "📁 Diretório de build: $BUILD_DIR"
+echo ""
+
+# Limpar diretório de build se solicitado
+if [ "$CLEAN_BUILD" = true ]; then
+    if [ -d "$BUILD_DIR" ]; then
+        echo "🧹 Limpando diretório de build..."
+        rm -rf "$BUILD_DIR"
+        echo "✅ Diretório limpo"
+        echo ""
+    fi
+fi
+
+# Criar diretório de build
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Configurar CMake
+echo "⚙️  Configurando CMake..."
+echo ""
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DCMAKE_OSX_ARCHITECTURES="$(uname -m)" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "❌ Falha na configuração do CMake!"
+    exit 1
+fi
+
+echo ""
+echo "🔨 Compilando RetroCapture..."
+echo "   Isso pode demorar alguns minutos..."
+echo ""
+
+# Compilar
+cmake --build . --config "$BUILD_TYPE" -j$(sysctl -n hw.ncpu)
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "❌ Falha na compilação!"
+    exit 1
+fi
+
+echo ""
+echo "✅ Build concluído com sucesso!"
+echo ""
+echo "📁 Executável: $BUILD_DIR/bin/retrocapture"
+echo ""
+echo "🚀 Para executar:"
+echo "   ./$BUILD_DIR/bin/retrocapture"
+echo ""
+echo "📝 Exemplo de uso:"
+echo "   ./$BUILD_DIR/bin/retrocapture --source avfoundation --width 1920 --height 1080"
+echo ""

--- a/tools/install-deps-macos.sh
+++ b/tools/install-deps-macos.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+echo "🍎 RetroCapture - Instalação de Dependências para macOS"
+echo "======================================================"
+echo ""
+
+# Verificar se Homebrew está instalado
+if ! command -v brew &> /dev/null; then
+    echo "❌ Homebrew não está instalado!"
+    echo ""
+    echo "   Instale o Homebrew primeiro:"
+    echo "   /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+    echo ""
+    exit 1
+fi
+
+echo "✅ Homebrew encontrado"
+echo ""
+
+# Atualizar Homebrew
+echo "📦 Atualizando Homebrew..."
+brew update
+
+echo ""
+echo "📦 Instalando dependências..."
+echo ""
+
+# Dependências principais
+echo "   - CMake (build system)"
+brew install cmake
+
+echo "   - GLFW (window management)"
+brew install glfw
+
+echo "   - FFmpeg (streaming/encoding)"
+brew install ffmpeg
+
+echo "   - libpng (image loading)"
+brew install libpng
+
+echo "   - pkg-config (dependency detection)"
+brew install pkg-config
+
+echo ""
+echo "✅ Todas as dependências foram instaladas!"
+echo ""
+echo "📝 Dependências instaladas:"
+echo "   - CMake"
+echo "   - GLFW"
+echo "   - FFmpeg (libavcodec, libavformat, libavutil, libswscale, libswresample)"
+echo "   - libpng"
+echo "   - pkg-config"
+echo ""
+echo "🎯 Próximo passo: Execute o build:"
+echo "   ./tools/build-macos.sh"
+echo ""

--- a/tools/macos/Info.plist.in
+++ b/tools/macos/Info.plist.in
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>RetroCapture</string>
+    <key>CFBundleDisplayName</key>
+    <string>RetroCapture</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.retrocapture.retrocapture</string>
+    <key>CFBundleExecutable</key>
+    <string>retrocapture</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>@RETROCAPTURE_VERSION@</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@RETROCAPTURE_VERSION@</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleSignature</key>
+    <string>RTRC</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
+
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.video</string>
+
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>RetroCapture project</string>
+
+    <!-- Permission descriptions: required for macOS to show the
+         consent prompt when AVFoundation / Core Audio first ask for
+         access. Without these the access is silently denied. -->
+    <key>NSCameraUsageDescription</key>
+    <string>RetroCapture reads frames from your camera or capture card to apply CRT-style shaders to them.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>RetroCapture records audio from your microphone or capture card so it can be streamed and monitored alongside the captured video.</string>
+
+    <!-- This is a GUI app that opens an OpenGL window. -->
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/tools/package-release.sh
+++ b/tools/package-release.sh
@@ -31,7 +31,17 @@ SKIP_X86=0
 SKIP_ARM64=0
 SKIP_ARM32=0
 SKIP_WIN=0
+SKIP_MACOS=0
 BUILD_TYPE="Release"
+
+# macOS bundle só pode ser produzido em host Darwin (build-macos-bundle.sh
+# falha cedo em outras plataformas). Em host não-Darwin pulamos por
+# padrão — não tem como cross-compile o `.app` de Linux.
+DEFAULT_SKIP_MACOS=1
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    DEFAULT_SKIP_MACOS=0
+fi
+SKIP_MACOS=$DEFAULT_SKIP_MACOS
 
 for arg in "$@"; do
     case "$arg" in
@@ -39,26 +49,36 @@ for arg in "$@"; do
         --skip-arm64) SKIP_ARM64=1 ;;
         --skip-arm32) SKIP_ARM32=1 ;;
         --skip-win|--skip-windows) SKIP_WIN=1 ;;
-        --only-x86)  SKIP_ARM64=1; SKIP_ARM32=1; SKIP_WIN=1 ;;
-        --only-arm)  SKIP_X86=1;   SKIP_WIN=1 ;;
-        --only-arm64) SKIP_X86=1;  SKIP_ARM32=1; SKIP_WIN=1 ;;
-        --only-arm32) SKIP_X86=1;  SKIP_ARM64=1; SKIP_WIN=1 ;;
-        --only-win)  SKIP_X86=1;   SKIP_ARM64=1; SKIP_ARM32=1 ;;
+        --skip-macos|--skip-mac) SKIP_MACOS=1 ;;
+        --only-x86)  SKIP_ARM64=1; SKIP_ARM32=1; SKIP_WIN=1; SKIP_MACOS=1 ;;
+        --only-arm)  SKIP_X86=1;   SKIP_WIN=1;   SKIP_MACOS=1 ;;
+        --only-arm64) SKIP_X86=1;  SKIP_ARM32=1; SKIP_WIN=1; SKIP_MACOS=1 ;;
+        --only-arm32) SKIP_X86=1;  SKIP_ARM64=1; SKIP_WIN=1; SKIP_MACOS=1 ;;
+        --only-win)  SKIP_X86=1;   SKIP_ARM64=1; SKIP_ARM32=1; SKIP_MACOS=1 ;;
+        --only-macos|--only-mac)
+            SKIP_X86=1; SKIP_ARM64=1; SKIP_ARM32=1; SKIP_WIN=1; SKIP_MACOS=0 ;;
         Release|Debug) BUILD_TYPE="$arg" ;;
         --help|-h)
             cat <<EOF
 Uso: $0 [Release|Debug] [flags]
 
-Por padrão constrói TUDO. Flags pra escolher subconjunto:
+Por padrão constrói TUDO no host Linux (AppImage + tarballs ARM +
+Windows installer). Em host macOS, também constrói o bundle .app.
+Cross-build de macOS a partir de Linux não é possível, então o bundle
+macOS é pulado por padrão fora de Darwin.
+
+Flags pra escolher subconjunto:
   --skip-x86       Pula AppImage Linux x86_64
   --skip-arm64     Pula tarball Linux ARM64
   --skip-arm32     Pula tarball Linux ARM32
   --skip-win       Pula instalador Windows
+  --skip-macos     Pula bundle macOS (default fora de Darwin)
   --only-x86       Só AppImage
   --only-arm       Só tarballs ARM (64+32)
   --only-arm64     Só tarball ARM64
   --only-arm32     Só tarball ARM32
   --only-win       Só Windows
+  --only-macos     Só macOS bundle (precisa rodar em host Darwin)
 
 Saída: \$REPO_ROOT/dist/ com SHA256SUMS no final.
 EOF
@@ -108,6 +128,14 @@ fi
 
 if [ "$SKIP_WIN" -eq 0 ]; then
     run_build "Windows x86_64 (NSIS installer)" "tools/build-windows-installer.sh" "$BUILD_TYPE"
+fi
+
+if [ "$SKIP_MACOS" -eq 0 ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        run_build "macOS bundle (.app tarball)" "tools/build-macos-bundle.sh" "$BUILD_TYPE"
+    else
+        RESULTS+=("⏭  macOS bundle (skipped — not running on Darwin)")
+    fi
 fi
 
 echo "══════════════════════════════════════════"

--- a/tools/test-macos.sh
+++ b/tools/test-macos.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+echo "🧪 RetroCapture - Teste Rápido no macOS"
+echo "======================================="
+echo ""
+
+# Detectar arquitetura
+ARCH=$(uname -m)
+BUILD_DIR="build-macos-$ARCH"
+
+# Verificar se o executável existe
+EXECUTABLE="$BUILD_DIR/bin/retrocapture"
+
+if [ ! -f "$EXECUTABLE" ]; then
+    echo "❌ Executável não encontrado: $EXECUTABLE"
+    echo ""
+    echo "   Execute primeiro o build:"
+    echo "   ./tools/build-macos.sh"
+    exit 1
+fi
+
+echo "✅ Executável encontrado: $EXECUTABLE"
+echo ""
+
+# Verificar permissões de câmera (se aplicável)
+echo "📋 Verificando permissões..."
+echo "   ⚠️  Certifique-se de que o RetroCapture tem permissão para:"
+echo "      - Acessar a câmera (System Preferences > Security & Privacy > Camera)"
+echo "      - Acessar o microfone (System Preferences > Security & Privacy > Microphone)"
+echo ""
+
+# Listar dispositivos disponíveis
+echo "📹 Dispositivos de vídeo disponíveis:"
+echo "   (Execute o RetroCapture para ver a lista completa)"
+echo ""
+
+# Teste básico: modo dummy
+echo "🧪 Teste 1: Modo Dummy (sem dispositivo físico)"
+echo "   Executando: $EXECUTABLE --source none --width 640 --height 480"
+echo ""
+
+"$EXECUTABLE" --source none --width 640 --height 480 --fps 30 &
+PID=$!
+
+sleep 3
+
+if ps -p $PID > /dev/null; then
+    echo "   ✅ RetroCapture iniciou com sucesso (PID: $PID)"
+    echo "   Pressione Ctrl+C para parar o teste"
+    echo ""
+    wait $PID
+else
+    echo "   ❌ RetroCapture falhou ao iniciar"
+    exit 1
+fi
+
+echo ""
+echo "✅ Teste concluído!"
+echo ""
+echo "📝 Para testar com dispositivo real:"
+echo "   $EXECUTABLE --source avfoundation --width 1920 --height 1080"
+echo ""


### PR DESCRIPTION
Closes #18.

Brings RetroCapture to macOS 13+ on Intel (x86_64). Both **host** and **client** modes work, audio + video pipelines mirror the Linux side architecturally, and the release flow gets a `.app` bundle counterpart to the AppImage / NSIS installer.

This branch cherry-picks the backend from the older `18-port-to-macos-13-or-later-x86_64` branch (which had been forked from `0.6.0-alpha`) onto current `0.8.0-alpha`, and **rebuilds the user-facing surface in 0.8 idioms** instead of carrying forward the pre-#45 monolithic configuration window. The decision to discard and rebuild the UI from that branch — rather than merge it — is what made this PR tractable; the old UI predated `UIConfigurationXxxx` split, the audio refactor of #78, the web portal redesign, and i18n.

## What's in here

### Host mode

- **Video capture** via `VideoCaptureAVFoundation` (UVC HDMI grabbers, FaceTime camera, virtual cameras) with the runtime camera-permission probe pattern (`AVAuthorizationStatusForMediaType:AVMediaTypeVideo`) so the dropdown stops being silently empty.
- **OBS-style format dropdown** — picking a format applies resolution + FPS range + pixel format atomically per device.
- Format changes do a **close + reopen** because `activeFormat` swaps on a running session silently revert on macOS. Output dimensions are forced via `videoSettings`'s `kCVPixelBufferWidthKey/HeightKey` because `AVCaptureSessionPresetInputPriority` is iOS-only on the macOS SDK.
- Framerate clamping via `AVFrameRateRange.minFrameDuration` (with `@try`/`@catch` belt-and-suspenders) prevents `NSInvalidArgumentException` on devices that only support rational rates like 29.97.

### Audio (host + client)

- **`AudioCaptureCoreAudio`** mirrors Linux's `AudioCapturePulse` architecture: same `AudioBus` fan-out, a local tap backing `getSamples()`, plus an in-class monitor playback (`AudioOutputCoreAudio` + writer thread). The AudioUnit gets bound to the user-selected device via `kAudioOutputUnitProperty_CurrentDevice` **before** format negotiation, then adopts the device's native sample rate / channel count so UVC cards that run at 48 kHz / mono / float32 don't fail with `-10863 kAudioUnitErr_CannotDoInCurrentContext`.
- **Microphone permission probe** at the top of `open()`, same pattern as the camera probe.
- Application loses its `m_audioOutput` member: the macOS monitor now lives inside the capture class, exactly like Linux's `MonitorPlayback` does.
- **`AudioPlaybackCoreAudio`** for client-mode `VideoCaptureRemote`: adapts `IAudioPlayback`'s float-PCM + PTS API onto `AudioOutputCoreAudio`'s int16 push.
- **`Resync monitor`** button works on macOS (atomic flag flipped on the writer thread).
- **`MediaEncoder::convertRGBToYUV`** clamps odd source heights to the nearest even value before `sws_scale` — macOS window framebuffer (1080 minus menu bar ≈ 953) is odd, and libswscale 9.x's AVX2 fastpath would `EXC_BAD_ACCESS` on the unaligned tail.

### UI

- Configurations menu shows **Audio** + **Source** on macOS (both were Linux-only guards).
- **Source tab**: `AVFoundation` source type, device dropdown, format dropdown (OBS-style).
- **Audio tab**: Core Audio input device dropdown, format line, Resync monitor button. AVFoundation audio-source picker for capture cards that bundle audio with video.
- **Web portal**: matching device + format cards in the Source tab and an AVFoundation audio device card in the Audio tab. New endpoints under `/api/v1/avfoundation/*` (devices, formats, audio-devices, device, format, audio-device).

### Lifecycle

- `Application` auto-opens the saved AVFoundation device + format on `SourceType::AVFoundation` activation. The first frame after launch is the same capture the user had in the previous session.
- `main.cpp` defaults `--source` to `avfoundation` on `__APPLE__`. `UIManager::loadConfig` coerces foreign source types (V4L2 saved on Linux, DS on Windows) back to the platform-native default.
- `Application::m_devicePath` empty default on `__APPLE__` so AVFoundation isn't asked to open the literal string `"/dev/video0"`.
- `signal(SIGPIPE, SIG_IGN)` in `main()` on `__APPLE__` (Linux uses `MSG_NOSIGNAL`; Windows doesn't generate SIGPIPE).

### Packaging

- **`tools/build-macos-bundle.sh`** produces `dist/RetroCapture-<version>-alpha-macos-<arch>.tar.gz` containing a runnable `RetroCapture.app/`.
- **`tools/macos/Info.plist.in`** template carries the bundle identity, `LSMinimumSystemVersion 13.0`, and crucially the `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` strings — these are what trigger the macOS consent prompts on first launch. Without them the OS silently denies access.
- **`Paths::getReadOnlyAssetsDir()`** probes `<exe>/../Resources` on `__APPLE__` for the canonical `Contents/Resources/{shaders,web,assets/i18n,ssl}` bundle layout. Running the raw binary from `build-macos-x86_64/bin/` during dev still works via the CWD probe.
- **`tools/package-release.sh`** gains `--skip-macos` / `--only-macos` flags. Cross-build from Linux isn't possible, so on non-Darwin hosts the macOS step is skipped by default with a friendly summary line.

### Cross-platform plumbing touched

A handful of guards that were `#ifdef PLATFORM_LINUX` (interpreted as "POSIX") had to be broadened to also fire on `PLATFORM_MACOS`. Sites: `Application.cpp` (13 sleep/usleep guards), `HTTPServer.cpp` + `HTTPTSStreamer.cpp` + `WebPortal.cpp` (POSIX socket headers + `setsockopt` paths), `HTTPServer.h` (`<sys/types.h>`). The V4L2-specific guards (`<linux/videodev2.h>`, `V4L2ControlMapper.h`) stayed strict-Linux.

`FFmpegCompat.h` got shims mapping `FF_PROFILE_*` onto `AV_PROFILE_*` because Homebrew's FFmpeg 7 dropped the legacy aliases that the codebase was using.

`AudioBus.cpp`'s CMake exclude was dropped from the macOS branch — the class is platform-agnostic and is now used by both `AudioCapturePulse` (Linux) and `AudioCaptureCoreAudio` (macOS).

## Test plan

Validated on the maintainer's Mac via the multi-iteration cycle that produced this PR's commit log. Manual reproduction list:

- [x] `tools/build-linux-x86_64-docker.sh`, `arm64v8`, `arm32v7`, `build-windows-x86_64-docker.sh` all build clean (cross-platform guards verified).
- [x] `tools/build-macos.sh Release` on a Mac produces `build-macos-x86_64/bin/retrocapture`.
- [x] `tools/build-macos-bundle.sh` produces `dist/RetroCapture-<version>-alpha-macos-x86_64.tar.gz` with a runnable `.app`.
- [x] First launch from the `.app` triggers the macOS camera prompt; granting access reveals capture devices in the Source dropdown. Same for the microphone prompt and the Core Audio device dropdown in the Audio tab.
- [x] Selecting a UVC HDMI capture card (fifine, native 48 kHz / mono / float) does NOT throw `-10863`; samples reach the bus and the monitor plays through the default output.
- [x] Switching format on a UVC card changes the delivered frame dimensions (verified via `Frame size:` logs and visually on screen).
- [x] Switching between FaceTime camera and fifine capture card back and forth no longer crashes with `NSInvalidArgumentException` (29 vs 29.97 framerate mismatch).
- [x] Host on macOS, client on Linux: client receives video + audio, host doesn't crash mid-stream (sws_scale AVX2 OOB fixed by the even-height clamp).
- [x] Client on macOS, host on Linux: audio plays through `AudioPlaybackCoreAudio`, shader from the host applies via `RemoteMetaSync` and stays applied (intermittent earlier symptom no longer repro'd after the auto-open + restore-format work).

## Known limitations (follow-ups, see `docs/MACOS_PORT_STRATEGY.md`)

1. **No codesigning / notarization** — Gatekeeper blocks the first launch from a download. Workaround: right-click → Open. Proper fix: Developer ID + `xcrun notarytool submit` in the release script.
2. **No Homebrew dylib relocation into the bundle** — `Contents/MacOS/retrocapture` still resolves `libavcodec.dylib` from `/opt/homebrew` or `/usr/local`. The `.app` runs on any Mac with the same Homebrew prefix; a properly redistributable bundle needs `install_name_tool` to rewrite paths and copy the libs into `Contents/Frameworks/`.
3. **No macOS source publisher** — Linux has `module-pipe-source RetroCapture` exposing the capture as a virtual source other apps can record from; macOS has no user-space equivalent (needs `AudioServerPlugIn` or a BlackHole-based bridge).
4. **OpenGL 4.1** — still works on macOS but is deprecated. Migration to Metal / MoltenVK is its own port.
5. **x86_64 only** — runs under Rosetta on Apple Silicon. Native arm64 build is a follow-up.
6. **No macOS in CI** — `build-macos-bundle.sh` runs locally on the maintainer's Mac. Self-hosted Mac runner or `macos-latest` Actions runner would close this.

## Scope

macOS x86_64 only this PR. All `__APPLE__`-guarded changes; Linux + Windows compile paths unchanged.