### PR TITLE
fix(remote): non-blocking connect + non-freezing disconnect with live feedback

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -272,6 +272,7 @@
   "overlay.reconnecting":  "Reconnecting...",
   "overlay.disconnecting": "Disconnecting...",
   "overlay.connected":     "Connected",
+  "overlay.connect_failed": "Can't reach host — retrying",
   "overlay.host_offline":  "Host appears offline",
 
   "web.lang.label":            "Language",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -272,6 +272,7 @@
   "overlay.reconnecting":  "Reconectando...",
   "overlay.disconnecting": "Desconectando...",
   "overlay.connected":     "Conectado",
+  "overlay.connect_failed": "Não foi possível conectar — tentando de novo",
   "overlay.host_offline":  "Host parece offline",
 
   "web.lang.label":            "Idioma",

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -52,14 +52,23 @@ bool VideoCaptureRemote::open(const std::string &url)
         m_url.pop_back();
     }
 
-    LOG_INFO("VideoCaptureRemote: connecting to remote base URL " + m_url);
+    // Non-blocking connect: we do NOT run the (potentially multi-second)
+    // avformat_open_input / find_stream_info here, because open() is
+    // called synchronously on the UI thread — blocking it froze the
+    // whole app during connect, so the "Connecting…" overlay never got
+    // a frame to paint and the user got no feedback at all.
+    //
+    // Instead we just arm the URL and let decodeLoop() do the open on
+    // its own thread, reusing the exact path reconnect already uses
+    // (the `if (!m_formatCtx)` branch). The UI keeps rendering, the
+    // overlay shows progress, and a first-connect failure surfaces via
+    // isInitialConnectFailing() instead of a synchronous false return.
+    LOG_INFO("VideoCaptureRemote: arming remote base URL " + m_url +
+             " (connect runs on the decode thread)");
 
-    if (!initDecoder())
-    {
-        cleanupDecoder();
-        return false;
-    }
-
+    m_everReceivedFrame.store(false);
+    m_consecutiveReconnectFailures.store(0);
+    m_hostLikelyOffline.store(false);
     m_open.store(true);
     return true;
 }
@@ -766,7 +775,9 @@ void VideoCaptureRemote::decodeLoop()
             // hiccup starts from the 2 s slot again.
             m_consecutiveReconnectFailures.store(0);
             m_hostLikelyOffline.store(false);
-            LOG_INFO("VideoCaptureRemote: reconnected to " + m_url);
+            LOG_INFO(std::string("VideoCaptureRemote: ") +
+                     (m_everReceivedFrame.load() ? "reconnected to " : "connected to ") +
+                     m_url);
         }
 
         int rc = av_read_frame(m_formatCtx, packet);
@@ -954,6 +965,10 @@ void VideoCaptureRemote::decodeLoop()
             // overlay can tell a live stream from a stalled one
             // even when m_streamAnchored hasn't been reset yet.
             m_lastFrameAtSteadyUs.store(nowWallUs);
+            // Sticky 'we've connected for real at least once' — clears
+            // the initial-connect-failing state and marks subsequent
+            // drops as reconnects rather than first-connect failures.
+            m_everReceivedFrame.store(true);
             if (!m_streamAnchored.load())
             {
                 m_streamAnchored.store(true);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -69,6 +69,14 @@ bool VideoCaptureRemote::open(const std::string &url)
     m_everReceivedFrame.store(false);
     m_consecutiveReconnectFailures.store(0);
     m_hostLikelyOffline.store(false);
+    // Arm a clean abort state once here, NOT per-initDecoder pass. The
+    // decode thread now runs the (blocking) avformat_open_input itself
+    // on every connect; if initDecoder reset this flag right before that
+    // call, a stopCapture() from a Disconnect click could land in the
+    // gap and get wiped, leaving open_input to run to its full 5 s
+    // timeout while the UI thread froze on the join. Resetting here means
+    // a later abort always sticks. (Disconnect-freeze fix, #104.)
+    m_decodeAborted.store(false);
     m_open.store(true);
     return true;
 }
@@ -107,9 +115,11 @@ bool VideoCaptureRemote::initDecoder()
         };
     static_cast<AVFormatContext *>(m_formatCtx)->interrupt_callback.opaque = this;
 
-    // Clear any stale abort flag from a previous teardown so this
-    // initDecoder pass starts with permission to block in I/O.
-    m_decodeAborted.store(false);
+    // NOTE: m_decodeAborted is intentionally NOT reset here. It's armed
+    // once in open() (and only ever set true by stopCapture()/close()).
+    // Resetting it per pass used to race with a Disconnect landing
+    // during avformat_open_input — see open(). Within a live decodeLoop
+    // it's always false anyway, so reconnect passes start clean.
 
     // Probing budget: must see at least one packet of each expected
     // stream so audio is detected, but every byte the probe consumes

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -276,6 +276,23 @@ public:
      * Cleared as soon as any reconnect succeeds.
      */
     bool isHostLikelyOffline() const override { return m_hostLikelyOffline.load(); }
+
+    /**
+     * #77 follow-up — true while the *initial* connect (this armed URL
+     * has never produced a frame) has failed a couple of times in a
+     * row. Distinguishes a genuine can't-connect (bad URL / host down /
+     * wrong password) from a mid-session reconnect, which the overlay
+     * already labels "Reconnecting…". Lets the UI surface a clear
+     * failure within a few seconds instead of spinning "Connecting…"
+     * forever or waiting ~15 min for the offline hint.
+     *
+     * Goes false again the moment the first frame arrives (m_everReceivedFrame).
+     */
+    bool isInitialConnectFailing() const
+    {
+        return !m_everReceivedFrame.load() &&
+               m_consecutiveReconnectFailures.load() >= 2;
+    }
     // 'Are we actively decoding right now?' — combines the
     // m_streamAnchored handshake bit (true once the first frame
     // decoded, reset in cleanupDecoder() / av_read_frame failure)
@@ -304,4 +321,11 @@ private:
     // offline hint clears with it).
     std::atomic<uint32_t> m_consecutiveReconnectFailures{0};
     std::atomic<bool>     m_hostLikelyOffline{false};
+
+    // Sticky 'a frame has arrived at least once since the current URL
+    // was armed' flag. Unlike m_streamAnchored (reset on every drop),
+    // this stays true across mid-session reconnects so the UI can tell
+    // a first-time connect failure apart from a reconnect. Reset in
+    // open() when a new URL is armed.
+    std::atomic<bool>     m_everReceivedFrame{false};
 };

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -6481,12 +6481,14 @@ void Application::syncDirectoryClient()
     {
         bool offline   = false;
         bool receiving = false;
+        bool failing   = false;
         if (m_capture)
         {
             if (auto *remote = dynamic_cast<VideoCaptureRemote *>(m_capture.get()))
             {
                 offline   = remote->isHostLikelyOffline();
                 receiving = remote->isReceivingFrames();
+                failing   = remote->isInitialConnectFailing();
             }
             else
             {
@@ -6495,6 +6497,7 @@ void Application::syncDirectoryClient()
         }
         m_ui->setRemoteHostLikelyOffline(offline);
         m_ui->setRemoteReceivingFrames(receiving);
+        m_ui->setRemoteInitialConnectFailing(failing);
     }
 
     // #49 Phase 3 — keep the server-side password gate in sync with

--- a/src/osd/ConnectionStatusOverlay.cpp
+++ b/src/osd/ConnectionStatusOverlay.cpp
@@ -37,6 +37,10 @@ void ConnectionStatusOverlay::render()
     // honest liveness signal.
     const bool hasFrames  = m_uiManager->getRemoteReceivingFrames();
     const bool offline    = m_uiManager->getRemoteHostLikelyOffline();
+    // First-connect failure: this armed URL has never produced a frame
+    // and the async connect has failed a few times. Distinct from a
+    // mid-session reconnect (which keeps the calmer "Reconnecting…").
+    const bool firstConnectFailing = m_uiManager->getRemoteInitialConnectFailing();
 
     // Disconnect tail — when the user clears the device, hold the
     // "Disconnecting…" label for a short window so the detached
@@ -72,6 +76,15 @@ void ConnectionStatusOverlay::render()
     else if (offline)
     {
         label    = T("overlay.host_offline");
+        spinning = true;
+    }
+    else if (!hasFrames && firstConnectFailing)
+    {
+        // Never connected and the retries are failing — tell the user
+        // plainly rather than spinning "Connecting…" indefinitely. The
+        // URL stays armed and keeps retrying in the background.
+        label    = T("overlay.connect_failed");
+        color    = ImVec4(0.95f, 0.45f, 0.40f, 1.0f); // red-ish
         spinning = true;
     }
     else if (!hasFrames)

--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -190,6 +190,16 @@ void RemoteMetaSync::stop()
 {
     if (!m_running.load()) return;
     m_running.store(false);
+    // Break the SSE thread out of its no-timeout recv() immediately.
+    // Without this the join() below blocks until the host happens to
+    // send the next event/keepalive — which froze the UI on Disconnect.
+    // shutdownSocket() makes the in-flight recv return at once; the loop
+    // then sees m_running == false and exits. #104.
+    const std::intptr_t s = m_sseSock.load();
+    if (s != -1)
+    {
+        httpinternal::shutdownSocket(static_cast<httpinternal::socket_t>(s));
+    }
     if (m_thread.joinable())
     {
         m_thread.join();
@@ -281,6 +291,18 @@ bool RemoteMetaSync::runSSE()
         // reconnect attempt when the host is offline.
         return false;
     }
+
+    // Register the live socket so stop() (on the UI thread) can break our
+    // blocking, no-timeout recv() by shutting it down. The guard clears
+    // the registration on every exit path; declared AFTER `conn` so it
+    // destructs FIRST — m_sseSock is back to -1 before `conn` closes the
+    // fd, so stop() can never shut down a closed/reused descriptor. #104.
+    m_sseSock.store(static_cast<std::intptr_t>(conn.sock));
+    struct SseSockGuard
+    {
+        std::atomic<std::intptr_t> &ref;
+        ~SseSockGuard() { ref.store(-1); }
+    } sseSockGuard{m_sseSock};
 
     // No recv timeout — SSE is intentionally long-lived. We rely on
     // peer-side keepalive comments and OS-level RST/FIN to notice

--- a/src/streaming/RemoteMetaSync.h
+++ b/src/streaming/RemoteMetaSync.h
@@ -132,6 +132,12 @@ private:
 
     std::thread         m_thread;
     std::atomic<bool>   m_running{false};
+    // Live SSE socket fd, registered by runSSE() while it's blocked in a
+    // no-timeout recv(). stop() shuts it down to break that recv at once
+    // so the join() doesn't hang until the host's next event/keepalive
+    // (which froze the UI on Disconnect). Stored as intptr_t so the
+    // header doesn't pull in socket headers; -1 == none. #104.
+    std::atomic<std::intptr_t> m_sseSock{-1};
 
     // Dedup state — only fire the callback when the snapshot actually
     // changed. Compared against the new snapshot before dispatch.

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -589,6 +589,11 @@ public:
     // VideoCaptureRemote::isReceivingFrames() every frame.
     bool getRemoteReceivingFrames() const { return m_remoteReceivingFrames; }
     void setRemoteReceivingFrames(bool v) { m_remoteReceivingFrames = v; }
+    // First-connect-failing mirror: true while a brand-new connection
+    // (no frame ever received yet) has failed a few times. Mirrored
+    // from VideoCaptureRemote::isInitialConnectFailing() every frame.
+    bool getRemoteInitialConnectFailing() const { return m_remoteInitialConnectFailing; }
+    void setRemoteInitialConnectFailing(bool v) { m_remoteInitialConnectFailing = v; }
 
     // Host's current viewer count, parsed from /meta when we're in
     // client mode (#68). Application piggybacks the
@@ -1122,6 +1127,7 @@ private:
     uint32_t m_captureFps = 0;
     bool     m_remoteHostLikelyOffline = false;
     bool     m_remoteReceivingFrames   = false;
+    bool     m_remoteInitialConnectFailing = false;
     uint32_t m_remoteUpstreamClientCount = 0;
     // Connection-overlay frame-to-frame tracking. We detect
     // Connection-overlay transition tracking moved to

--- a/src/utils/HttpClientTls.h
+++ b/src/utils/HttpClientTls.h
@@ -58,10 +58,14 @@ namespace httpinternal
     // no ODR issue.
     static constexpr socket_t INVALID_SOCK = INVALID_SOCKET;
     inline int closeSocket(socket_t s) { return ::closesocket(s); }
+    // Half-close to wake a thread blocked in recv() on this socket from
+    // another thread (the socket stays valid; the blocked recv returns).
+    inline int shutdownSocket(socket_t s) { return ::shutdown(s, SD_BOTH); }
 #else
     using socket_t = int;
     static constexpr socket_t INVALID_SOCK = -1;
     inline int closeSocket(socket_t s) { return ::close(s); }
+    inline int shutdownSocket(socket_t s) { return ::shutdown(s, SHUT_RDWR); }
 #endif
 
     struct UrlParts


### PR DESCRIPTION
Fixes #104.

Connecting to a remote stream — and disconnecting from one — both ran **synchronously on the UI thread**, freezing the whole app with no visual feedback. This makes both ends of the lifecycle non-blocking and surfaces the state in the OSD overlay.

## 1. Non-blocking connect

`open()` ran `avformat_open_input` + `avformat_find_stream_info` (seconds on a long-GOP / mid-join stream) inline on the UI thread, inside the `OnDeviceChanged` callback. The app froze for the whole connect, so the `ConnectionStatusOverlay` never got a frame to paint "Connecting…" on the *first* attempt — it only ever worked on reconnects (which already run on the decode thread).

- `VideoCaptureRemote::open()` no longer blocks: it arms the URL and returns immediately; `decodeLoop()`'s existing `if (!m_formatCtx)` branch performs the open on the decode thread (same capped backoff). The UI keeps rendering throughout.
- New sticky `m_everReceivedFrame` + `isInitialConnectFailing()`: true while a brand-new connection (no frame ever received) has failed ≥2 times in a row — distinct from a mid-session reconnect. Mirrored to `UIManager` each frame alongside the existing receiving/offline signals.
- `ConnectionStatusOverlay` surfaces a red **"Can't reach host — retrying"** for the first-connect-failing case instead of spinning "Connecting…" forever; success still flashes green **"Connected"**. New i18n keys (en/pt).
- The startup remote path benefits too — launching with a remote source no longer freezes until the host answers.

## 2. Non-freezing disconnect

Disconnect (and source switches) froze the UI because the synchronous teardown joins two threads that could block well past the click:

- **SSE poll thread (`RemoteMetaSync`)** reads with no recv timeout. `stop()` only flipped `m_running` and joined, so the join hung inside the blocking `recv()` until the host happened to send the next event/keepalive. The live SSE socket fd is now registered in an atomic; `stop()` `shutdownSocket()`s it so the recv returns at once and the loop exits. A scope guard (declared after the `Connection`, so it runs first) clears the registration before the fd closes, so `stop()` can never shut down a closed/reused descriptor. New `httpinternal::shutdownSocket` helper (`SHUT_RDWR` / `SD_BOTH`).
- **Decode thread (`VideoCaptureRemote`)** reset `m_decodeAborted=false` at the top of every `initDecoder` pass — right before the blocking `avformat_open_input`. A Disconnect landing in that gap got its abort wiped, so open ran to its full 5 s timeout while the UI sat on the join. (The non-blocking connect above made that phase run on the decode thread for every connect, so it hit often.) The flag is now armed once in `open()` and only ever set by `stopCapture()`/`close()`, so a teardown's abort always sticks.

Teardown stays **synchronous** (no regression to #92/#95) — both joins now just return immediately, so the "Disconnecting…" overlay shows instead of a freeze.

## Testing

- Linux x86_64 + Windows x86_64 (Docker) build clean.
- Manually verified: connect (manual + directory) shows Connecting → Connected / failure feedback with no freeze; disconnect is instant, including during a slow/failing connect.
- macOS path is platform-agnostic here (decode-thread connect, socket shutdown) — not tested locally.