### PR TITLE
fix(client): native remote connection lifecycle — disconnect, reconnect count, long-GOP connect (#92, #95, #100)

### DIFF
--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -177,25 +177,29 @@ bool VideoCaptureRemote::initDecoder()
     }
 
     AVCodecParameters *codecPar = m_formatCtx->streams[m_videoStreamIdx]->codecpar;
-    // Reject the open when probe didn't resolve video dimensions. The
-    // demuxer is allowed to surface a stream that's still being
-    // analyzed (the FFmpeg log line is 'Could not find codec
-    // parameters ... none: unspecified size'). If we proceed with
-    // width/height = 0, m_width/m_height are stuck at zero for the
-    // whole session and the consumer dead-locks at
-    //   decoded=N/s consumed=0/s drops=N queueDepth=20
-    // because nothing downstream can route 0x0 frames. Better to fail
-    // initDecoder and let the outer reconnect loop try again — by the
-    // time the next attempt fires, the upstream MPEG-TS is usually
-    // past the partial-PMT region that caused the first probe to
-    // give up.
+    // The probe sometimes can't resolve the video dimensions in its
+    // budget — FFmpeg logs 'Could not find codec parameters ... none:
+    // unspecified size'. This happens when the client joins mid-GOP
+    // and no SPS/keyframe lands inside the 2.5 s window. We USED to
+    // reject + reconnect here, but for a host with a long GOP every
+    // probe misses the keyframe and the client never connects at all
+    // ("não se conecta de jeito nenhum").
+    //
+    // Instead, proceed: the H.264 decoder derives width/height from
+    // the in-band SPS of the first decoded keyframe (which always
+    // arrives within one GOP), and decodeLoop sets m_width/m_height +
+    // the per-frame queue dims from frame->width/height once it does.
+    // So a 0x0 probe just delays the first visible frame by up to one
+    // GOP instead of blocking the connection forever. (The old
+    // dead-lock that motivated the reject is gone now that the consumer
+    // routes by per-frame dims, not the at-open m_width.)
     if (codecPar->width <= 0 || codecPar->height <= 0)
     {
         LOG_WARN("VideoCaptureRemote: probe returned " +
                  std::to_string(codecPar->width) + "x" +
                  std::to_string(codecPar->height) +
-                 " for video stream — rejecting and forcing reconnect");
-        return false;
+                 " for video stream — opening anyway; size resolves "
+                 "from the first decoded keyframe");
     }
     const AVCodec *codec = avcodec_find_decoder(codecPar->codec_id);
     if (!codec)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2547,36 +2547,36 @@ bool Application::initUI()
                 m_frameProcessor->deleteTexture();
             }
 
-            // Tear down any existing remote pipeline on a background
-            // thread so the main loop doesn't stall while
-            // VideoCaptureRemote joins its decode thread (up to ~1.5 s
-            // with the interrupt callback). We move ownership of both
-            // objects into a detached worker; the main thread
-            // continues immediately to spin up the new capture.
-            //
-            // Switching from one remote URL straight to another used
-            // to freeze the UI for the full join duration; this is
-            // what made "click another stream while connected" feel
-            // unresponsive even though the new connection itself was
-            // already fast.
-            if (m_remoteMetaSync || m_capture)
+            // Tear down any existing remote pipeline SYNCHRONOUSLY
+            // before we open the next one (#92/#95). This used to run
+            // on a detached worker so the main loop wouldn't stall on
+            // VideoCaptureRemote's decode-thread join — but that left
+            // the old /raw connection (a real "viewer" on the host)
+            // alive while the new one opened, so:
+            //   - #92: rapidly reconnecting / switching URLs stacked
+            //     several live connections; the host counted each as a
+            //     separate viewer.
+            //   - #95: on Disconnect (empty URL) nothing waited for the
+            //     teardown, so the socket / decode thread lingered and
+            //     the client stayed "connected".
+            // The teardown is actually fast: stopCapture() trips the
+            // ffmpeg interrupt callback so the blocking read returns at
+            // once, and RemoteMetaSync's poll loop sleeps in 100 ms
+            // slices that check its stop flag. Doing it inline closes
+            // the old socket (and joins both threads) before the next
+            // open — exactly one live connection at any time. The
+            // on-screen frame was already wiped above, so the brief
+            // (~100-300 ms) join isn't visible as a freeze.
+            if (m_remoteMetaSync)
             {
-                auto deadCapture = std::move(m_capture);
-                auto deadMeta    = std::move(m_remoteMetaSync);
-                std::thread([cap = std::move(deadCapture),
-                             meta = std::move(deadMeta)]() mutable {
-                    if (meta)
-                    {
-                        meta->stop();
-                        meta.reset();
-                    }
-                    if (cap)
-                    {
-                        cap->stopCapture();
-                        cap->close();
-                        cap.reset();
-                    }
-                }).detach();
+                m_remoteMetaSync->stop();
+                m_remoteMetaSync.reset();
+            }
+            if (m_capture)
+            {
+                m_capture->stopCapture();
+                m_capture->close();
+                m_capture.reset();
             }
 
             m_devicePath = devicePath;

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -29,6 +29,42 @@ extern "C"
 #include <libswresample/swresample.h>
 }
 
+// Enable aggressive TCP keep-alive on a client socket so a viewer that
+// vanishes WITHOUT a clean FIN (network drop, a remote client whose
+// TLS read errored and was reaped over the internet) is detected by
+// the kernel in ~25 s instead of the default ~2 h. The disconnect
+// monitor loop's blocking recv() then returns and the client is
+// reaped, so the viewer count converges to reality.
+//
+// Without this, half-open connections from failed/repeated connects
+// pile up in m_clientSockets / m_rawClientSockets and inflate the
+// reported viewer count (the symptom: "counter already >6 even
+// without completing a connection"). #92.
+static void enableClientKeepalive(int fd)
+{
+    if (fd < 0) return;
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_MACOS)
+    int on = 1;
+    setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
+#  if defined(PLATFORM_LINUX)
+    int idle  = 10; // begin probing after 10 s idle
+    int intvl = 5;  // probe every 5 s
+    int cnt   = 3;  // 3 missed probes → dead (~25 s total)
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,  &idle,  sizeof(idle));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,   &cnt,   sizeof(cnt));
+#  elif defined(PLATFORM_MACOS)
+    int idle = 10; // macOS: seconds before first probe
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &idle, sizeof(idle));
+#  endif
+#else
+    // Windows: SO_KEEPALIVE via the winsock fd (host build links winsock).
+    DWORD on = 1;
+    setsockopt(static_cast<SOCKET>(fd), SOL_SOCKET, SO_KEEPALIVE,
+               reinterpret_cast<const char *>(&on), sizeof(on));
+#endif
+}
+
 // Callback para escrever dados do MPEG-TS para os clientes HTTP
 // Diferentes versões do FFmpeg têm assinaturas diferentes:
 // - FFmpeg 6.1+ (libavformat 61+): const uint8_t*
@@ -1135,6 +1171,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
             }
         }
 
+        enableClientKeepalive(clientFd);
         {
             std::lock_guard<std::mutex> lock(m_rawOutputMutex);
             m_rawClientSockets.push_back(clientFd);
@@ -1194,6 +1231,7 @@ void HTTPTSStreamer::handleClient(int clientFd)
     }
 
     // Adicionar cliente à lista
+    enableClientKeepalive(clientFd);
     {
         std::lock_guard<std::mutex> lock(m_outputMutex);
         m_clientSockets.push_back(clientFd);


### PR DESCRIPTION
## Summary

Fixes the native-client remote-connection lifecycle: disconnect now actually finalizes, reconnecting no longer inflates the host's viewer count, and connecting to a long-GOP host no longer loops forever. All three were verified end-to-end on a real host+client setup.

Closes #92, #95, #100.

## The bugs

- **#95** — clicking **Disconnect** in native client mode didn't stop the connection; the decode thread + socket lingered and the client stayed "connected".
- **#92** — reconnecting / failed connects in a row stacked multiple live connections; the host counted each as a separate viewer ("counter already >6 even without completing a connection").
- **#100** — connecting to a host whose H.264 GOP is longer than the probe window failed **forever** ("não se conecta de jeito nenhum"): every mid-GOP join missed the keyframe, the probe returned 0x0, and the client rejected + reconnected in a loop.

## The fixes

**Client teardown is synchronous (`3a82491`) — #92/#95**
The connect/disconnect path used to move the old `VideoCaptureRemote` + `RemoteMetaSync` into a *detached* worker and return immediately, leaving the old `/raw` connection (a real viewer) alive while the next action proceeded. Now the old pipeline is torn down inline before the next one opens, so there's exactly one live connection at any instant and Disconnect completes before returning. It's cheap: `stopCapture()` trips the ffmpeg interrupt callback so the blocking read aborts at once, and `RemoteMetaSync`'s poll loop sleeps in 100 ms slices that watch its stop flag (~100–300 ms join). The on-screen frame is wiped first, so the brief join isn't a visible freeze.

**Host reaps dead viewers via TCP keep-alive (`d9bc873`) — #92**
The host detects disconnect with a blocking 1-byte `recv()`, which catches a clean FIN but leaves a viewer that vanishes *without* one (network drop / remote TLS read error over the internet) blocked until the default ~2 h keep-alive — so half-open connections piled up and inflated the count. Now every `/stream` and `/raw` client socket gets aggressive `SO_KEEPALIVE` (Linux `TCP_KEEPIDLE=10s`/`KEEPINTVL=5s`/`KEEPCNT=3` ≈ 25 s; `TCP_KEEPALIVE` on macOS; `SO_KEEPALIVE` on Windows). A vanished peer is reaped in ~25 s and the count converges.

**Tolerate a 0x0 video probe instead of rejecting (`49f4cf7`) — #100**
`initDecoder` rejected the open when `avformat_find_stream_info` couldn't resolve the video size in its 2.5 s / 512 KB budget. For a long-GOP host every reconnect missed the SPS → reject → reconnect → never connects. Now the H.264 decoder is opened anyway; it derives width/height from the in-band SPS of the first decoded keyframe (within one GOP), and `decodeLoop` already sets `m_width/m_height` + the per-frame queue dims from the decoded frame. A 0x0 probe just delays the first visible frame by up to one GOP instead of blocking the connection. The old dead-lock the reject guarded against is gone — the consumer routes by per-frame dims, not the at-open `m_width`.

## Test plan

- [x] Reconnect / failed-connect repeatedly → host viewer count stays correct (settles back instead of climbing).
- [x] Disconnect → host viewer drops and the client decode thread + socket are gone (no lingering "connected").
- [x] Connect to a long-GOP host → connects and video appears within ~one GOP (no infinite "Failed to connect" loop).
- [x] Linux + Windows builds clean (0 errors).

## Out of scope (separate issues surfaced during this work)

- #97 — switching source Remote→V4L2 reuses the remote capture for a local device.
- #98 — remote audio dropped when the initial AAC probe returns `0 channels` (the audio sibling of #100; same defer-don't-reject fix applies).
- #99 — host `/meta` emits invalid JSON (bare `-` number).
