### PR TITLE
fix(build): unbreak Windows cross-build after chat #84 (refs #89)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,47 @@ else()
         endif()
     endif()
 
+    # IXWebSocket — mirror of the FetchContent branch above for CMake
+    # 3.10 (dockcross/Windows). Cache vars must be set before the
+    # add_subdirectory call so they take effect on the first configure.
+    # On Linux we'd pick OpenSSL explicitly; this branch only runs on
+    # the Windows cross-build, where ixwebsocket defaults to SChannel.
+    set(IXWS_DIR ${CMAKE_BINARY_DIR}/_deps/ixwebsocket-src)
+    if(NOT EXISTS ${IXWS_DIR}/CMakeLists.txt)
+        message(STATUS "Baixando IXWebSocket...")
+        if(EXISTS ${IXWS_DIR})
+            file(REMOVE_RECURSE ${IXWS_DIR})
+        endif()
+        file(MAKE_DIRECTORY ${IXWS_DIR})
+        execute_process(
+            COMMAND git clone --depth 1 --branch v11.4.5 https://github.com/machinezone/IXWebSocket.git ${IXWS_DIR}
+            RESULT_VARIABLE GIT_RESULT
+        )
+        if(NOT GIT_RESULT EQUAL "0")
+            message(FATAL_ERROR "Falha ao baixar IXWebSocket")
+        endif()
+    endif()
+
+    # ixwebsocket hardcodes `Crypt32` (capital C) in its Windows link
+    # block. On real MSVC the file system is case-insensitive so that
+    # works, but the MinGW cross-toolchain in MXE ships the import
+    # lib as `libcrypt32.a` and the Linux host FS *is* case-sensitive,
+    # so `-lCrypt32` fails to resolve. Rewrite to lowercase in place.
+    # `string(REPLACE)` is a no-op once the patch is already applied,
+    # so this stays idempotent on subsequent configures.
+    file(READ ${IXWS_DIR}/CMakeLists.txt _IXWS_CML)
+    string(REPLACE "PRIVATE Crypt32" "PRIVATE crypt32" _IXWS_CML "${_IXWS_CML}")
+    file(WRITE ${IXWS_DIR}/CMakeLists.txt "${_IXWS_CML}")
+    # ixwebsocket v11.4.5 doesn't auto-pick a Windows backend, it
+    # defaults to mbedtls (which MXE doesn't ship). Force OpenSSL
+    # since MXE builds it and our HTTPS support already links it.
+    set(USE_TLS         ON  CACHE BOOL "ixwebsocket: TLS support"           FORCE)
+    set(USE_WS          OFF CACHE BOOL "ixwebsocket: build the ws CLI demo" FORCE)
+    set(USE_ZLIB        OFF CACHE BOOL "ixwebsocket: permessage-deflate"    FORCE)
+    set(USE_OPEN_SSL    ON  CACHE BOOL "ixwebsocket: OpenSSL backend"       FORCE)
+    set(USE_MBED_TLS    OFF CACHE BOOL "ixwebsocket: mbedTLS backend"       FORCE)
+    add_subdirectory(${IXWS_DIR} ${CMAKE_BINARY_DIR}/_deps/ixwebsocket-build EXCLUDE_FROM_ALL)
+
     set(imgui_SOURCE_DIR ${IMGUI_DIR})
     set(json_SOURCE_DIR ${JSON_DIR})
 endif()

--- a/src/osd/OSDChat.cpp
+++ b/src/osd/OSDChat.cpp
@@ -764,7 +764,10 @@ void OSDChat::render()
     // "lives outside the m_uiVisible gate so F12 doesn't hide it".
     const ImGuiViewport *vp = ImGui::GetMainViewport();
     const float initialW = 340.0f;
-    const float initialH = std::clamp(vp->WorkSize.y * 0.45f, 240.0f, 480.0f);
+    // std::clamp is C++17; the MinGW 5.5 used by the Windows
+    // cross-build predates it, so use the std::min(std::max(...))
+    // pattern already established elsewhere in the codebase.
+    const float initialH = std::max(240.0f, std::min(480.0f, vp->WorkSize.y * 0.45f));
     const ImVec2 initialPos(vp->WorkPos.x + vp->WorkSize.x - initialW - 16.0f,
                             vp->WorkPos.y + 16.0f);
     ImGui::SetNextWindowPos(initialPos, ImGuiCond_FirstUseEver);
@@ -981,7 +984,7 @@ void OSDChat::render()
     const float bodyAvailY   = ImGui::GetContentRegionAvail().y - footerHeight;
     const bool  showParts    = m_showParticipants && !snap.participants.empty();
     const float partsW       = showParts
-                                   ? std::clamp(bodyAvailX * 0.30f, 110.0f, 180.0f)
+                                   ? std::max(110.0f, std::min(180.0f, bodyAvailX * 0.30f))
                                    : 0.0f;
     const float gap          = showParts ? ImGui::GetStyle().ItemSpacing.x : 0.0f;
     const float logW         = bodyAvailX - partsW - gap;


### PR DESCRIPTION
## Summary

- Restore the Windows x86_64 cross-build (MXE / dockcross), broken since chat (#84) landed.
- Three independent breakages — one in C++ code, two in the CMake dependency wiring — all gated by the dockcross toolchain (CMake 3.10 + MinGW GCC 5.5).
- Verified end-to-end by `./tools/build-windows-x86_64-docker.sh`: produces a 71 MB PE32+ `retrocapture.exe`.

## Root cause

The dockcross/windows-x64 image bundles:
- CMake **3.10** — predates `FetchContent_MakeAvailable` (3.11+)
- MinGW **GCC 5.5.0** — predates C++17 `<algorithm>::clamp` (GCC 7+)

The chat work was developed and tested on Linux, where both are modern, so the breakages only surface on the Windows cross-build path.

## Fix breakdown

### 1. `std::clamp` → `std::max/std::min`

`src/osd/OSDChat.cpp` had two `std::clamp(...)` call sites (#84 chat overlay sizing). GCC 5.5's libstdc++ never shipped `std::clamp` regardless of `-std=c++17`, so they fail to compile. Replaced with the `std::max(lo, std::min(hi, x))` pattern already established in `Application.cpp` (`overscanX/Y` clamping) — same comment style, same form.

### 2. ixwebsocket missing from the CMake 3.10 fallback

`CMakeLists.txt` already had a CMake-3.10 fallback branch that manually `git clone`s imgui and nlohmann/json into `_deps/`. It never fetched ixwebsocket, so `<ixwebsocket/IXWebSocket.h>` was unresolved on Windows.

Mirror the FetchContent block:
- `git clone --depth 1 --branch v11.4.5` into `_deps/ixwebsocket-src`
- `add_subdirectory(... EXCLUDE_FROM_ALL)` so the `ixwebsocket` CMake target exists for the main `target_link_libraries` line

Force `USE_OPEN_SSL=ON` (the FetchContent branch only set this on Linux, assuming Windows would pick SChannel — but ixwebsocket v11.4.5 actually defaults to **mbedtls** on Windows when no backend is requested, and MXE doesn't ship mbedtls). We already build OpenSSL via MXE for HTTPS, so reusing it keeps the dependency footprint flat.

### 3. ixwebsocket `Crypt32` case mismatch on MinGW cross

`ixwebsocket/CMakeLists.txt:251` hardcodes:
```cmake
target_link_libraries(ixwebsocket PRIVATE Crypt32)
```
On MSVC the Windows filesystem is case-insensitive so capital-C resolves fine. On the MXE cross-toolchain the import lib is named `libcrypt32.a` (lowercase), and the Linux build host's filesystem **is** case-sensitive, so `-lCrypt32` fails with `cannot find -lCrypt32` at the very last link step.

Rather than vendoring a patched ixwebsocket, the fix patches the freshly cloned `CMakeLists.txt` in place between clone and `add_subdirectory`, using pure CMake (`file(READ/WRITE)` + `string(REPLACE)`). The replace is a no-op once the substring is gone, so it stays idempotent across reconfigures.

## Test plan

- [x] `./tools/build-linux-x86_64-docker.sh` — Linux still builds (the fallback branch only runs under CMake < 3.11)
- [x] `./tools/build-windows-x86_64-docker.sh` — completes `[100%] Linking CXX executable bin/retrocapture.exe`
- [x] `file build-windows-x86_64/bin/retrocapture.exe` → `PE32+ executable for MS Windows 5.02 (console), x86-64`
- [x] Smoke-test the resulting `.exe` on a Windows host (chat WS connect, identity persistence)

## Notes / follow-ups

- The dockcross image is **deeply** out of date (CMake 3.10, GCC 5.5, both from 2017–2018). A future bump (or migration to a newer MXE base) would let the FetchContent path run on Windows too and would unlock other modern C++17/20 features. Out of scope here — this PR is the minimal surgical fix to unbreak release.

Closes #89
