### PR TITLE
feat(source): screen capture (monitor/window/region) — Linux, macOS, Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,16 @@ if(PLATFORM_LINUX)
         message(WARNING "libdbus-1 not found — Linux system-tray disabled "
                         "(install libdbus-1-dev / dbus). Close button will quit.")
     endif()
+    # #107 screen capture — PipeWire + xdg-desktop-portal (ScreenCast).
+    # Needs PipeWire (the frame transport) and libdbus (the portal D-Bus
+    # handshake); when either is missing the screen source falls back to
+    # the test-pattern stub instead of failing to build.
+    pkg_check_modules(PIPEWIRE libpipewire-0.3)
+    if(PIPEWIRE_FOUND AND DBUS_FOUND)
+        message(STATUS "PipeWire + libdbus found — screen capture (PipeWire/portal) ENABLED")
+    else()
+        message(WARNING "PipeWire or libdbus missing — screen capture uses the test-pattern stub")
+    endif()
 elseif(PLATFORM_MACOS)
     # macOS: tentar pkg-config primeiro (Homebrew), depois find_package
     find_package(PkgConfig QUIET)
@@ -683,7 +693,18 @@ if(PLATFORM_LINUX AND DBUS_FOUND)
     target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_TRAY_BACKEND_LINUX)
     target_include_directories(retrocapture PRIVATE ${DBUS_INCLUDE_DIRS})
     target_link_libraries(retrocapture PRIVATE ${DBUS_LIBRARIES})
-elseif(PLATFORM_WINDOWS)
+endif()
+
+# #107 — Linux screen-capture backend (PipeWire stream + portal over
+# D-Bus). Gated on both deps; VideoCaptureScreen_linux.cpp keys off
+# RETROCAPTURE_SCREEN_PIPEWIRE and the stub stands in when it's absent.
+if(PLATFORM_LINUX AND PIPEWIRE_FOUND AND DBUS_FOUND)
+    target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_SCREEN_PIPEWIRE)
+    target_include_directories(retrocapture PRIVATE ${PIPEWIRE_INCLUDE_DIRS} ${DBUS_INCLUDE_DIRS})
+    target_link_libraries(retrocapture PRIVATE ${PIPEWIRE_LIBRARIES} ${DBUS_LIBRARIES})
+endif()
+
+if(PLATFORM_WINDOWS)
     # Shell_NotifyIcon + TrackPopupMenu — shell32/user32/gdi32 are part
     # of the standard Win32 link set (MXE links them by default, but be
     # explicit).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,15 @@ if(PLATFORM_LINUX)
     else()
         message(WARNING "PipeWire or libdbus missing — screen capture uses the test-pattern stub")
     endif()
+    # #107 — EGL enables the DMABUF zero-copy path (import the compositor's
+    # GPU buffer straight into a GL texture, no per-frame CPU/SHM copy).
+    # Optional: without it the screen backend falls back to the SHM copy.
+    pkg_check_modules(EGL egl)
+    if(EGL_FOUND AND PIPEWIRE_FOUND AND DBUS_FOUND)
+        message(STATUS "EGL found — screen capture DMABUF zero-copy ENABLED")
+    else()
+        message(WARNING "EGL missing — screen capture uses the SHM copy path (slower)")
+    endif()
 elseif(PLATFORM_MACOS)
     # macOS: tentar pkg-config primeiro (Homebrew), depois find_package
     find_package(PkgConfig QUIET)
@@ -702,6 +711,11 @@ if(PLATFORM_LINUX AND PIPEWIRE_FOUND AND DBUS_FOUND)
     target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_SCREEN_PIPEWIRE)
     target_include_directories(retrocapture PRIVATE ${PIPEWIRE_INCLUDE_DIRS} ${DBUS_INCLUDE_DIRS})
     target_link_libraries(retrocapture PRIVATE ${PIPEWIRE_LIBRARIES} ${DBUS_LIBRARIES})
+    if(EGL_FOUND)
+        target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_SCREEN_DMABUF)
+        target_include_directories(retrocapture PRIVATE ${EGL_INCLUDE_DIRS})
+        target_link_libraries(retrocapture PRIVATE ${EGL_LIBRARIES})
+    endif()
 endif()
 
 if(PLATFORM_WINDOWS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,7 @@ if(PLATFORM_LINUX)
     list(FILTER SOURCES EXCLUDE REGEX ".*SystemTrayMac\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureWASAPI\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureScreen_mac\\.(mm|h)$") # #107 macOS SCK backend
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
@@ -598,6 +599,7 @@ elseif(PLATFORM_WINDOWS)
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioBus\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*V4L2.*\\.(cpp|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureScreen_mac\\.(mm|h)$") # #107 macOS SCK backend
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
@@ -716,6 +718,25 @@ if(PLATFORM_LINUX AND PIPEWIRE_FOUND AND DBUS_FOUND)
         target_include_directories(retrocapture PRIVATE ${EGL_INCLUDE_DIRS})
         target_link_libraries(retrocapture PRIVATE ${EGL_LIBRARIES})
     endif()
+endif()
+
+# #107 — Windows screen-capture backend (DXGI Desktop Duplication).
+# VideoCaptureScreen_win.cpp keys off RETROCAPTURE_SCREEN_DXGI; d3d11/dxgi
+# headers + libs ship with MinGW-w64 / MXE.
+if(PLATFORM_WINDOWS)
+    target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_SCREEN_DXGI)
+    target_link_libraries(retrocapture PRIVATE d3d11 dxgi)
+endif()
+
+# #107 — macOS screen-capture backend (ScreenCaptureKit). The .mm is
+# excluded from non-Apple builds (below); the framework is 12.3+.
+if(PLATFORM_MACOS)
+    target_compile_definitions(retrocapture PRIVATE RETROCAPTURE_SCREEN_SCK)
+    target_link_libraries(retrocapture PRIVATE
+        "-framework ScreenCaptureKit"
+        "-framework CoreMedia"
+        "-framework CoreVideo"
+        "-framework CoreGraphics")
 endif()
 
 if(PLATFORM_WINDOWS)

--- a/Dockerfile.linux-x86_64
+++ b/Dockerfile.linux-x86_64
@@ -36,6 +36,9 @@ RUN apt-get update && apt-get install -y \
     libx11-dev \
     libdbus-1-dev \
     libpipewire-0.3-dev \
+    libegl1-mesa-dev \
+    libgbm-dev \
+    libdrm-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Script de build

--- a/Dockerfile.linux-x86_64
+++ b/Dockerfile.linux-x86_64
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
     libpulse-dev \
     libx11-dev \
     libdbus-1-dev \
+    libpipewire-0.3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Script de build

--- a/src/capture/IVideoCapture.h
+++ b/src/capture/IVideoCapture.h
@@ -14,6 +14,14 @@ struct Frame
     uint32_t format = 0; // Platform-specific pixel format
 };
 
+// Packed 32-bit pixel formats used by the screen-capture source (#107).
+// FrameProcessor uploads these straight to GL with GL_BGRA / GL_RGBA and
+// lets the driver swizzle to the RGB texture — no CPU colour conversion
+// on the hot path, which is what keeps large-monitor capture at full
+// frame rate. Sentinel values chosen to not collide with V4L2 fourccs.
+static constexpr uint32_t RC_PIXFMT_BGRA = 0xB07A0001u;
+static constexpr uint32_t RC_PIXFMT_RGBA = 0xB07A0002u;
+
 struct DeviceInfo
 {
     std::string id;        // Device identifier (path, GUID, etc.)

--- a/src/capture/IVideoCapture.h
+++ b/src/capture/IVideoCapture.h
@@ -97,6 +97,22 @@ public:
      */
     virtual bool isReceivingFrames() const { return isOpen(); }
 
+    /**
+     * Zero-copy GPU path (#107 screen capture). If the backend can hand
+     * the current frame as a ready GL texture (e.g. a DMABUF imported via
+     * EGL), it returns the texture id and sets w/h; FrameProcessor then
+     * uses it directly and skips the CPU upload. Returns 0 when there's
+     * no GPU frame this call (the caller falls back to captureLatestFrame).
+     * MUST be called on the GL thread — it may issue GL/EGL calls.
+     * The returned texture stays owned by the capture; the caller must
+     * not delete it.
+     */
+    virtual unsigned int getGpuTexture(uint32_t &width, uint32_t &height)
+    {
+        (void)width; (void)height;
+        return 0;
+    }
+
     // AVFoundation-specific extensions. Default no-op so V4L2,
     // DirectShow and Remote captures don't need to implement them.
     virtual std::vector<AVFoundationFormatInfo> listFormats(const std::string &deviceId = "")

--- a/src/capture/ScreenBackend.h
+++ b/src/capture/ScreenBackend.h
@@ -26,21 +26,44 @@ enum class ScreenPixelFormat
     RGBX  // R,G,B,unused
 };
 
+// A captured frame delivered as a DMABUF handle (zero-copy GPU buffer)
+// instead of CPU pixels. The receiver imports `fd` into a GL texture via
+// EGL and OWNS the fd (must close it). drmFourcc/modifier describe the
+// buffer layout for EGL_LINUX_DMA_BUF import.
+struct ScreenDmabufFrame
+{
+    int      fd        = -1;
+    uint32_t width     = 0;
+    uint32_t height    = 0;
+    uint32_t stride    = 0;
+    uint32_t offset    = 0;
+    uint32_t drmFourcc = 0;
+    uint64_t modifier  = 0; // DRM_FORMAT_MOD_INVALID when implicit
+    bool     hasModifier = false;
+};
+
 class IScreenFrameSink
 {
 public:
     virtual ~IScreenFrameSink() = default;
 
     /**
-     * Deliver one captured frame. `data` is `height` rows of `stride`
-     * bytes; the visible pixels are the first width*4 bytes of each row.
-     * Called on the backend's capture thread.
+     * Deliver one captured frame as CPU pixels. `data` is `height` rows
+     * of `stride` bytes; the visible pixels are the first width*4 bytes
+     * of each row. Called on the backend's capture thread.
      */
     virtual void onScreenFrame(const uint8_t *data,
                                uint32_t width,
                                uint32_t height,
                                uint32_t stride,
                                ScreenPixelFormat format) = 0;
+
+    /**
+     * Deliver one captured frame as a DMABUF (zero-copy). The sink takes
+     * ownership of frame.fd. Default ignores it (CPU path only). Called
+     * on the backend's capture thread.
+     */
+    virtual void onScreenDmabuf(const ScreenDmabufFrame &frame) { (void)frame; }
 };
 
 class ScreenBackend

--- a/src/capture/ScreenBackend.h
+++ b/src/capture/ScreenBackend.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "IVideoCapture.h" // DeviceInfo
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * Platform backend abstraction for the screen-capture source (#107).
+ *
+ * VideoCaptureScreen owns one ScreenBackend (PipeWire/portal on Linux,
+ * DXGI/WGC on Windows, ScreenCaptureKit on macOS — or a test-pattern
+ * stub until those land). The backend grabs desktop frames on its own
+ * thread and pushes each one to the sink as packed 32-bit pixels; the
+ * sink (VideoCaptureScreen) crops to the region and converts to RGB24
+ * for the rest of the pipeline.
+ */
+
+enum class ScreenPixelFormat
+{
+    BGRA, // byte order B,G,R,A (the common PipeWire / DXGI layout)
+    BGRX, // B,G,R,unused
+    RGBA, // R,G,B,A
+    RGBX  // R,G,B,unused
+};
+
+class IScreenFrameSink
+{
+public:
+    virtual ~IScreenFrameSink() = default;
+
+    /**
+     * Deliver one captured frame. `data` is `height` rows of `stride`
+     * bytes; the visible pixels are the first width*4 bytes of each row.
+     * Called on the backend's capture thread.
+     */
+    virtual void onScreenFrame(const uint8_t *data,
+                               uint32_t width,
+                               uint32_t height,
+                               uint32_t stride,
+                               ScreenPixelFormat format) = 0;
+};
+
+class ScreenBackend
+{
+public:
+    virtual ~ScreenBackend() = default;
+
+    /**
+     * Begin capturing `target` ("monitor:N" / "window:<id>" / "" for
+     * the platform default — on Wayland the portal's own picker decides
+     * regardless). Non-blocking: the heavy handshake runs on a worker
+     * thread, frames arrive via the sink once it's up. Returns false
+     * only on an immediate, unrecoverable setup failure.
+     */
+    virtual bool start(const std::string &target, bool captureCursor) = 0;
+
+    /** Stop capturing and release all OS resources. Idempotent. */
+    virtual void stop() = 0;
+
+    /**
+     * Enumerate selectable targets for the UI dropdown. On Wayland the
+     * portal drives selection through its own dialog, so this may be a
+     * single synthetic entry there.
+     */
+    virtual std::vector<DeviceInfo> listTargets() { return {}; }
+};
+
+// Per-platform factory (one definition compiled per build).
+std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink);

--- a/src/capture/VideoCaptureScreen.cpp
+++ b/src/capture/VideoCaptureScreen.cpp
@@ -1,0 +1,165 @@
+#include "VideoCaptureScreen.h"
+#include "../utils/Logger.h"
+
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+// ─────────────────────────────────────────────────────────────────────
+// Cross-platform shell for the screen-capture source (#107).
+//
+// The real per-platform grabbers (PipeWire/portal on Linux, DXGI/WGC on
+// Windows, ScreenCaptureKit on macOS) plug into Backend and push RGB24
+// frames through deliverFrame(). Until a platform backend is wired in,
+// this shell runs a moving test pattern so the whole source path —
+// selection, format negotiation, FrameProcessor, streaming/recording —
+// can be exercised end to end. Frames are RGB24 (size = w*h*3,
+// pixelFormat 0) to match what the FrameProcessor already accepts from
+// the DirectShow / Remote paths; backends convert their native BGRA.
+// ─────────────────────────────────────────────────────────────────────
+
+struct VideoCaptureScreen::Backend
+{
+    // Placeholder until the platform grabbers land. Holds the worker
+    // thread that, for now, synthesises the test pattern.
+    std::thread        thread;
+    std::atomic<bool>  running{false};
+};
+
+VideoCaptureScreen::VideoCaptureScreen()
+    : m_backend(std::make_unique<Backend>())
+{
+}
+
+VideoCaptureScreen::~VideoCaptureScreen()
+{
+    stopCapture();
+    close();
+}
+
+std::vector<DeviceInfo> VideoCaptureScreen::listDevices()
+{
+    // TODO(#107): real monitor/window enumeration per platform. On
+    // Wayland the portal drives selection via its own dialog, so this
+    // returns a single synthetic entry there; on Windows/macOS it will
+    // list each display and capturable window.
+    std::vector<DeviceInfo> out;
+    DeviceInfo d;
+    d.id        = "monitor:0";
+    d.name      = "Primary display";
+    d.driver    = "screen";
+    d.available = true;
+    out.push_back(d);
+    return out;
+}
+
+bool VideoCaptureScreen::open(const std::string &device)
+{
+    m_target = device;
+    LOG_INFO("VideoCaptureScreen: open target '" +
+             (device.empty() ? std::string("(default)") : device) + "'");
+    // The shell test pattern has no real target to validate; platform
+    // backends will fail here when the target can't be acquired.
+    m_open.store(true);
+    return true;
+}
+
+void VideoCaptureScreen::close()
+{
+    if (!m_open.exchange(false)) return;
+    LOG_INFO("VideoCaptureScreen: close");
+    m_width.store(0);
+    m_height.store(0);
+    m_receiving.store(false);
+}
+
+bool VideoCaptureScreen::setFormat(uint32_t width, uint32_t height, uint32_t)
+{
+    // The desktop dictates its own resolution; we honour the crop region
+    // instead. Seed a sane default so a consumer that queries before the
+    // first frame doesn't see 0x0.
+    if (m_width.load() == 0 && width)  m_width.store(width);
+    if (m_height.load() == 0 && height) m_height.store(height);
+    return true;
+}
+
+bool VideoCaptureScreen::setFramerate(uint32_t) { return true; }
+
+void VideoCaptureScreen::setRegion(uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+{
+    std::lock_guard<std::mutex> lock(m_regionMutex);
+    m_regionX = x; m_regionY = y; m_regionW = w; m_regionH = h;
+}
+
+bool VideoCaptureScreen::isReceivingFrames() const
+{
+    return m_open.load() && m_receiving.load();
+}
+
+bool VideoCaptureScreen::startCapture()
+{
+    if (!m_open.load())
+    {
+        LOG_ERROR("VideoCaptureScreen::startCapture — not open");
+        return false;
+    }
+    if (m_backend->running.load()) return true;
+    m_backend->running.store(true);
+
+    // Placeholder generator thread. Replaced per-platform; kept here so
+    // the integration is exercisable before the grabbers land.
+    m_backend->thread = std::thread([this]() {
+        const uint32_t w = 1280, h = 720;
+        m_width.store(w);
+        m_height.store(h);
+        m_pixelFormat = 0; // RGB24
+        uint32_t tick = 0;
+        while (m_backend->running.load())
+        {
+            // A slow diagonal gradient so it's visibly "live".
+            {
+                std::lock_guard<std::mutex> lock(m_frameMutex);
+                m_frameBuf.resize(static_cast<size_t>(w) * h * 3);
+                uint8_t *p = m_frameBuf.data();
+                for (uint32_t y = 0; y < h; ++y)
+                    for (uint32_t x = 0; x < w; ++x)
+                    {
+                        const size_t i = (static_cast<size_t>(y) * w + x) * 3;
+                        p[i + 0] = static_cast<uint8_t>((x + tick) & 0xFF);
+                        p[i + 1] = static_cast<uint8_t>((y + tick) & 0xFF);
+                        p[i + 2] = static_cast<uint8_t>((x + y) & 0xFF);
+                    }
+                m_haveFrame = true;
+            }
+            m_receiving.store(true);
+            ++tick;
+            std::this_thread::sleep_for(std::chrono::milliseconds(33)); // ~30 fps
+        }
+    });
+    return true;
+}
+
+void VideoCaptureScreen::stopCapture()
+{
+    if (!m_backend) return;
+    if (!m_backend->running.exchange(false)) return;
+    if (m_backend->thread.joinable()) m_backend->thread.join();
+    m_receiving.store(false);
+}
+
+bool VideoCaptureScreen::captureFrame(Frame &frame)
+{
+    return captureLatestFrame(frame);
+}
+
+bool VideoCaptureScreen::captureLatestFrame(Frame &frame)
+{
+    std::lock_guard<std::mutex> lock(m_frameMutex);
+    if (!m_haveFrame || m_frameBuf.empty()) return false;
+    frame.data   = m_frameBuf.data();
+    frame.size   = m_frameBuf.size();
+    frame.width  = m_width.load();
+    frame.height = m_height.load();
+    frame.format = m_pixelFormat;
+    return true;
+}

--- a/src/capture/VideoCaptureScreen.cpp
+++ b/src/capture/VideoCaptureScreen.cpp
@@ -99,7 +99,7 @@ bool VideoCaptureScreen::captureLatestFrame(Frame &frame)
     frame.size   = m_frameBuf.size();
     frame.width  = m_width.load();
     frame.height = m_height.load();
-    frame.format = m_pixelFormat; // 0 == RGB24
+    frame.format = m_pixelFormat.load();
     return true;
 }
 
@@ -121,33 +121,27 @@ void VideoCaptureScreen::onScreenFrame(const uint8_t *data, uint32_t w, uint32_t
     if (ry + rh > h) rh = h - ry;
     if (rw == 0 || rh == 0) return;
 
-    // Source byte indices for R/G/B inside each 4-byte pixel.
-    int rIdx, gIdx, bIdx;
-    switch (format)
-    {
-        case ScreenPixelFormat::BGRA:
-        case ScreenPixelFormat::BGRX: rIdx = 2; gIdx = 1; bIdx = 0; break;
-        case ScreenPixelFormat::RGBA:
-        case ScreenPixelFormat::RGBX:
-        default:                      rIdx = 0; gIdx = 1; bIdx = 2; break;
-    }
+    // Keep the packed 32-bit data as-is — no per-pixel colour conversion
+    // here (it ran on the PipeWire process callback and throttled the
+    // whole stream on large monitors). The GPU does the BGRA/RGBA→RGB
+    // swizzle on upload (FrameProcessor). We only copy out the cropped
+    // sub-rect, row by row.
+    const uint32_t outFmt = (format == ScreenPixelFormat::RGBA ||
+                             format == ScreenPixelFormat::RGBX)
+                                ? RC_PIXFMT_RGBA
+                                : RC_PIXFMT_BGRA;
 
     std::lock_guard<std::mutex> lock(m_frameMutex);
-    m_frameBuf.resize(static_cast<size_t>(rw) * rh * 3);
+    const size_t dstStride = static_cast<size_t>(rw) * 4;
+    m_frameBuf.resize(dstStride * rh);
     uint8_t *dst = m_frameBuf.data();
     for (uint32_t y = 0; y < rh; ++y)
     {
         const uint8_t *srow = data + static_cast<size_t>(ry + y) * stride +
                               static_cast<size_t>(rx) * 4;
-        uint8_t *drow = dst + static_cast<size_t>(y) * rw * 3;
-        for (uint32_t x = 0; x < rw; ++x)
-        {
-            const uint8_t *p = srow + static_cast<size_t>(x) * 4;
-            drow[x * 3 + 0] = p[rIdx];
-            drow[x * 3 + 1] = p[gIdx];
-            drow[x * 3 + 2] = p[bIdx];
-        }
+        std::memcpy(dst + static_cast<size_t>(y) * dstStride, srow, dstStride);
     }
+    m_pixelFormat.store(outFmt);
     m_width.store(rw);
     m_height.store(rh);
     m_haveFrame = true;

--- a/src/capture/VideoCaptureScreen.cpp
+++ b/src/capture/VideoCaptureScreen.cpp
@@ -1,33 +1,18 @@
 #include "VideoCaptureScreen.h"
 #include "../utils/Logger.h"
 
-#include <chrono>
 #include <cstring>
-#include <thread>
 
 // ─────────────────────────────────────────────────────────────────────
-// Cross-platform shell for the screen-capture source (#107).
-//
-// The real per-platform grabbers (PipeWire/portal on Linux, DXGI/WGC on
-// Windows, ScreenCaptureKit on macOS) plug into Backend and push RGB24
-// frames through deliverFrame(). Until a platform backend is wired in,
-// this shell runs a moving test pattern so the whole source path —
-// selection, format negotiation, FrameProcessor, streaming/recording —
-// can be exercised end to end. Frames are RGB24 (size = w*h*3,
-// pixelFormat 0) to match what the FrameProcessor already accepts from
-// the DirectShow / Remote paths; backends convert their native BGRA.
+// Cross-platform glue for the screen-capture source (#107). The actual
+// grabbing lives in the platform ScreenBackend (createScreenBackend);
+// this class drives it through the IVideoCapture contract and turns the
+// backend's packed-32-bit frames into the cropped RGB24 the rest of the
+// pipeline consumes.
 // ─────────────────────────────────────────────────────────────────────
-
-struct VideoCaptureScreen::Backend
-{
-    // Placeholder until the platform grabbers land. Holds the worker
-    // thread that, for now, synthesises the test pattern.
-    std::thread        thread;
-    std::atomic<bool>  running{false};
-};
 
 VideoCaptureScreen::VideoCaptureScreen()
-    : m_backend(std::make_unique<Backend>())
+    : m_backend(createScreenBackend(*this))
 {
 }
 
@@ -39,18 +24,7 @@ VideoCaptureScreen::~VideoCaptureScreen()
 
 std::vector<DeviceInfo> VideoCaptureScreen::listDevices()
 {
-    // TODO(#107): real monitor/window enumeration per platform. On
-    // Wayland the portal drives selection via its own dialog, so this
-    // returns a single synthetic entry there; on Windows/macOS it will
-    // list each display and capturable window.
-    std::vector<DeviceInfo> out;
-    DeviceInfo d;
-    d.id        = "monitor:0";
-    d.name      = "Primary display";
-    d.driver    = "screen";
-    d.available = true;
-    out.push_back(d);
-    return out;
+    return m_backend ? m_backend->listTargets() : std::vector<DeviceInfo>{};
 }
 
 bool VideoCaptureScreen::open(const std::string &device)
@@ -58,8 +32,6 @@ bool VideoCaptureScreen::open(const std::string &device)
     m_target = device;
     LOG_INFO("VideoCaptureScreen: open target '" +
              (device.empty() ? std::string("(default)") : device) + "'");
-    // The shell test pattern has no real target to validate; platform
-    // backends will fail here when the target can't be acquired.
     m_open.store(true);
     return true;
 }
@@ -67,18 +39,24 @@ bool VideoCaptureScreen::open(const std::string &device)
 void VideoCaptureScreen::close()
 {
     if (!m_open.exchange(false)) return;
+    stopCapture();
     LOG_INFO("VideoCaptureScreen: close");
     m_width.store(0);
     m_height.store(0);
     m_receiving.store(false);
+    {
+        std::lock_guard<std::mutex> lock(m_frameMutex);
+        m_haveFrame = false;
+        m_frameBuf.clear();
+    }
 }
 
 bool VideoCaptureScreen::setFormat(uint32_t width, uint32_t height, uint32_t)
 {
-    // The desktop dictates its own resolution; we honour the crop region
-    // instead. Seed a sane default so a consumer that queries before the
-    // first frame doesn't see 0x0.
-    if (m_width.load() == 0 && width)  m_width.store(width);
+    // The desktop dictates its own resolution; the crop region is the
+    // only sizing knob. Seed a default so a query before the first frame
+    // doesn't see 0x0.
+    if (m_width.load() == 0 && width)   m_width.store(width);
     if (m_height.load() == 0 && height) m_height.store(height);
     return true;
 }
@@ -91,11 +69,6 @@ void VideoCaptureScreen::setRegion(uint32_t x, uint32_t y, uint32_t w, uint32_t 
     m_regionX = x; m_regionY = y; m_regionW = w; m_regionH = h;
 }
 
-bool VideoCaptureScreen::isReceivingFrames() const
-{
-    return m_open.load() && m_receiving.load();
-}
-
 bool VideoCaptureScreen::startCapture()
 {
     if (!m_open.load())
@@ -103,47 +76,13 @@ bool VideoCaptureScreen::startCapture()
         LOG_ERROR("VideoCaptureScreen::startCapture — not open");
         return false;
     }
-    if (m_backend->running.load()) return true;
-    m_backend->running.store(true);
-
-    // Placeholder generator thread. Replaced per-platform; kept here so
-    // the integration is exercisable before the grabbers land.
-    m_backend->thread = std::thread([this]() {
-        const uint32_t w = 1280, h = 720;
-        m_width.store(w);
-        m_height.store(h);
-        m_pixelFormat = 0; // RGB24
-        uint32_t tick = 0;
-        while (m_backend->running.load())
-        {
-            // A slow diagonal gradient so it's visibly "live".
-            {
-                std::lock_guard<std::mutex> lock(m_frameMutex);
-                m_frameBuf.resize(static_cast<size_t>(w) * h * 3);
-                uint8_t *p = m_frameBuf.data();
-                for (uint32_t y = 0; y < h; ++y)
-                    for (uint32_t x = 0; x < w; ++x)
-                    {
-                        const size_t i = (static_cast<size_t>(y) * w + x) * 3;
-                        p[i + 0] = static_cast<uint8_t>((x + tick) & 0xFF);
-                        p[i + 1] = static_cast<uint8_t>((y + tick) & 0xFF);
-                        p[i + 2] = static_cast<uint8_t>((x + y) & 0xFF);
-                    }
-                m_haveFrame = true;
-            }
-            m_receiving.store(true);
-            ++tick;
-            std::this_thread::sleep_for(std::chrono::milliseconds(33)); // ~30 fps
-        }
-    });
-    return true;
+    if (!m_backend) return false;
+    return m_backend->start(m_target, m_captureCursor.load());
 }
 
 void VideoCaptureScreen::stopCapture()
 {
-    if (!m_backend) return;
-    if (!m_backend->running.exchange(false)) return;
-    if (m_backend->thread.joinable()) m_backend->thread.join();
+    if (m_backend) m_backend->stop();
     m_receiving.store(false);
 }
 
@@ -160,6 +99,57 @@ bool VideoCaptureScreen::captureLatestFrame(Frame &frame)
     frame.size   = m_frameBuf.size();
     frame.width  = m_width.load();
     frame.height = m_height.load();
-    frame.format = m_pixelFormat;
+    frame.format = m_pixelFormat; // 0 == RGB24
     return true;
+}
+
+void VideoCaptureScreen::onScreenFrame(const uint8_t *data, uint32_t w, uint32_t h,
+                                       uint32_t stride, ScreenPixelFormat format)
+{
+    if (!data || w == 0 || h == 0) return;
+
+    // Resolve the crop region against the live frame size.
+    uint32_t rx, ry, rw, rh;
+    {
+        std::lock_guard<std::mutex> lock(m_regionMutex);
+        rx = m_regionX; ry = m_regionY; rw = m_regionW; rh = m_regionH;
+    }
+    if (rw == 0 || rh == 0) { rx = 0; ry = 0; rw = w; rh = h; } // full target
+    if (rx >= w) rx = 0;
+    if (ry >= h) ry = 0;
+    if (rx + rw > w) rw = w - rx;
+    if (ry + rh > h) rh = h - ry;
+    if (rw == 0 || rh == 0) return;
+
+    // Source byte indices for R/G/B inside each 4-byte pixel.
+    int rIdx, gIdx, bIdx;
+    switch (format)
+    {
+        case ScreenPixelFormat::BGRA:
+        case ScreenPixelFormat::BGRX: rIdx = 2; gIdx = 1; bIdx = 0; break;
+        case ScreenPixelFormat::RGBA:
+        case ScreenPixelFormat::RGBX:
+        default:                      rIdx = 0; gIdx = 1; bIdx = 2; break;
+    }
+
+    std::lock_guard<std::mutex> lock(m_frameMutex);
+    m_frameBuf.resize(static_cast<size_t>(rw) * rh * 3);
+    uint8_t *dst = m_frameBuf.data();
+    for (uint32_t y = 0; y < rh; ++y)
+    {
+        const uint8_t *srow = data + static_cast<size_t>(ry + y) * stride +
+                              static_cast<size_t>(rx) * 4;
+        uint8_t *drow = dst + static_cast<size_t>(y) * rw * 3;
+        for (uint32_t x = 0; x < rw; ++x)
+        {
+            const uint8_t *p = srow + static_cast<size_t>(x) * 4;
+            drow[x * 3 + 0] = p[rIdx];
+            drow[x * 3 + 1] = p[gIdx];
+            drow[x * 3 + 2] = p[bIdx];
+        }
+    }
+    m_width.store(rw);
+    m_height.store(rh);
+    m_haveFrame = true;
+    m_receiving.store(true);
 }

--- a/src/capture/VideoCaptureScreen.cpp
+++ b/src/capture/VideoCaptureScreen.cpp
@@ -3,6 +3,16 @@
 
 #include <cstring>
 
+#ifdef RETROCAPTURE_SCREEN_DMABUF
+#include "../renderer/glad_loader.h"
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <unistd.h>
+#ifndef DRM_FORMAT_MOD_INVALID
+#define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL
+#endif
+#endif
+
 // ─────────────────────────────────────────────────────────────────────
 // Cross-platform glue for the screen-capture source (#107). The actual
 // grabbing lives in the platform ScreenBackend (createScreenBackend);
@@ -146,4 +156,104 @@ void VideoCaptureScreen::onScreenFrame(const uint8_t *data, uint32_t w, uint32_t
     m_height.store(rh);
     m_haveFrame = true;
     m_receiving.store(true);
+}
+
+void VideoCaptureScreen::onScreenDmabuf(const ScreenDmabufFrame &frame)
+{
+#ifdef RETROCAPTURE_SCREEN_DMABUF
+    std::lock_guard<std::mutex> lock(m_dmabufMutex);
+    if (m_pendingDmabuf.fd >= 0) ::close(m_pendingDmabuf.fd); // drop unconsumed
+    m_pendingDmabuf = frame;        // we now own frame.fd
+    m_width.store(frame.width);
+    m_height.store(frame.height);
+    m_receiving.store(true);
+#else
+    // No DMABUF build → backend never produces these; nothing to own.
+    (void)frame;
+#endif
+}
+
+unsigned int VideoCaptureScreen::getGpuTexture(uint32_t &w, uint32_t &h)
+{
+#ifdef RETROCAPTURE_SCREEN_DMABUF
+    ScreenDmabufFrame f;
+    {
+        std::lock_guard<std::mutex> lock(m_dmabufMutex);
+        if (m_pendingDmabuf.fd < 0)
+        {
+            if (m_glTex) { w = m_glW; h = m_glH; } // reuse last imported
+            return m_glTex;
+        }
+        f = m_pendingDmabuf;
+        m_pendingDmabuf.fd = -1; // consumed
+    }
+
+    static auto pCreate =
+        reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
+    static auto pDestroy =
+        reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
+    typedef void (*RC_TargetTex)(GLenum, void *);
+    static auto pTarget =
+        reinterpret_cast<RC_TargetTex>(eglGetProcAddress("glEGLImageTargetTexture2DOES"));
+
+    EGLDisplay dpy = eglGetCurrentDisplay();
+    if (!pCreate || !pTarget || dpy == EGL_NO_DISPLAY)
+    {
+        if (f.fd >= 0) ::close(f.fd);
+        static bool warned = false;
+        if (!warned) { warned = true; LOG_WARN("VideoCaptureScreen: EGL DMABUF import unavailable — falling back"); }
+        return 0;
+    }
+
+    EGLint attribs[40];
+    int n = 0;
+    attribs[n++] = EGL_WIDTH;                     attribs[n++] = static_cast<EGLint>(f.width);
+    attribs[n++] = EGL_HEIGHT;                    attribs[n++] = static_cast<EGLint>(f.height);
+    attribs[n++] = EGL_LINUX_DRM_FOURCC_EXT;      attribs[n++] = static_cast<EGLint>(f.drmFourcc);
+    attribs[n++] = EGL_DMA_BUF_PLANE0_FD_EXT;     attribs[n++] = f.fd;
+    attribs[n++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT; attribs[n++] = static_cast<EGLint>(f.offset);
+    attribs[n++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;  attribs[n++] = static_cast<EGLint>(f.stride);
+    if (f.hasModifier)
+    {
+        attribs[n++] = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+        attribs[n++] = static_cast<EGLint>(f.modifier & 0xFFFFFFFFu);
+        attribs[n++] = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+        attribs[n++] = static_cast<EGLint>(f.modifier >> 32);
+    }
+    attribs[n++] = EGL_NONE;
+
+    EGLImageKHR img = pCreate(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
+                              static_cast<EGLClientBuffer>(nullptr), attribs);
+    ::close(f.fd); // EGL holds its own reference to the buffer
+    if (img == EGL_NO_IMAGE_KHR)
+    {
+        static bool warned = false;
+        if (!warned) { warned = true; LOG_WARN("VideoCaptureScreen: eglCreateImage(DMABUF) failed — falling back"); }
+        return 0;
+    }
+
+    if (m_glTex == 0)
+    {
+        glGenTextures(1, &m_glTex);
+        glBindTexture(GL_TEXTURE_2D, m_glTex);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
+    glBindTexture(GL_TEXTURE_2D, m_glTex);
+    pTarget(GL_TEXTURE_2D, img);
+
+    // Bind first, then drop the previous image (the texture now samples
+    // the new one).
+    if (m_eglImage && pDestroy) pDestroy(dpy, static_cast<EGLImageKHR>(m_eglImage));
+    m_eglImage = img;
+
+    m_glW = f.width; m_glH = f.height;
+    w = m_glW; h = m_glH;
+    return m_glTex;
+#else
+    (void)w; (void)h;
+    return 0;
+#endif
 }

--- a/src/capture/VideoCaptureScreen.h
+++ b/src/capture/VideoCaptureScreen.h
@@ -66,7 +66,7 @@ public:
 
     uint32_t getWidth() const override { return m_width.load(); }
     uint32_t getHeight() const override { return m_height.load(); }
-    uint32_t getPixelFormat() const override { return m_pixelFormat; }
+    uint32_t getPixelFormat() const override { return m_pixelFormat.load(); }
 
     bool isReceivingFrames() const override { return m_open.load() && m_receiving.load(); }
 
@@ -94,7 +94,7 @@ private:
     // Live captured dimensions (after crop), updated as frames arrive.
     std::atomic<uint32_t> m_width{0};
     std::atomic<uint32_t> m_height{0};
-    uint32_t           m_pixelFormat = 0;   // 0 == RGB24 downstream
+    std::atomic<uint32_t> m_pixelFormat{0};  // RC_PIXFMT_* set per frame
 
     // Region crop (target pixels). Guarded — the UI thread sets it while
     // the capture thread reads it in onScreenFrame().

--- a/src/capture/VideoCaptureScreen.h
+++ b/src/capture/VideoCaptureScreen.h
@@ -73,6 +73,12 @@ public:
     // IScreenFrameSink — called by the backend on its capture thread.
     void onScreenFrame(const uint8_t *data, uint32_t width, uint32_t height,
                        uint32_t stride, ScreenPixelFormat format) override;
+    void onScreenDmabuf(const ScreenDmabufFrame &frame) override;
+
+    // Zero-copy GPU path: import the latest DMABUF into a GL texture
+    // (EGL) on the GL thread. Returns 0 when there's no DMABUF build /
+    // frame, so the caller uses the CPU path.
+    unsigned int getGpuTexture(uint32_t &width, uint32_t &height) override;
 
     /**
      * Region crop, in target pixels, applied on top of whatever target
@@ -109,4 +115,12 @@ private:
     std::mutex            m_frameMutex;
     std::vector<uint8_t>  m_frameBuf;
     bool                  m_haveFrame = false;
+
+    // DMABUF zero-copy path. The backend hands a dup'd fd (we own it);
+    // getGpuTexture() imports it into m_glTex via EGL on the GL thread.
+    std::mutex          m_dmabufMutex;
+    ScreenDmabufFrame   m_pendingDmabuf;          // fd >= 0 == new frame pending
+    unsigned int        m_glTex = 0;              // imported GL texture
+    uint32_t            m_glW = 0, m_glH = 0;
+    void               *m_eglImage = nullptr;     // EGLImageKHR of m_glTex
 };

--- a/src/capture/VideoCaptureScreen.h
+++ b/src/capture/VideoCaptureScreen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "IVideoCapture.h"
+#include "ScreenBackend.h"
 
 #include <atomic>
 #include <cstdint>
@@ -17,27 +18,21 @@
  * by V4L2 / DirectShow / AVFoundation / Remote, so shaders, streaming,
  * recording and the virtual camera all compose with it for free.
  *
- * Target model
- * ------------
- * open(device) takes an identifier string describing what to capture:
- *   - "monitor:N"      capture display index N (N from listDevices())
- *   - "window:<id>"    capture a single window (platform-native handle)
- *   - ""               platform default (primary monitor, or — on
- *                      Wayland — let the portal's own picker decide)
+ * The actual grabbing is delegated to a platform ScreenBackend
+ * (PipeWire/portal on Linux, DXGI/WGC on Windows, ScreenCaptureKit on
+ * macOS). The backend pushes packed-32-bit frames to onScreenFrame();
+ * this class crops them to the region and converts to RGB24 for the
+ * downstream FrameProcessor (same format the DirectShow / Remote paths
+ * already deliver).
+ *
+ * Target model — open(device):
+ *   - "monitor:N"   capture display index N
+ *   - "window:<id>" capture a single window
+ *   - ""            platform default (or, on Wayland, let the portal pick)
  * A region crop (x, y, w, h in target pixels) layered on top of any
- * target is set via setRegion(); (0,0,0,0) means "no crop / full target".
- *
- * Platform backends (selected at compile time, hidden behind a pimpl):
- *   - Linux:   PipeWire + xdg-desktop-portal ScreenCast (Wayland + X11)
- *   - Windows: DXGI Desktop Duplication (monitor) / WGC|GDI (window)
- *   - macOS:   ScreenCaptureKit (display / window / region)
- *
- * Frames are delivered as packed 32-bit BGRA/RGBA (see getPixelFormat);
- * the FrameProcessor converts to RGB24 like every other source. Sizes
- * are dynamic — getWidth()/getHeight() report the live captured size
- * (after crop), which can change if the user switches target.
+ * target is set via setRegion(); (0,0,0,0) means "no crop".
  */
-class VideoCaptureScreen : public IVideoCapture
+class VideoCaptureScreen : public IVideoCapture, public IScreenFrameSink
 {
 public:
     VideoCaptureScreen();
@@ -73,13 +68,16 @@ public:
     uint32_t getHeight() const override { return m_height.load(); }
     uint32_t getPixelFormat() const override { return m_pixelFormat; }
 
-    bool isReceivingFrames() const override;
+    bool isReceivingFrames() const override { return m_open.load() && m_receiving.load(); }
+
+    // IScreenFrameSink — called by the backend on its capture thread.
+    void onScreenFrame(const uint8_t *data, uint32_t width, uint32_t height,
+                       uint32_t stride, ScreenPixelFormat format) override;
 
     /**
      * Region crop, in target pixels, applied on top of whatever target
-     * open() selected. (0,0,0,0) disables cropping (capture full target).
-     * Safe to call before or after open(); takes effect on the next
-     * delivered frame.
+     * open() selected. (0,0,0,0) disables cropping. Safe to call any
+     * time; takes effect on the next delivered frame.
      */
     void setRegion(uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 
@@ -87,32 +85,27 @@ public:
     void setCaptureCursor(bool on) { m_captureCursor.store(on); }
 
 private:
-    // Platform backend, pimpl so the PipeWire / DXGI / ScreenCaptureKit
-    // headers stay out of this .h. Defined per-platform in the matching
-    // VideoCaptureScreen_*.cpp.
-    struct Backend;
-    std::unique_ptr<Backend> m_backend;
+    std::unique_ptr<ScreenBackend> m_backend;
 
     std::string        m_target;          // last opened identifier
     std::atomic<bool>  m_open{false};
     bool               m_dummyMode = false;
 
-    // Live captured dimensions (after crop), updated by the backend.
+    // Live captured dimensions (after crop), updated as frames arrive.
     std::atomic<uint32_t> m_width{0};
     std::atomic<uint32_t> m_height{0};
-    // Packed 32-bit; downstream treats this as BGRA→RGB in FrameProcessor.
-    uint32_t           m_pixelFormat = 0;
+    uint32_t           m_pixelFormat = 0;   // 0 == RGB24 downstream
 
-    // Region crop (target pixels). Guarded because the UI thread sets it
-    // while the capture thread reads it.
+    // Region crop (target pixels). Guarded — the UI thread sets it while
+    // the capture thread reads it in onScreenFrame().
     std::mutex            m_regionMutex;
     uint32_t              m_regionX = 0, m_regionY = 0, m_regionW = 0, m_regionH = 0;
 
     std::atomic<bool>  m_captureCursor{true};
     std::atomic<bool>  m_receiving{false};
 
-    // Latest decoded frame, RGB24. The backend writes under the lock;
-    // captureLatestFrame() hands a pointer to it back to the pipeline.
+    // Latest frame, RGB24. onScreenFrame() writes under the lock;
+    // captureLatestFrame() hands a pointer to it to the pipeline.
     std::mutex            m_frameMutex;
     std::vector<uint8_t>  m_frameBuf;
     bool                  m_haveFrame = false;

--- a/src/capture/VideoCaptureScreen.h
+++ b/src/capture/VideoCaptureScreen.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "IVideoCapture.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Screen-capture video source (#107).
+ *
+ * Feeds the desktop — a whole monitor, a specific window, or an
+ * arbitrary cropped region — into the same IVideoCapture contract used
+ * by V4L2 / DirectShow / AVFoundation / Remote, so shaders, streaming,
+ * recording and the virtual camera all compose with it for free.
+ *
+ * Target model
+ * ------------
+ * open(device) takes an identifier string describing what to capture:
+ *   - "monitor:N"      capture display index N (N from listDevices())
+ *   - "window:<id>"    capture a single window (platform-native handle)
+ *   - ""               platform default (primary monitor, or — on
+ *                      Wayland — let the portal's own picker decide)
+ * A region crop (x, y, w, h in target pixels) layered on top of any
+ * target is set via setRegion(); (0,0,0,0) means "no crop / full target".
+ *
+ * Platform backends (selected at compile time, hidden behind a pimpl):
+ *   - Linux:   PipeWire + xdg-desktop-portal ScreenCast (Wayland + X11)
+ *   - Windows: DXGI Desktop Duplication (monitor) / WGC|GDI (window)
+ *   - macOS:   ScreenCaptureKit (display / window / region)
+ *
+ * Frames are delivered as packed 32-bit BGRA/RGBA (see getPixelFormat);
+ * the FrameProcessor converts to RGB24 like every other source. Sizes
+ * are dynamic — getWidth()/getHeight() report the live captured size
+ * (after crop), which can change if the user switches target.
+ */
+class VideoCaptureScreen : public IVideoCapture
+{
+public:
+    VideoCaptureScreen();
+    ~VideoCaptureScreen() override;
+
+    // IVideoCapture
+    bool open(const std::string &device) override;
+    void close() override;
+    bool isOpen() const override { return m_open.load(); }
+
+    bool setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat = 0) override;
+    bool setFramerate(uint32_t fps) override;
+
+    bool captureFrame(Frame &frame) override;
+    bool captureLatestFrame(Frame &frame) override;
+
+    // No hardware knobs on a screen grab.
+    bool setControl(const std::string &, int32_t) override { return false; }
+    bool getControl(const std::string &, int32_t &) override { return false; }
+    bool getControlMin(const std::string &, int32_t &) override { return false; }
+    bool getControlMax(const std::string &, int32_t &) override { return false; }
+    bool getControlDefault(const std::string &, int32_t &) override { return false; }
+
+    std::vector<DeviceInfo> listDevices() override;
+
+    void setDummyMode(bool enabled) override { m_dummyMode = enabled; }
+    bool isDummyMode() const override { return m_dummyMode; }
+
+    bool startCapture() override;
+    void stopCapture() override;
+
+    uint32_t getWidth() const override { return m_width.load(); }
+    uint32_t getHeight() const override { return m_height.load(); }
+    uint32_t getPixelFormat() const override { return m_pixelFormat; }
+
+    bool isReceivingFrames() const override;
+
+    /**
+     * Region crop, in target pixels, applied on top of whatever target
+     * open() selected. (0,0,0,0) disables cropping (capture full target).
+     * Safe to call before or after open(); takes effect on the next
+     * delivered frame.
+     */
+    void setRegion(uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+
+    /** Whether the captured cursor should be composited into the frame. */
+    void setCaptureCursor(bool on) { m_captureCursor.store(on); }
+
+private:
+    // Platform backend, pimpl so the PipeWire / DXGI / ScreenCaptureKit
+    // headers stay out of this .h. Defined per-platform in the matching
+    // VideoCaptureScreen_*.cpp.
+    struct Backend;
+    std::unique_ptr<Backend> m_backend;
+
+    std::string        m_target;          // last opened identifier
+    std::atomic<bool>  m_open{false};
+    bool               m_dummyMode = false;
+
+    // Live captured dimensions (after crop), updated by the backend.
+    std::atomic<uint32_t> m_width{0};
+    std::atomic<uint32_t> m_height{0};
+    // Packed 32-bit; downstream treats this as BGRA→RGB in FrameProcessor.
+    uint32_t           m_pixelFormat = 0;
+
+    // Region crop (target pixels). Guarded because the UI thread sets it
+    // while the capture thread reads it.
+    std::mutex            m_regionMutex;
+    uint32_t              m_regionX = 0, m_regionY = 0, m_regionW = 0, m_regionH = 0;
+
+    std::atomic<bool>  m_captureCursor{true};
+    std::atomic<bool>  m_receiving{false};
+
+    // Latest decoded frame, RGB24. The backend writes under the lock;
+    // captureLatestFrame() hands a pointer to it back to the pipeline.
+    std::mutex            m_frameMutex;
+    std::vector<uint8_t>  m_frameBuf;
+    bool                  m_haveFrame = false;
+};

--- a/src/capture/VideoCaptureScreen_linux.cpp
+++ b/src/capture/VideoCaptureScreen_linux.cpp
@@ -505,11 +505,11 @@ private:
         struct spa_rectangle defSize = SPA_RECTANGLE(1920, 1080);
         struct spa_rectangle minSize = SPA_RECTANGLE(1, 1);
         struct spa_rectangle maxSize = SPA_RECTANGLE(8192, 8192);
-        // Preferred 60 fps; min 1 (not 0 — some portals treat 0/1 as
-        // "unspecified" and fall back to a low rate). The compositor
-        // ultimately decides, but stating a real preference helps.
+        // Preferred 60 fps. min stays 0/1 — the compositor decides the
+        // actual rate; a tighter floor was observed to break format
+        // negotiation on some portals (no frames).
         struct spa_fraction  defRate = SPA_FRACTION(60, 1);
-        struct spa_fraction  minRate = SPA_FRACTION(1, 1);
+        struct spa_fraction  minRate = SPA_FRACTION(0, 1);
         struct spa_fraction  maxRate = SPA_FRACTION(360, 1);
         const struct spa_pod *params[1];
         params[0] = static_cast<const spa_pod *>(spa_pod_builder_add_object(&b,

--- a/src/capture/VideoCaptureScreen_linux.cpp
+++ b/src/capture/VideoCaptureScreen_linux.cpp
@@ -153,6 +153,22 @@ private:
             }
         }
         pw_stream_queue_buffer(self->m_stream, b);
+
+        // Lightweight delivered-rate log (every ~2 s) to make the
+        // compositor's actual capture rate visible while tuning.
+        if (++self->m_frameCount == 1)
+            self->m_fpsClock = std::chrono::steady_clock::now();
+        const auto now = std::chrono::steady_clock::now();
+        const double secs =
+            std::chrono::duration<double>(now - self->m_fpsClock).count();
+        if (secs >= 2.0)
+        {
+            LOG_INFO("VideoCaptureScreen(pw): " +
+                     std::to_string(static_cast<int>(self->m_frameCount / secs)) +
+                     " fps delivered");
+            self->m_frameCount = 0;
+            self->m_fpsClock = now;
+        }
     }
 
     // ── worker thread: portal handshake then pipewire loop ───────────
@@ -548,6 +564,10 @@ private:
     struct pw_stream      *m_stream = nullptr;
     struct spa_hook        m_streamListener {};
     struct spa_video_info_raw m_format {};
+
+    // Delivered-fps instrumentation.
+    unsigned long          m_frameCount = 0;
+    std::chrono::steady_clock::time_point m_fpsClock {};
 };
 } // namespace
 

--- a/src/capture/VideoCaptureScreen_linux.cpp
+++ b/src/capture/VideoCaptureScreen_linux.cpp
@@ -19,13 +19,37 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <thread>
 #include <unistd.h>
 
+// DRM fourccs / modifier (defined here to avoid a hard libdrm header dep).
+#ifndef DRM_FORMAT_MOD_INVALID
+#define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL
+#endif
+
 namespace
 {
+inline uint32_t drmFourccCC(char a, char b, char c, char d)
+{
+    return static_cast<uint32_t>(a) | (static_cast<uint32_t>(b) << 8) |
+           (static_cast<uint32_t>(c) << 16) | (static_cast<uint32_t>(d) << 24);
+}
+// SPA byte-order → DRM fourcc (the standard PipeWire↔DRM mapping).
+inline uint32_t spaFormatToDrmFourcc(uint32_t spaFmt)
+{
+    switch (spaFmt)
+    {
+        case SPA_VIDEO_FORMAT_BGRA: return drmFourccCC('A', 'R', '2', '4'); // ARGB8888
+        case SPA_VIDEO_FORMAT_BGRx: return drmFourccCC('X', 'R', '2', '4'); // XRGB8888
+        case SPA_VIDEO_FORMAT_RGBA: return drmFourccCC('A', 'B', '2', '4'); // ABGR8888
+        case SPA_VIDEO_FORMAT_RGBx: return drmFourccCC('X', 'B', '2', '4'); // XBGR8888
+        default:                    return drmFourccCC('A', 'R', '2', '4');
+    }
+}
+
 constexpr const char *kPortalService = "org.freedesktop.portal.Desktop";
 constexpr const char *kPortalPath    = "/org/freedesktop/portal/desktop";
 constexpr const char *kScreenCastIf  = "org.freedesktop.portal.ScreenCast";
@@ -141,7 +165,7 @@ private:
         if (!b) return;
 
         struct spa_buffer *buf = b->buffer;
-        if (buf && buf->n_datas > 0 && buf->datas[0].data)
+        if (buf && buf->n_datas > 0)
         {
             const struct spa_data &d = buf->datas[0];
             const uint32_t w = self->m_format.size.width;
@@ -149,11 +173,31 @@ private:
             uint32_t stride = d.chunk ? static_cast<uint32_t>(d.chunk->stride) : 0;
             if (stride == 0 && w) stride = w * 4;
 
-            ScreenPixelFormat fmt;
-            if (w && h && stride && spaFormatToSink(self->m_format.format, fmt))
+            if (d.type == SPA_DATA_DmaBuf && d.fd >= 0 && w && h)
             {
-                self->m_sink.onScreenFrame(static_cast<const uint8_t *>(d.data),
-                                           w, h, stride, fmt);
+                // Zero-copy: hand the DMABUF fd to the sink (it imports it
+                // into a GL texture via EGL). dup() it — the original
+                // belongs to the buffer and is recycled on queue.
+                ScreenDmabufFrame df;
+                df.fd          = ::dup(static_cast<int>(d.fd));
+                df.width       = w;
+                df.height      = h;
+                df.stride      = stride;
+                df.offset      = d.chunk ? static_cast<uint32_t>(d.chunk->offset) : 0;
+                df.drmFourcc   = spaFormatToDrmFourcc(self->m_format.format);
+                df.hasModifier = (self->m_format.modifier != 0 &&
+                                  self->m_format.modifier != DRM_FORMAT_MOD_INVALID);
+                df.modifier    = self->m_format.modifier;
+                if (df.fd >= 0) self->m_sink.onScreenDmabuf(df);
+            }
+            else if (d.data)
+            {
+                ScreenPixelFormat fmt;
+                if (w && h && stride && spaFormatToSink(self->m_format.format, fmt))
+                {
+                    self->m_sink.onScreenFrame(static_cast<const uint8_t *>(d.data),
+                                               w, h, stride, fmt);
+                }
             }
         }
         pw_stream_queue_buffer(self->m_stream, b);
@@ -498,21 +542,52 @@ private:
         }();
         pw_stream_add_listener(m_stream, &m_streamListener, &kEvents, this);
 
-        // Offer the packed-32-bit formats we can convert, no DMABUF
-        // modifiers so the buffers come back as mappable memory.
-        uint8_t buffer[1024];
+        uint8_t buffer[2048];
         struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
         struct spa_rectangle defSize = SPA_RECTANGLE(1920, 1080);
         struct spa_rectangle minSize = SPA_RECTANGLE(1, 1);
         struct spa_rectangle maxSize = SPA_RECTANGLE(8192, 8192);
-        // Preferred 60 fps. min stays 0/1 — the compositor decides the
-        // actual rate; a tighter floor was observed to break format
-        // negotiation on some portals (no frames).
+        // Preferred 60 fps. min stays 0/1 — the compositor decides.
         struct spa_fraction  defRate = SPA_FRACTION(60, 1);
         struct spa_fraction  minRate = SPA_FRACTION(0, 1);
         struct spa_fraction  maxRate = SPA_FRACTION(360, 1);
-        const struct spa_pod *params[1];
-        params[0] = static_cast<const spa_pod *>(spa_pod_builder_add_object(&b,
+
+        const struct spa_pod *params[2];
+        int nParams = 0;
+
+#ifdef RETROCAPTURE_SCREEN_DMABUF
+        // DMABUF format (preferred): advertise the modifier property with
+        // DONT_FIXATE so the compositor picks an implicit modifier and
+        // hands us GPU buffers we import zero-copy via EGL.
+        // Opt-in for now (RC_SCREEN_DMABUF=1) while the EGL import is
+        // validated on real hardware — default stays on the safe SHM path
+        // so a failed import can't black-screen the capture.
+        if (::getenv("RC_SCREEN_DMABUF"))
+        {
+            struct spa_pod_frame fObj;
+            spa_pod_builder_push_object(&b, &fObj, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
+            spa_pod_builder_add(&b,
+                SPA_FORMAT_mediaType,    SPA_POD_Id(SPA_MEDIA_TYPE_video),
+                SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+                SPA_FORMAT_VIDEO_format, SPA_POD_CHOICE_ENUM_Id(5,
+                    SPA_VIDEO_FORMAT_BGRx, SPA_VIDEO_FORMAT_BGRx, SPA_VIDEO_FORMAT_BGRA,
+                    SPA_VIDEO_FORMAT_RGBx, SPA_VIDEO_FORMAT_RGBA),
+                SPA_FORMAT_VIDEO_size, SPA_POD_CHOICE_RANGE_Rectangle(&defSize, &minSize, &maxSize),
+                SPA_FORMAT_VIDEO_framerate, SPA_POD_CHOICE_RANGE_Fraction(&defRate, &minRate, &maxRate),
+                0);
+            spa_pod_builder_prop(&b, SPA_FORMAT_VIDEO_modifier,
+                                 SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
+            struct spa_pod_frame fChoice;
+            spa_pod_builder_push_choice(&b, &fChoice, SPA_CHOICE_Enum, 0);
+            spa_pod_builder_long(&b, static_cast<int64_t>(DRM_FORMAT_MOD_INVALID));
+            spa_pod_builder_long(&b, static_cast<int64_t>(DRM_FORMAT_MOD_INVALID));
+            spa_pod_builder_pop(&b, &fChoice);
+            params[nParams++] = static_cast<const spa_pod *>(spa_pod_builder_pop(&b, &fObj));
+        }
+#endif
+
+        // SHM format (fallback): mappable memory, CPU path.
+        params[nParams++] = static_cast<const spa_pod *>(spa_pod_builder_add_object(&b,
             SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
             SPA_FORMAT_mediaType,    SPA_POD_Id(SPA_MEDIA_TYPE_video),
             SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
@@ -525,7 +600,7 @@ private:
         pw_stream_connect(m_stream, PW_DIRECTION_INPUT, nodeId,
                           static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT |
                                                        PW_STREAM_FLAG_MAP_BUFFERS),
-                          params, 1);
+                          params, static_cast<uint32_t>(nParams));
         pw_thread_loop_unlock(m_loop);
         pw_thread_loop_start(m_loop);
 

--- a/src/capture/VideoCaptureScreen_linux.cpp
+++ b/src/capture/VideoCaptureScreen_linux.cpp
@@ -1,0 +1,560 @@
+#include "ScreenBackend.h"
+
+// Real Linux screen-capture backend: xdg-desktop-portal ScreenCast
+// (session set-up over D-Bus via libdbus) + a PipeWire stream for the
+// frames. Works on Wayland and X11. Compiled only when both deps are
+// present (see CMake / RETROCAPTURE_SCREEN_PIPEWIRE); otherwise the
+// test-pattern stub in VideoCaptureScreen_stub.cpp stands in.
+#ifdef RETROCAPTURE_SCREEN_PIPEWIRE
+
+#include "../utils/Logger.h"
+
+#include <dbus/dbus.h>
+
+#include <pipewire/pipewire.h>
+#include <spa/param/video/format-utils.h>
+#include <spa/param/video/raw.h>
+#include <spa/utils/result.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <unistd.h>
+
+namespace
+{
+constexpr const char *kPortalService = "org.freedesktop.portal.Desktop";
+constexpr const char *kPortalPath    = "/org/freedesktop/portal/desktop";
+constexpr const char *kScreenCastIf  = "org.freedesktop.portal.ScreenCast";
+constexpr const char *kRequestIf     = "org.freedesktop.portal.Request";
+
+// ── small libdbus helpers ────────────────────────────────────────────
+
+void appendVariantString(DBusMessageIter *dict, const char *key, const char *val)
+{
+    DBusMessageIter entry, var;
+    dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+    dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+    dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT, "s", &var);
+    dbus_message_iter_append_basic(&var, DBUS_TYPE_STRING, &val);
+    dbus_message_iter_close_container(&entry, &var);
+    dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendVariantUint(DBusMessageIter *dict, const char *key, dbus_uint32_t val)
+{
+    DBusMessageIter entry, var;
+    dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+    dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+    dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT, "u", &var);
+    dbus_message_iter_append_basic(&var, DBUS_TYPE_UINT32, &val);
+    dbus_message_iter_close_container(&entry, &var);
+    dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendVariantBool(DBusMessageIter *dict, const char *key, dbus_bool_t val)
+{
+    DBusMessageIter entry, var;
+    dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+    dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+    dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT, "b", &var);
+    dbus_message_iter_append_basic(&var, DBUS_TYPE_BOOLEAN, &val);
+    dbus_message_iter_close_container(&entry, &var);
+    dbus_message_iter_close_container(dict, &entry);
+}
+
+// Map a PipeWire SPA raw video format to our sink's pixel format.
+bool spaFormatToSink(uint32_t spaFmt, ScreenPixelFormat &out)
+{
+    switch (spaFmt)
+    {
+        case SPA_VIDEO_FORMAT_BGRA: out = ScreenPixelFormat::BGRA; return true;
+        case SPA_VIDEO_FORMAT_BGRx: out = ScreenPixelFormat::BGRX; return true;
+        case SPA_VIDEO_FORMAT_RGBA: out = ScreenPixelFormat::RGBA; return true;
+        case SPA_VIDEO_FORMAT_RGBx: out = ScreenPixelFormat::RGBX; return true;
+        default: return false;
+    }
+}
+
+class PipeWireScreenBackend : public ScreenBackend
+{
+public:
+    explicit PipeWireScreenBackend(IScreenFrameSink &sink) : m_sink(sink) {}
+    ~PipeWireScreenBackend() override { stop(); }
+
+    bool start(const std::string &target, bool captureCursor) override
+    {
+        if (m_running.exchange(true)) return true;
+        m_thread = std::thread(&PipeWireScreenBackend::run, this, target, captureCursor);
+        return true;
+    }
+
+    void stop() override
+    {
+        if (!m_running.exchange(false)) return;
+        // Wake the D-Bus handshake loop / let the pipewire loop exit.
+        if (m_thread.joinable()) m_thread.join();
+    }
+
+    std::vector<DeviceInfo> listTargets() override
+    {
+        // The portal's own dialog performs the real monitor/window pick;
+        // we expose a single synthetic entry to drive the UI.
+        DeviceInfo d;
+        d.id        = "portal";
+        d.name      = "Desktop (choose in system dialog)";
+        d.driver    = "pipewire-portal";
+        d.available = true;
+        return {d};
+    }
+
+private:
+    // ── PipeWire stream callbacks ────────────────────────────────────
+    static void onStreamParamChanged(void *data, uint32_t id, const struct spa_pod *param)
+    {
+        auto *self = static_cast<PipeWireScreenBackend *>(data);
+        if (!param || id != SPA_PARAM_Format) return;
+
+        uint32_t mediaType = 0, mediaSubtype = 0;
+        if (spa_format_parse(param, &mediaType, &mediaSubtype) < 0) return;
+        if (mediaType != SPA_MEDIA_TYPE_video || mediaSubtype != SPA_MEDIA_SUBTYPE_raw) return;
+
+        spa_zero(self->m_format);
+        if (spa_format_video_raw_parse(param, &self->m_format) < 0) return;
+
+        LOG_INFO("VideoCaptureScreen(pw): negotiated " +
+                 std::to_string(self->m_format.size.width) + "x" +
+                 std::to_string(self->m_format.size.height));
+    }
+
+    static void onStreamProcess(void *data)
+    {
+        auto *self = static_cast<PipeWireScreenBackend *>(data);
+        struct pw_buffer *b = pw_stream_dequeue_buffer(self->m_stream);
+        if (!b) return;
+
+        struct spa_buffer *buf = b->buffer;
+        if (buf && buf->n_datas > 0 && buf->datas[0].data)
+        {
+            const struct spa_data &d = buf->datas[0];
+            const uint32_t w = self->m_format.size.width;
+            const uint32_t h = self->m_format.size.height;
+            uint32_t stride = d.chunk ? static_cast<uint32_t>(d.chunk->stride) : 0;
+            if (stride == 0 && w) stride = w * 4;
+
+            ScreenPixelFormat fmt;
+            if (w && h && stride && spaFormatToSink(self->m_format.format, fmt))
+            {
+                self->m_sink.onScreenFrame(static_cast<const uint8_t *>(d.data),
+                                           w, h, stride, fmt);
+            }
+        }
+        pw_stream_queue_buffer(self->m_stream, b);
+    }
+
+    // ── worker thread: portal handshake then pipewire loop ───────────
+    void run(std::string /*target*/, bool captureCursor)
+    {
+        DBusError err;
+        dbus_error_init(&err);
+        // Private connection: we pump it from this worker thread, and a
+        // shared one would race the tray's session-bus connection.
+        m_dbus = dbus_bus_get_private(DBUS_BUS_SESSION, &err);
+        if (!m_dbus)
+        {
+            LOG_ERROR(std::string("VideoCaptureScreen(portal): no session bus — ") +
+                      (dbus_error_is_set(&err) ? err.message : "?"));
+            dbus_error_free(&err);
+            m_running.store(false);
+            return;
+        }
+        dbus_connection_set_exit_on_disconnect(m_dbus, FALSE);
+        dbus_bus_add_match(m_dbus,
+            "type='signal',interface='org.freedesktop.portal.Request',member='Response'",
+            &err);
+        dbus_connection_flush(m_dbus);
+
+        const std::string sender = uniqueSenderToken();
+        std::string sessionHandle;
+        uint32_t nodeId = 0;
+
+        if (!createSession(sender, sessionHandle) ||
+            !selectSources(sessionHandle, sender, captureCursor) ||
+            !startPortal(sessionHandle, sender, nodeId))
+        {
+            LOG_WARN("VideoCaptureScreen(portal): handshake did not complete "
+                     "(cancelled or unsupported)");
+            cleanupDbus();
+            m_running.store(false);
+            return;
+        }
+
+        const int pwFd = openPipeWireRemote(sessionHandle);
+        if (pwFd < 0)
+        {
+            LOG_ERROR("VideoCaptureScreen(portal): OpenPipeWireRemote failed");
+            cleanupDbus();
+            m_running.store(false);
+            return;
+        }
+
+        runPipeWire(pwFd, nodeId);
+        cleanupDbus();
+        m_running.store(false);
+    }
+
+    // Predictable-ish unique token for handle_token / matching.
+    std::string uniqueSenderToken()
+    {
+        return "rc" + std::to_string(static_cast<long>(::getpid())) + "_" +
+               std::to_string(m_tokenSeq++);
+    }
+
+    // Send a ScreenCast method that returns a Request handle, then block
+    // (respecting m_running) until its Response signal arrives. Returns
+    // the Response (u, a{sv}) message — caller parses results — or null.
+    DBusMessage *callAndWait(DBusMessage *call)
+    {
+        DBusError err;
+        dbus_error_init(&err);
+        DBusMessage *reply =
+            dbus_connection_send_with_reply_and_block(m_dbus, call, 5000, &err);
+        dbus_message_unref(call);
+        if (!reply)
+        {
+            if (dbus_error_is_set(&err))
+            {
+                LOG_WARN(std::string("VideoCaptureScreen(portal): call failed — ") + err.message);
+                dbus_error_free(&err);
+            }
+            return nullptr;
+        }
+        // Reply carries the Request object path (o).
+        const char *requestPath = nullptr;
+        if (!dbus_message_get_args(reply, &err, DBUS_TYPE_OBJECT_PATH, &requestPath,
+                                   DBUS_TYPE_INVALID) || !requestPath)
+        {
+            dbus_message_unref(reply);
+            if (dbus_error_is_set(&err)) dbus_error_free(&err);
+            return nullptr;
+        }
+        std::string path = requestPath;
+        dbus_message_unref(reply);
+
+        // Pump the bus until the Response signal for `path` lands. The
+        // Start request blocks on the user's portal dialog, so this can
+        // take a while; bail promptly if stop() flips m_running.
+        while (m_running.load())
+        {
+            if (!dbus_connection_read_write_dispatch(m_dbus, 200))
+                return nullptr; // disconnected
+            DBusMessage *msg = dbus_connection_pop_message(m_dbus);
+            while (msg)
+            {
+                if (dbus_message_is_signal(msg, kRequestIf, "Response") &&
+                    path == dbus_message_get_path(msg))
+                {
+                    return msg; // caller owns it
+                }
+                dbus_message_unref(msg);
+                msg = dbus_connection_pop_message(m_dbus);
+            }
+        }
+        return nullptr;
+    }
+
+    // results a{sv} → find a string value by key.
+    static bool resultString(DBusMessageIter *results, const char *key, std::string &out)
+    {
+        DBusMessageIter arr = *results;
+        while (dbus_message_iter_get_arg_type(&arr) == DBUS_TYPE_DICT_ENTRY)
+        {
+            DBusMessageIter entry;
+            dbus_message_iter_recurse(&arr, &entry);
+            const char *k = nullptr;
+            dbus_message_iter_get_basic(&entry, &k);
+            dbus_message_iter_next(&entry);
+            if (k && std::strcmp(k, key) == 0 &&
+                dbus_message_iter_get_arg_type(&entry) == DBUS_TYPE_VARIANT)
+            {
+                DBusMessageIter var;
+                dbus_message_iter_recurse(&entry, &var);
+                if (dbus_message_iter_get_arg_type(&var) == DBUS_TYPE_STRING)
+                {
+                    const char *v = nullptr;
+                    dbus_message_iter_get_basic(&var, &v);
+                    if (v) { out = v; return true; }
+                }
+            }
+            dbus_message_iter_next(&arr);
+        }
+        return false;
+    }
+
+    // Position the iterator on the Response results dict (after the
+    // leading 'u' response code). Returns response code, or -1.
+    static int responseResults(DBusMessage *msg, DBusMessageIter *resultsOut)
+    {
+        DBusMessageIter it;
+        if (!dbus_message_iter_init(msg, &it)) return -1;
+        if (dbus_message_iter_get_arg_type(&it) != DBUS_TYPE_UINT32) return -1;
+        dbus_uint32_t code = 0;
+        dbus_message_iter_get_basic(&it, &code);
+        dbus_message_iter_next(&it);
+        if (dbus_message_iter_get_arg_type(&it) != DBUS_TYPE_ARRAY) return static_cast<int>(code);
+        dbus_message_iter_recurse(&it, resultsOut);
+        return static_cast<int>(code);
+    }
+
+    bool createSession(const std::string &sender, std::string &sessionHandle)
+    {
+        DBusMessage *call = dbus_message_new_method_call(
+            kPortalService, kPortalPath, kScreenCastIf, "CreateSession");
+        DBusMessageIter args, dict;
+        dbus_message_iter_init_append(call, &args);
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &dict);
+        const std::string ht = "ct" + sender;
+        const std::string st = "se" + sender;
+        appendVariantString(&dict, "handle_token", ht.c_str());
+        appendVariantString(&dict, "session_handle_token", st.c_str());
+        dbus_message_iter_close_container(&args, &dict);
+
+        DBusMessage *resp = callAndWait(call);
+        if (!resp) return false;
+        DBusMessageIter results;
+        const int code = responseResults(resp, &results);
+        bool ok = (code == 0) && resultString(&results, "session_handle", sessionHandle);
+        dbus_message_unref(resp);
+        return ok;
+    }
+
+    bool selectSources(const std::string &session, const std::string &sender, bool cursor)
+    {
+        DBusMessage *call = dbus_message_new_method_call(
+            kPortalService, kPortalPath, kScreenCastIf, "SelectSources");
+        DBusMessageIter args, dict;
+        dbus_message_iter_init_append(call, &args);
+        const char *sh = session.c_str();
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_OBJECT_PATH, &sh);
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &dict);
+        const std::string ht = "ss" + sender;
+        appendVariantString(&dict, "handle_token", ht.c_str());
+        appendVariantUint(&dict, "types", 1u | 2u);    // monitor | window
+        appendVariantBool(&dict, "multiple", FALSE);
+        appendVariantUint(&dict, "cursor_mode", cursor ? 2u : 1u); // embedded | hidden
+        dbus_message_iter_close_container(&args, &dict);
+
+        DBusMessage *resp = callAndWait(call);
+        if (!resp) return false;
+        DBusMessageIter results;
+        const int code = responseResults(resp, &results);
+        dbus_message_unref(resp);
+        return code == 0;
+    }
+
+    bool startPortal(const std::string &session, const std::string &sender, uint32_t &nodeId)
+    {
+        DBusMessage *call = dbus_message_new_method_call(
+            kPortalService, kPortalPath, kScreenCastIf, "Start");
+        DBusMessageIter args, dict;
+        dbus_message_iter_init_append(call, &args);
+        const char *sh = session.c_str();
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_OBJECT_PATH, &sh);
+        const char *parent = "";
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &parent);
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &dict);
+        const std::string ht = "st" + sender;
+        appendVariantString(&dict, "handle_token", ht.c_str());
+        dbus_message_iter_close_container(&args, &dict);
+
+        DBusMessage *resp = callAndWait(call); // blocks on the user's dialog
+        if (!resp) return false;
+        DBusMessageIter results;
+        const int code = responseResults(resp, &results);
+        bool ok = false;
+        if (code == 0)
+        {
+            // results["streams"] = a(ua{sv}); take the first node id.
+            DBusMessageIter arr = results;
+            while (dbus_message_iter_get_arg_type(&arr) == DBUS_TYPE_DICT_ENTRY)
+            {
+                DBusMessageIter entry;
+                dbus_message_iter_recurse(&arr, &entry);
+                const char *k = nullptr;
+                dbus_message_iter_get_basic(&entry, &k);
+                dbus_message_iter_next(&entry);
+                if (k && std::strcmp(k, "streams") == 0 &&
+                    dbus_message_iter_get_arg_type(&entry) == DBUS_TYPE_VARIANT)
+                {
+                    DBusMessageIter var, streams, stream;
+                    dbus_message_iter_recurse(&entry, &var);     // a(ua{sv})
+                    if (dbus_message_iter_get_arg_type(&var) == DBUS_TYPE_ARRAY)
+                    {
+                        dbus_message_iter_recurse(&var, &streams);
+                        if (dbus_message_iter_get_arg_type(&streams) == DBUS_TYPE_STRUCT)
+                        {
+                            dbus_message_iter_recurse(&streams, &stream);
+                            if (dbus_message_iter_get_arg_type(&stream) == DBUS_TYPE_UINT32)
+                            {
+                                dbus_uint32_t id = 0;
+                                dbus_message_iter_get_basic(&stream, &id);
+                                nodeId = id;
+                                ok = true;
+                            }
+                        }
+                    }
+                    break;
+                }
+                dbus_message_iter_next(&arr);
+            }
+        }
+        dbus_message_unref(resp);
+        return ok;
+    }
+
+    int openPipeWireRemote(const std::string &session)
+    {
+        DBusMessage *call = dbus_message_new_method_call(
+            kPortalService, kPortalPath, kScreenCastIf, "OpenPipeWireRemote");
+        DBusMessageIter args, dict;
+        dbus_message_iter_init_append(call, &args);
+        const char *sh = session.c_str();
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_OBJECT_PATH, &sh);
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &dict);
+        dbus_message_iter_close_container(&args, &dict);
+
+        DBusError err;
+        dbus_error_init(&err);
+        DBusMessage *reply =
+            dbus_connection_send_with_reply_and_block(m_dbus, call, 5000, &err);
+        dbus_message_unref(call);
+        if (!reply)
+        {
+            if (dbus_error_is_set(&err)) dbus_error_free(&err);
+            return -1;
+        }
+        int fd = -1;
+        DBusError perr;
+        dbus_error_init(&perr);
+        if (!dbus_message_get_args(reply, &perr, DBUS_TYPE_UNIX_FD, &fd, DBUS_TYPE_INVALID))
+        {
+            if (dbus_error_is_set(&perr)) dbus_error_free(&perr);
+            fd = -1;
+        }
+        dbus_message_unref(reply);
+        return fd;
+    }
+
+    void runPipeWire(int pwFd, uint32_t nodeId)
+    {
+        pw_init(nullptr, nullptr);
+        m_loop = pw_thread_loop_new("rc-screencast", nullptr);
+        if (!m_loop) { ::close(pwFd); return; }
+
+        pw_thread_loop_lock(m_loop);
+        m_ctx = pw_context_new(pw_thread_loop_get_loop(m_loop), nullptr, 0);
+        if (!m_ctx) { pw_thread_loop_unlock(m_loop); teardownPipeWire(); ::close(pwFd); return; }
+
+        m_core = pw_context_connect_fd(m_ctx, pwFd, nullptr, 0); // takes the fd
+        if (!m_core) { pw_thread_loop_unlock(m_loop); teardownPipeWire(); return; }
+
+        struct pw_properties *props = pw_properties_new(
+            PW_KEY_MEDIA_TYPE, "Video",
+            PW_KEY_MEDIA_CATEGORY, "Capture",
+            PW_KEY_MEDIA_ROLE, "Screen",
+            nullptr);
+        m_stream = pw_stream_new(m_core, "retrocapture-screencast", props);
+        if (!m_stream) { pw_thread_loop_unlock(m_loop); teardownPipeWire(); return; }
+
+        static const struct pw_stream_events kEvents = []() {
+            struct pw_stream_events e {};
+            e.version       = PW_VERSION_STREAM_EVENTS;
+            e.param_changed = onStreamParamChanged;
+            e.process       = onStreamProcess;
+            return e;
+        }();
+        pw_stream_add_listener(m_stream, &m_streamListener, &kEvents, this);
+
+        // Offer the packed-32-bit formats we can convert, no DMABUF
+        // modifiers so the buffers come back as mappable memory.
+        uint8_t buffer[1024];
+        struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+        struct spa_rectangle defSize = SPA_RECTANGLE(1920, 1080);
+        struct spa_rectangle minSize = SPA_RECTANGLE(1, 1);
+        struct spa_rectangle maxSize = SPA_RECTANGLE(8192, 8192);
+        struct spa_fraction  defRate = SPA_FRACTION(60, 1);
+        struct spa_fraction  minRate = SPA_FRACTION(0, 1);
+        struct spa_fraction  maxRate = SPA_FRACTION(360, 1);
+        const struct spa_pod *params[1];
+        params[0] = static_cast<const spa_pod *>(spa_pod_builder_add_object(&b,
+            SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
+            SPA_FORMAT_mediaType,    SPA_POD_Id(SPA_MEDIA_TYPE_video),
+            SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+            SPA_FORMAT_VIDEO_format, SPA_POD_CHOICE_ENUM_Id(5,
+                SPA_VIDEO_FORMAT_BGRx, SPA_VIDEO_FORMAT_BGRx, SPA_VIDEO_FORMAT_BGRA,
+                SPA_VIDEO_FORMAT_RGBx, SPA_VIDEO_FORMAT_RGBA),
+            SPA_FORMAT_VIDEO_size, SPA_POD_CHOICE_RANGE_Rectangle(&defSize, &minSize, &maxSize),
+            SPA_FORMAT_VIDEO_framerate, SPA_POD_CHOICE_RANGE_Fraction(&defRate, &minRate, &maxRate)));
+
+        pw_stream_connect(m_stream, PW_DIRECTION_INPUT, nodeId,
+                          static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT |
+                                                       PW_STREAM_FLAG_MAP_BUFFERS),
+                          params, 1);
+        pw_thread_loop_unlock(m_loop);
+        pw_thread_loop_start(m_loop);
+
+        LOG_INFO("VideoCaptureScreen(pw): stream connected to node " + std::to_string(nodeId));
+
+        // Hold here until stop() asks us to leave.
+        while (m_running.load())
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        teardownPipeWire();
+    }
+
+    void teardownPipeWire()
+    {
+        if (m_loop) pw_thread_loop_stop(m_loop);
+        if (m_stream) { pw_stream_destroy(m_stream); m_stream = nullptr; }
+        if (m_core) { pw_core_disconnect(m_core); m_core = nullptr; }
+        if (m_ctx) { pw_context_destroy(m_ctx); m_ctx = nullptr; }
+        if (m_loop) { pw_thread_loop_destroy(m_loop); m_loop = nullptr; }
+    }
+
+    void cleanupDbus()
+    {
+        if (m_dbus)
+        {
+            // Private connections must be explicitly closed before unref.
+            dbus_connection_close(m_dbus);
+            dbus_connection_unref(m_dbus);
+            m_dbus = nullptr;
+        }
+    }
+
+    IScreenFrameSink     &m_sink;
+    std::thread           m_thread;
+    std::atomic<bool>     m_running{false};
+    unsigned              m_tokenSeq = 0;
+
+    DBusConnection       *m_dbus = nullptr;
+
+    struct pw_thread_loop *m_loop   = nullptr;
+    struct pw_context     *m_ctx    = nullptr;
+    struct pw_core        *m_core   = nullptr;
+    struct pw_stream      *m_stream = nullptr;
+    struct spa_hook        m_streamListener {};
+    struct spa_video_info_raw m_format {};
+};
+} // namespace
+
+std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink)
+{
+    LOG_INFO("ScreenBackend: PipeWire + xdg-desktop-portal (Linux)");
+    return std::make_unique<PipeWireScreenBackend>(sink);
+}
+
+#endif // RETROCAPTURE_SCREEN_PIPEWIRE

--- a/src/capture/VideoCaptureScreen_linux.cpp
+++ b/src/capture/VideoCaptureScreen_linux.cpp
@@ -125,9 +125,13 @@ private:
         spa_zero(self->m_format);
         if (spa_format_video_raw_parse(param, &self->m_format) < 0) return;
 
+        const auto &fr  = self->m_format.framerate;
+        const auto &mfr = self->m_format.max_framerate;
         LOG_INFO("VideoCaptureScreen(pw): negotiated " +
                  std::to_string(self->m_format.size.width) + "x" +
-                 std::to_string(self->m_format.size.height));
+                 std::to_string(self->m_format.size.height) +
+                 " @ " + std::to_string(fr.num) + "/" + std::to_string(fr.denom) +
+                 " (max " + std::to_string(mfr.num) + "/" + std::to_string(mfr.denom) + ")");
     }
 
     static void onStreamProcess(void *data)
@@ -501,8 +505,11 @@ private:
         struct spa_rectangle defSize = SPA_RECTANGLE(1920, 1080);
         struct spa_rectangle minSize = SPA_RECTANGLE(1, 1);
         struct spa_rectangle maxSize = SPA_RECTANGLE(8192, 8192);
+        // Preferred 60 fps; min 1 (not 0 — some portals treat 0/1 as
+        // "unspecified" and fall back to a low rate). The compositor
+        // ultimately decides, but stating a real preference helps.
         struct spa_fraction  defRate = SPA_FRACTION(60, 1);
-        struct spa_fraction  minRate = SPA_FRACTION(0, 1);
+        struct spa_fraction  minRate = SPA_FRACTION(1, 1);
         struct spa_fraction  maxRate = SPA_FRACTION(360, 1);
         const struct spa_pod *params[1];
         params[0] = static_cast<const spa_pod *>(spa_pod_builder_add_object(&b,

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -48,6 +48,13 @@ API_AVAILABLE(macos(12.3))
     const uint32_t stride = static_cast<uint32_t>(CVPixelBufferGetBytesPerRow(px));
     if (base && w && h)
     {
+        static bool loggedDims = false;
+        if (!loggedDims)
+        {
+            loggedDims = true;
+            LOG_INFO("VideoCaptureScreen(sck): delivering " + std::to_string(w) + "x" +
+                     std::to_string(h) + " (stride " + std::to_string(stride) + ")");
+        }
         sink->onScreenFrame(base, w, h, stride, ScreenPixelFormat::BGRA);
     }
     CVPixelBufferUnlockBaseAddress(px, kCVPixelBufferLock_ReadOnly);
@@ -179,8 +186,33 @@ private:
                 if ((unsigned long)win.windowID == wantId)
                 {
                     filter = [[SCContentFilter alloc] initWithDesktopIndependentWindow:win];
-                    capW = (uint32_t)win.frame.size.width;
-                    capH = (uint32_t)win.frame.size.height;
+                    // win.frame is in POINTS. Capture at native pixels so a
+                    // Retina (2x) window isn't grabbed at half resolution —
+                    // which made shaders (scanlines) space wrong. Scale by
+                    // the backing factor of the display the window sits on.
+                    double scale = 1.0;
+                    for (SCDisplay *d in content.displays)
+                    {
+                        if (CGRectContainsPoint(d.frame,
+                                CGPointMake(CGRectGetMidX(win.frame), CGRectGetMidY(win.frame))))
+                        {
+                            CGDisplayModeRef m = CGDisplayCopyDisplayMode(d.displayID);
+                            if (m)
+                            {
+                                // True backing scale from the mode itself
+                                // (pixels / points), independent of how
+                                // SCDisplay reports its size.
+                                const double ptW = CGDisplayModeGetWidth(m);
+                                if (ptW > 0)
+                                    scale = (double)CGDisplayModeGetPixelWidth(m) / ptW;
+                                CGDisplayModeRelease(m);
+                            }
+                            break;
+                        }
+                    }
+                    if (scale < 1.0) scale = 1.0;
+                    capW = (uint32_t)(win.frame.size.width  * scale);
+                    capH = (uint32_t)(win.frame.size.height * scale);
                     break;
                 }
             }

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -1,0 +1,277 @@
+#include "ScreenBackend.h"
+
+// macOS screen-capture backend: ScreenCaptureKit (macOS 12.3+). Enumerates
+// displays + windows, captures a display (or window) as BGRA CMSampleBuffers
+// and hands them to the cross-platform sink (which crops + GPU-uploads).
+// Compiled only when RETROCAPTURE_SCREEN_SCK is set (macOS); the test
+// pattern stub stands in otherwise. The project builds Objective-C without
+// ARC, so memory is managed manually (retain/release).
+#ifdef RETROCAPTURE_SCREEN_SCK
+
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+#include "../utils/Logger.h"
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// ── delegate: receives sample buffers, forwards BGRA to the C++ sink ──
+API_AVAILABLE(macos(12.3))
+@interface RCScreenDelegate : NSObject <SCStreamOutput, SCStreamDelegate>
+{
+@public
+    IScreenFrameSink *sink;
+}
+@end
+
+@implementation RCScreenDelegate
+- (void)stream:(SCStream *)stream
+    didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+                   ofType:(SCStreamOutputType)type
+{
+    (void)stream;
+    if (type != SCStreamOutputTypeScreen || sink == nullptr) return;
+    if (!CMSampleBufferIsValid(sampleBuffer)) return;
+
+    CVImageBufferRef px = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!px) return;
+
+    CVPixelBufferLockBaseAddress(px, kCVPixelBufferLock_ReadOnly);
+    const uint8_t *base = static_cast<const uint8_t *>(CVPixelBufferGetBaseAddress(px));
+    const uint32_t w      = static_cast<uint32_t>(CVPixelBufferGetWidth(px));
+    const uint32_t h      = static_cast<uint32_t>(CVPixelBufferGetHeight(px));
+    const uint32_t stride = static_cast<uint32_t>(CVPixelBufferGetBytesPerRow(px));
+    if (base && w && h)
+    {
+        sink->onScreenFrame(base, w, h, stride, ScreenPixelFormat::BGRA);
+    }
+    CVPixelBufferUnlockBaseAddress(px, kCVPixelBufferLock_ReadOnly);
+}
+
+- (void)stream:(SCStream *)stream didStopWithError:(NSError *)error
+{
+    (void)stream;
+    LOG_WARN(std::string("VideoCaptureScreen(sck): stream stopped — ") +
+             (error ? error.localizedDescription.UTF8String : "?"));
+}
+@end
+
+namespace
+{
+// Fetch the shareable content synchronously (the API is async).
+SCShareableContent *fetchContentBlocking() API_AVAILABLE(macos(12.3))
+{
+    __block SCShareableContent *result = nil;
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [SCShareableContent getShareableContentWithCompletionHandler:
+        ^(SCShareableContent *content, NSError *error) {
+            if (content) result = [content retain]; // keep past the block (MRR)
+            (void)error;
+            dispatch_semaphore_signal(sem);
+        }];
+    dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW,
+                                               (int64_t)(5 * NSEC_PER_SEC)));
+    return result; // caller releases
+}
+
+class SckScreenBackend : public ScreenBackend
+{
+public:
+    explicit SckScreenBackend(IScreenFrameSink &sink) : m_sink(sink) {}
+    ~SckScreenBackend() override { stop(); }
+
+    bool start(const std::string &target, bool captureCursor) override
+    {
+        if (m_running.exchange(true)) return true;
+        if (@available(macOS 12.3, *))
+        {
+            return startSCK(target, captureCursor);
+        }
+        LOG_ERROR("VideoCaptureScreen(sck): ScreenCaptureKit needs macOS 12.3+");
+        m_running.store(false);
+        return false;
+    }
+
+    void stop() override
+    {
+        if (!m_running.exchange(false)) return;
+        if (@available(macOS 12.3, *))
+        {
+            if (m_stream)
+            {
+                [m_stream stopCaptureWithCompletionHandler:^(NSError *e) { (void)e; }];
+                [m_stream release];
+                m_stream = nil;
+            }
+            if (m_delegate) { [m_delegate release]; m_delegate = nil; }
+        }
+    }
+
+    std::vector<DeviceInfo> listTargets() override
+    {
+        std::vector<DeviceInfo> out;
+        if (@available(macOS 12.3, *))
+        {
+            SCShareableContent *content = fetchContentBlocking();
+            if (content)
+            {
+                int i = 0;
+                for (SCDisplay *d in content.displays)
+                {
+                    DeviceInfo di;
+                    di.id   = "monitor:" + std::to_string(i++);
+                    di.name = "Display " + std::to_string(i) + " (" +
+                              std::to_string((int)d.width) + "x" +
+                              std::to_string((int)d.height) + ")";
+                    di.driver = "screencapturekit";
+                    out.push_back(di);
+                }
+                for (SCWindow *win in content.windows)
+                {
+                    if (!win.title || win.title.length == 0) continue;
+                    DeviceInfo di;
+                    di.id   = "window:" + std::to_string((unsigned long)win.windowID);
+                    di.name = std::string("Window: ") + win.title.UTF8String;
+                    di.driver = "screencapturekit";
+                    out.push_back(di);
+                }
+                [content release];
+            }
+        }
+        if (out.empty())
+        {
+            DeviceInfo di;
+            di.id = "monitor:0"; di.name = "Primary display"; di.driver = "screencapturekit";
+            out.push_back(di);
+        }
+        return out;
+    }
+
+private:
+    bool startSCK(const std::string &target, bool captureCursor) API_AVAILABLE(macos(12.3))
+    {
+        SCShareableContent *content = fetchContentBlocking();
+        if (!content || content.displays.count == 0)
+        {
+            LOG_ERROR("VideoCaptureScreen(sck): no shareable content (screen-recording permission?)");
+            [content release];
+            m_running.store(false);
+            return false;
+        }
+
+        // Resolve the target. "window:<id>" → a window; "monitor:N" /
+        // default → a display. Window capture uses the display the
+        // window's filter is built from.
+        SCContentFilter *filter = nil;
+        uint32_t capW = 0, capH = 0;
+
+        if (target.rfind("window:", 0) == 0)
+        {
+            const std::string idStr = target.substr(7);
+            const unsigned long wantId = idStr.empty() ? 0 : strtoul(idStr.c_str(), nullptr, 10);
+            for (SCWindow *win in content.windows)
+            {
+                if ((unsigned long)win.windowID == wantId)
+                {
+                    filter = [[SCContentFilter alloc] initWithDesktopIndependentWindow:win];
+                    capW = (uint32_t)win.frame.size.width;
+                    capH = (uint32_t)win.frame.size.height;
+                    break;
+                }
+            }
+        }
+
+        if (!filter)
+        {
+            int idx = 0;
+            const auto p = target.find(':');
+            if (p != std::string::npos)
+            {
+                const std::string n = target.substr(p + 1);
+                if (!n.empty()) idx = atoi(n.c_str());
+            }
+            if (idx < 0 || idx >= (int)content.displays.count) idx = 0;
+            SCDisplay *display = content.displays[idx];
+            filter = [[SCContentFilter alloc] initWithDisplay:display
+                                            excludingWindows:@[]];
+            capW = (uint32_t)display.width;
+            capH = (uint32_t)display.height;
+        }
+
+        if (!filter || capW == 0 || capH == 0)
+        {
+            LOG_ERROR("VideoCaptureScreen(sck): could not build a content filter");
+            [filter release];
+            [content release];
+            m_running.store(false);
+            return false;
+        }
+
+        SCStreamConfiguration *cfg = [[SCStreamConfiguration alloc] init];
+        cfg.width  = capW;
+        cfg.height = capH;
+        cfg.pixelFormat = kCVPixelFormatType_32BGRA;
+        cfg.minimumFrameInterval = CMTimeMake(1, 60); // up to 60 fps
+        cfg.queueDepth = 5;
+        cfg.showsCursor = captureCursor ? YES : NO;
+
+        m_delegate = [[RCScreenDelegate alloc] init];
+        m_delegate->sink = &m_sink;
+
+        m_stream = [[SCStream alloc] initWithFilter:filter
+                                      configuration:cfg
+                                           delegate:m_delegate];
+        [filter release];
+        [cfg release];
+
+        NSError *addErr = nil;
+        dispatch_queue_t q = dispatch_queue_create("com.retrocapture.sck",
+                                                   DISPATCH_QUEUE_SERIAL);
+        BOOL added = [m_stream addStreamOutput:m_delegate
+                                          type:SCStreamOutputTypeScreen
+                            sampleHandlerQueue:q
+                                         error:&addErr];
+        dispatch_release(q);
+        if (!added)
+        {
+            LOG_ERROR(std::string("VideoCaptureScreen(sck): addStreamOutput failed — ") +
+                      (addErr ? addErr.localizedDescription.UTF8String : "?"));
+            [m_stream release]; m_stream = nil;
+            [m_delegate release]; m_delegate = nil;
+            [content release];
+            m_running.store(false);
+            return false;
+        }
+
+        [m_stream startCaptureWithCompletionHandler:^(NSError *e) {
+            if (e)
+                LOG_ERROR(std::string("VideoCaptureScreen(sck): startCapture failed — ") +
+                          e.localizedDescription.UTF8String);
+            else
+                LOG_INFO("VideoCaptureScreen(sck): capture started " +
+                         std::to_string(capW) + "x" + std::to_string(capH));
+        }];
+
+        [content release];
+        return true;
+    }
+
+    IScreenFrameSink &m_sink;
+    std::atomic<bool>  m_running{false};
+    SCStream          *m_stream   = nil;   // owned (retain/release)
+    RCScreenDelegate  *m_delegate = nil;   // owned
+};
+} // namespace
+
+std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink)
+{
+    LOG_INFO("ScreenBackend: ScreenCaptureKit (macOS)");
+    return std::make_unique<SckScreenBackend>(sink);
+}
+
+#endif // RETROCAPTURE_SCREEN_SCK

--- a/src/capture/VideoCaptureScreen_stub.cpp
+++ b/src/capture/VideoCaptureScreen_stub.cpp
@@ -1,0 +1,81 @@
+#include "ScreenBackend.h"
+
+// Fallback screen backend: a moving test pattern. Compiled when no real
+// platform grabber is enabled for this build (Windows/macOS until their
+// backends land, or Linux without PipeWire). The real Linux backend in
+// VideoCaptureScreen_linux.cpp takes over when RETROCAPTURE_SCREEN_PIPEWIRE
+// is defined.
+#ifndef RETROCAPTURE_SCREEN_PIPEWIRE
+
+#include "../utils/Logger.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+namespace
+{
+class TestPatternBackend : public ScreenBackend
+{
+public:
+    explicit TestPatternBackend(IScreenFrameSink &sink) : m_sink(sink) {}
+    ~TestPatternBackend() override { stop(); }
+
+    bool start(const std::string &, bool) override
+    {
+        if (m_running.exchange(true)) return true;
+        m_thread = std::thread([this]() {
+            const uint32_t w = 1280, h = 720;
+            std::vector<uint8_t> buf(static_cast<size_t>(w) * h * 4);
+            uint32_t tick = 0;
+            while (m_running.load())
+            {
+                uint8_t *p = buf.data();
+                for (uint32_t y = 0; y < h; ++y)
+                    for (uint32_t x = 0; x < w; ++x)
+                    {
+                        const size_t i = (static_cast<size_t>(y) * w + x) * 4;
+                        p[i + 0] = static_cast<uint8_t>((x + tick) & 0xFF); // B
+                        p[i + 1] = static_cast<uint8_t>((y + tick) & 0xFF); // G
+                        p[i + 2] = static_cast<uint8_t>((x + y) & 0xFF);    // R
+                        p[i + 3] = 255;
+                    }
+                m_sink.onScreenFrame(buf.data(), w, h, w * 4, ScreenPixelFormat::BGRA);
+                ++tick;
+                std::this_thread::sleep_for(std::chrono::milliseconds(33)); // ~30 fps
+            }
+        });
+        return true;
+    }
+
+    void stop() override
+    {
+        if (!m_running.exchange(false)) return;
+        if (m_thread.joinable()) m_thread.join();
+    }
+
+    std::vector<DeviceInfo> listTargets() override
+    {
+        DeviceInfo d;
+        d.id        = "monitor:0";
+        d.name      = "Primary display (test pattern)";
+        d.driver    = "screen";
+        d.available = true;
+        return {d};
+    }
+
+private:
+    IScreenFrameSink  &m_sink;
+    std::atomic<bool>  m_running{false};
+    std::thread        m_thread;
+};
+} // namespace
+
+std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink)
+{
+    LOG_INFO("ScreenBackend: test-pattern stub (no platform grabber in this build)");
+    return std::make_unique<TestPatternBackend>(sink);
+}
+
+#endif // !RETROCAPTURE_SCREEN_PIPEWIRE

--- a/src/capture/VideoCaptureScreen_stub.cpp
+++ b/src/capture/VideoCaptureScreen_stub.cpp
@@ -1,11 +1,13 @@
 #include "ScreenBackend.h"
 
-// Fallback screen backend: a moving test pattern. Compiled when no real
-// platform grabber is enabled for this build (Windows/macOS until their
-// backends land, or Linux without PipeWire). The real Linux backend in
-// VideoCaptureScreen_linux.cpp takes over when RETROCAPTURE_SCREEN_PIPEWIRE
-// is defined.
-#ifndef RETROCAPTURE_SCREEN_PIPEWIRE
+// Fallback screen backend: a moving test pattern. Compiled only when no
+// real platform grabber is enabled for this build (Linux without
+// PipeWire, or a platform whose backend isn't built). The real backends
+// — VideoCaptureScreen_linux.cpp (PipeWire), _win.cpp (DXGI), _mac.mm
+// (ScreenCaptureKit) — take over when their macro is defined.
+#if !defined(RETROCAPTURE_SCREEN_PIPEWIRE) && \
+    !defined(RETROCAPTURE_SCREEN_DXGI) && \
+    !defined(RETROCAPTURE_SCREEN_SCK)
 
 #include "../utils/Logger.h"
 
@@ -78,4 +80,4 @@ std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink)
     return std::make_unique<TestPatternBackend>(sink);
 }
 
-#endif // !RETROCAPTURE_SCREEN_PIPEWIRE
+#endif // no real screen backend for this build

--- a/src/capture/VideoCaptureScreen_win.cpp
+++ b/src/capture/VideoCaptureScreen_win.cpp
@@ -1,0 +1,264 @@
+#include "ScreenBackend.h"
+
+// Windows screen-capture backend: DXGI Desktop Duplication (monitor
+// capture, Windows 8+). Delivers BGRA frames; the cross-platform sink
+// crops + uploads. Window capture (WGC) is a follow-up — DXGI duplication
+// is monitor-only. Compiled only when RETROCAPTURE_SCREEN_DXGI is set
+// (Windows); the test-pattern stub stands in otherwise.
+#ifdef RETROCAPTURE_SCREEN_DXGI
+
+#include "../utils/Logger.h"
+
+#include <windows.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+template <class T> void safeRelease(T *&p) { if (p) { p->Release(); p = nullptr; } }
+
+class DxgiScreenBackend : public ScreenBackend
+{
+public:
+    explicit DxgiScreenBackend(IScreenFrameSink &sink) : m_sink(sink) {}
+    ~DxgiScreenBackend() override { stop(); }
+
+    bool start(const std::string &target, bool captureCursor) override
+    {
+        if (m_running.exchange(true)) return true;
+        m_target = target;
+        m_cursor = captureCursor;
+        m_thread = std::thread(&DxgiScreenBackend::run, this);
+        return true;
+    }
+
+    void stop() override
+    {
+        if (!m_running.exchange(false)) return;
+        if (m_thread.joinable()) m_thread.join();
+    }
+
+    std::vector<DeviceInfo> listTargets() override { return enumerateOutputs(); }
+
+private:
+    static std::vector<DeviceInfo> enumerateOutputs()
+    {
+        std::vector<DeviceInfo> out;
+        IDXGIFactory1 *factory = nullptr;
+        if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1),
+                                      reinterpret_cast<void **>(&factory))) || !factory)
+            return out;
+
+        IDXGIAdapter1 *adapter = nullptr;
+        for (UINT ai = 0; factory->EnumAdapters1(ai, &adapter) == S_OK; ++ai)
+        {
+            IDXGIOutput *o = nullptr;
+            for (UINT oi = 0; adapter->EnumOutputs(oi, &o) == S_OK; ++oi)
+            {
+                DXGI_OUTPUT_DESC desc;
+                if (SUCCEEDED(o->GetDesc(&desc)))
+                {
+                    char name[64] = {0};
+                    ::wcstombs(name, desc.DeviceName, sizeof(name) - 1);
+                    DeviceInfo di;
+                    di.id        = "monitor:" + std::to_string(out.size());
+                    di.name      = "Display " + std::to_string(out.size()) +
+                                   " (" + name + ")";
+                    di.driver    = "dxgi";
+                    di.available  = desc.AttachedToDesktop != 0;
+                    out.push_back(di);
+                }
+                safeRelease(o);
+            }
+            safeRelease(adapter);
+        }
+        safeRelease(factory);
+
+        if (out.empty())
+        {
+            DeviceInfo di;
+            di.id = "monitor:0"; di.name = "Primary display"; di.driver = "dxgi";
+            out.push_back(di);
+        }
+        return out;
+    }
+
+    int targetIndex() const
+    {
+        const auto p = m_target.find(':');
+        if (p != std::string::npos)
+        {
+            const std::string n = m_target.substr(p + 1);
+            if (!n.empty())
+            {
+                char *end = nullptr;
+                const long v = std::strtol(n.c_str(), &end, 10);
+                if (end != n.c_str() && v >= 0) return static_cast<int>(v);
+            }
+        }
+        return 0;
+    }
+
+    void run()
+    {
+        const int wantOut = targetIndex();
+
+        IDXGIFactory1 *factory = nullptr;
+        if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1),
+                                      reinterpret_cast<void **>(&factory))) || !factory)
+        {
+            LOG_ERROR("VideoCaptureScreen(dxgi): CreateDXGIFactory1 failed");
+            m_running.store(false);
+            return;
+        }
+
+        // Find the adapter + output for the global output index.
+        IDXGIAdapter1 *adapter = nullptr;
+        IDXGIOutput   *output  = nullptr;
+        int globalIdx = 0;
+        for (UINT ai = 0; !output && factory->EnumAdapters1(ai, &adapter) == S_OK; ++ai)
+        {
+            IDXGIOutput *o = nullptr;
+            for (UINT oi = 0; adapter->EnumOutputs(oi, &o) == S_OK; ++oi)
+            {
+                if (globalIdx == wantOut) { output = o; break; }
+                ++globalIdx;
+                safeRelease(o);
+            }
+            if (!output) safeRelease(adapter);
+        }
+        if (!output) // fall back to adapter 0 / output 0
+        {
+            safeRelease(adapter);
+            if (factory->EnumAdapters1(0, &adapter) == S_OK)
+                adapter->EnumOutputs(0, &output);
+        }
+        if (!adapter || !output)
+        {
+            LOG_ERROR("VideoCaptureScreen(dxgi): no usable output");
+            safeRelease(output); safeRelease(adapter); safeRelease(factory);
+            m_running.store(false);
+            return;
+        }
+
+        ID3D11Device        *dev = nullptr;
+        ID3D11DeviceContext *ctx = nullptr;
+        D3D_FEATURE_LEVEL    fl;
+        HRESULT hr = D3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0,
+                                       nullptr, 0, D3D11_SDK_VERSION, &dev, &fl, &ctx);
+        if (FAILED(hr) || !dev || !ctx)
+        {
+            LOG_ERROR("VideoCaptureScreen(dxgi): D3D11CreateDevice failed");
+            safeRelease(output); safeRelease(adapter); safeRelease(factory);
+            m_running.store(false);
+            return;
+        }
+
+        IDXGIOutput1 *output1 = nullptr;
+        output->QueryInterface(__uuidof(IDXGIOutput1), reinterpret_cast<void **>(&output1));
+        IDXGIOutputDuplication *dup = nullptr;
+        if (output1) output1->DuplicateOutput(dev, &dup);
+        if (!dup)
+        {
+            LOG_ERROR("VideoCaptureScreen(dxgi): DuplicateOutput failed");
+            safeRelease(output1); safeRelease(ctx); safeRelease(dev);
+            safeRelease(output); safeRelease(adapter); safeRelease(factory);
+            m_running.store(false);
+            return;
+        }
+
+        LOG_INFO("VideoCaptureScreen(dxgi): duplicating output " + std::to_string(wantOut));
+
+        ID3D11Texture2D *staging = nullptr;
+        UINT stW = 0, stH = 0;
+
+        while (m_running.load())
+        {
+            DXGI_OUTDUPL_FRAME_INFO info;
+            IDXGIResource *res = nullptr;
+            hr = dup->AcquireNextFrame(100, &info, &res); // 100 ms poll
+            if (hr == DXGI_ERROR_WAIT_TIMEOUT) { continue; } // no new frame
+            if (FAILED(hr))
+            {
+                // Access lost (resolution change, mode switch, secure
+                // desktop) — rebuild the duplication.
+                safeRelease(res);
+                safeRelease(dup);
+                if (output1) output1->DuplicateOutput(dev, &dup);
+                if (!dup) { std::this_thread::sleep_for(std::chrono::milliseconds(200)); }
+                continue;
+            }
+
+            ID3D11Texture2D *tex = nullptr;
+            res->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(&tex));
+            if (tex)
+            {
+                D3D11_TEXTURE2D_DESC td;
+                tex->GetDesc(&td);
+                if (!staging || stW != td.Width || stH != td.Height)
+                {
+                    safeRelease(staging);
+                    D3D11_TEXTURE2D_DESC sd = {};
+                    sd.Width = td.Width; sd.Height = td.Height;
+                    sd.MipLevels = 1; sd.ArraySize = 1;
+                    sd.Format = td.Format; // B8G8R8A8_UNORM from the desktop
+                    sd.SampleDesc.Count = 1;
+                    sd.Usage = D3D11_USAGE_STAGING;
+                    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+                    if (SUCCEEDED(dev->CreateTexture2D(&sd, nullptr, &staging)))
+                    {
+                        stW = td.Width; stH = td.Height;
+                    }
+                }
+                if (staging)
+                {
+                    ctx->CopyResource(staging, tex);
+                    D3D11_MAPPED_SUBRESOURCE map;
+                    if (SUCCEEDED(ctx->Map(staging, 0, D3D11_MAP_READ, 0, &map)))
+                    {
+                        m_sink.onScreenFrame(static_cast<const uint8_t *>(map.pData),
+                                             td.Width, td.Height,
+                                             static_cast<uint32_t>(map.RowPitch),
+                                             ScreenPixelFormat::BGRA);
+                        ctx->Unmap(staging, 0);
+                    }
+                }
+            }
+            safeRelease(tex);
+            safeRelease(res);
+            dup->ReleaseFrame();
+        }
+
+        safeRelease(staging);
+        safeRelease(dup);
+        safeRelease(output1);
+        safeRelease(ctx);
+        safeRelease(dev);
+        safeRelease(output);
+        safeRelease(adapter);
+        safeRelease(factory);
+    }
+
+    IScreenFrameSink &m_sink;
+    std::atomic<bool> m_running{false};
+    std::thread       m_thread;
+    std::string       m_target;
+    bool              m_cursor = true;
+};
+} // namespace
+
+std::unique_ptr<ScreenBackend> createScreenBackend(IScreenFrameSink &sink)
+{
+    LOG_INFO("ScreenBackend: DXGI Desktop Duplication (Windows)");
+    return std::make_unique<DxgiScreenBackend>(sink);
+}
+
+#endif // RETROCAPTURE_SCREEN_DXGI

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2275,6 +2275,107 @@ bool Application::initUI()
                                          m_window->setVsync(sourceType == UIManager::SourceType::Remote);
                                      }
 
+                                     // #97/#107 — the concrete backend differs per source
+                                     // type (factory V4L2/DS/AVF, VideoCaptureScreen,
+                                     // VideoCaptureRemote). Reusing the old instance across a
+                                     // switch opened a screen target as a V4L2 device
+                                     // (segfault) and carried the previous source's device
+                                     // path into the new one. When the type no longer matches
+                                     // the live backend, tear it down and build the right one,
+                                     // dropping the stale device so the new source starts
+                                     // clean.
+                                     {
+                                         using ST = UIManager::SourceType;
+                                         const bool wantScreen = (sourceType == ST::Screen);
+                                         const bool wantRemote = (sourceType == ST::Remote);
+                                         const bool wantFactory = !wantScreen && !wantRemote; // V4L2/DS/AVF/None
+
+                                         const bool haveScreen  = dynamic_cast<VideoCaptureScreen *>(m_capture.get()) != nullptr;
+                                         const bool haveRemote  = dynamic_cast<VideoCaptureRemote *>(m_capture.get()) != nullptr;
+                                         const bool haveFactory = m_capture && !haveScreen && !haveRemote;
+
+                                         const bool wrongType =
+                                             !m_capture ||
+                                             (wantScreen && !haveScreen) ||
+                                             (wantRemote && !haveRemote) ||
+                                             (wantFactory && !haveFactory);
+
+                                         if (wrongType)
+                                         {
+                                             LOG_INFO("Source type changed — rebuilding capture backend");
+                                             // Drop the UI's raw capture pointer BEFORE the old
+                                             // instance is destroyed. setCaptureControls() stashes
+                                             // it in UIManager::m_capture (what getCapture() hands
+                                             // the Source tab); leaving it dangling across the
+                                             // rebuild segfaulted on the next render of the new
+                                             // tab. Cleared here, re-pointed at the new backend
+                                             // below.
+                                             if (m_ui) m_ui->setCaptureControls(nullptr);
+                                             if (m_remoteMetaSync) { m_remoteMetaSync->stop(); m_remoteMetaSync.reset(); }
+                                             if (m_capture) { m_capture->stopCapture(); m_capture->close(); m_capture.reset(); }
+                                             m_devicePath.clear();
+                                             if (m_ui) m_ui->setCurrentDeviceSilent("");
+
+                                             if (wantScreen)      m_capture = std::make_unique<VideoCaptureScreen>();
+                                             else if (wantRemote) m_capture = std::make_unique<VideoCaptureRemote>();
+                                             else                 m_capture = VideoCaptureFactory::create();
+
+                                             // Factory backend with no device yet → idle dummy
+                                             // so there's always valid output (black) until the
+                                             // user picks a device, instead of a half-init grab.
+                                             if (wantFactory && m_capture && sourceType != ST::None)
+                                             {
+                                                 m_capture->setDummyMode(true);
+                                                 if (m_capture->setFormat(m_captureWidth, m_captureHeight, 0))
+                                                     m_capture->startCapture();
+                                             }
+
+                                             // Re-point the UI at the freshly built backend so
+                                             // getCapture() is valid again. For Screen/Remote
+                                             // this carries no hardware controls (no-op queries);
+                                             // for V4L2/DS it re-enumerates the control set.
+                                             if (m_ui) m_ui->setCaptureControls(m_capture.get());
+                                         }
+                                     }
+
+                                     // #107 — Screen: auto-open the default target so the
+                                     // user sees frames immediately instead of having to
+                                     // pick from the dropdown.
+                                     if (sourceType == UIManager::SourceType::Screen)
+                                     {
+                                         LOG_INFO("Screen source selected");
+                                         if (m_capture)
+                                         {
+                                             std::string target = m_ui ? m_ui->getCurrentDevice() : std::string();
+                                             if (target.empty())
+                                             {
+                                                 const auto devs = m_capture->listDevices();
+                                                 if (!devs.empty()) target = devs.front().id;
+                                             }
+                                             if (!target.empty())
+                                             {
+                                                 if (auto *screen = dynamic_cast<VideoCaptureScreen *>(m_capture.get()))
+                                                 {
+                                                     if (m_ui)
+                                                         screen->setRegion(m_ui->getScreenRegionX(), m_ui->getScreenRegionY(),
+                                                                           m_ui->getScreenRegionW(), m_ui->getScreenRegionH());
+                                                 }
+                                                 if (m_capture->open(target))
+                                                 {
+                                                     m_capture->startCapture();
+                                                     m_devicePath = target;
+                                                     if (m_ui)
+                                                     {
+                                                         m_ui->setCurrentDeviceSilent(target);
+                                                         m_ui->setCaptureInfo(m_capture->getWidth(), m_capture->getHeight(),
+                                                                              m_captureFps, target);
+                                                     }
+                                                 }
+                                             }
+                                         }
+                                         return; // Screen fully handled
+                                     }
+
                                      if (sourceType == UIManager::SourceType::None)
                                      {
                                          LOG_INFO("None source selected - activating dummy mode");

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2666,6 +2666,20 @@ bool Application::initUI()
         // VideoCaptureScreen pointed at it. Empty target == stop.
         if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Screen)
         {
+            // Dedup: if we're already capturing this exact target, don't
+            // tear the portal session down and re-create it (that popped
+            // a fresh portal dialog and interrupted PipeWire format
+            // negotiation, leaving the stream with no frames). The
+            // source-type switch already auto-opened the target, so the
+            // UI re-selecting the same one must be a no-op. #107.
+            if (!devicePath.empty() && devicePath == m_devicePath &&
+                dynamic_cast<VideoCaptureScreen *>(m_capture.get()) &&
+                m_capture->isOpen())
+            {
+                processingDeviceChange = false;
+                return;
+            }
+
             LOG_INFO("Screen target change: " +
                      (devicePath.empty() ? std::string("(stop)") : devicePath));
             if (m_capture)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4,6 +4,7 @@
 #include "../capture/IVideoCapture.h"
 #include "../capture/VideoCaptureFactory.h"
 #include "../capture/VideoCaptureRemote.h"
+#include "../capture/VideoCaptureScreen.h"
 #include "../streaming/RemoteMetaSync.h"
 #include "../encoding/MediaEncoder.h"
 #ifdef PLATFORM_LINUX
@@ -451,6 +452,17 @@ bool Application::initCapture()
         remote->setInterpolationMode(imode);
         remote->setAudioVolume(m_remoteAudioGain);
         m_capture = std::move(remote);
+    }
+    else if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Screen)
+    {
+        // #107 — screen capture is its own backend (not in the
+        // platform factory, like Remote). Target + region come from the
+        // UI/config; open() happens below via the shared device path.
+        LOG_INFO("Source is screen — creating VideoCaptureScreen");
+        auto screen = std::make_unique<VideoCaptureScreen>();
+        screen->setRegion(m_ui->getScreenRegionX(), m_ui->getScreenRegionY(),
+                          m_ui->getScreenRegionW(), m_ui->getScreenRegionH());
+        m_capture = std::move(screen);
     }
     else
     {
@@ -1768,6 +1780,15 @@ bool Application::initUI()
         }
     });
 
+    // #107 — live screen-capture region crop. Push the new rect to the
+    // active VideoCaptureScreen so the crop changes without a restart.
+    m_ui->setOnScreenRegionChanged([this](uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+        if (auto *screen = dynamic_cast<VideoCaptureScreen *>(m_capture.get()))
+        {
+            screen->setRegion(x, y, w, h);
+        }
+    });
+
     // Callbacks for buffer settings
     m_ui->setOnStreamingMaxVideoBufferSizeChanged([this](size_t size)
                                                   {
@@ -2538,6 +2559,54 @@ bool Application::initUI()
             return;
         }
         processingDeviceChange = true;
+
+        // #107 — Screen source: the callback carries the capture target
+        // ("monitor:N" / "window:<id>" / ""). Replace the capture with a
+        // VideoCaptureScreen pointed at it. Empty target == stop.
+        if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Screen)
+        {
+            LOG_INFO("Screen target change: " +
+                     (devicePath.empty() ? std::string("(stop)") : devicePath));
+            if (m_capture)
+            {
+                m_capture->stopCapture();
+                m_capture->close();
+                m_capture.reset();
+            }
+            m_devicePath = devicePath;
+
+            if (devicePath.empty())
+            {
+                if (m_ui) m_ui->setCaptureInfo(0, 0, 0, "");
+                processingDeviceChange = false;
+                return;
+            }
+
+            auto screen = std::make_unique<VideoCaptureScreen>();
+            screen->setRegion(m_ui->getScreenRegionX(), m_ui->getScreenRegionY(),
+                              m_ui->getScreenRegionW(), m_ui->getScreenRegionH());
+            m_capture = std::move(screen);
+            if (m_capture->open(devicePath))
+            {
+                m_capture->startCapture();
+                const uint32_t w = m_capture->getWidth();
+                const uint32_t h = m_capture->getHeight();
+                if (w > 0 && h > 0) { m_captureWidth = w; m_captureHeight = h; }
+                if (m_ui) m_ui->setCaptureInfo(w, h, m_captureFps, devicePath);
+            }
+            else
+            {
+                LOG_WARN("VideoCaptureScreen: failed to open target " + devicePath);
+                if (m_ui)
+                {
+                    m_ui->setCaptureInfo(0, 0, 0, "Screen (failed)");
+                    m_ui->setCurrentDeviceSilent("");
+                }
+                m_devicePath.clear();
+            }
+            processingDeviceChange = false;
+            return;
+        }
 
         // Phase 5b/#47: when the active source is Remote, this callback
         // carries the remote BASE URL — not a V4L2 / DirectShow device

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4155,6 +4155,14 @@ void Application::run()
         // Skip rendering during reconfiguration to avoid accessing deleted textures
         if (!m_isReconfiguring && m_frameProcessor && m_frameProcessor->hasValidFrame() && m_frameProcessor->getTexture() != 0)
         {
+            // #107 — publish the live capture texture for the screen
+            // region selector (it draws the current frame to pick on).
+            if (m_ui)
+            {
+                m_ui->setCaptureTexture(m_frameProcessor->getTexture(),
+                                        m_frameProcessor->getTextureWidth(),
+                                        m_frameProcessor->getTextureHeight());
+            }
             // Log resolução de captura original (antes de qualquer processamento)
             static int originalCaptureLogCount = 0;
             if (originalCaptureLogCount++ < 3)

--- a/src/processing/FrameProcessor.cpp
+++ b/src/processing/FrameProcessor.cpp
@@ -55,6 +55,22 @@ bool FrameProcessor::processFrame(IVideoCapture *capture)
         return false; // Device is closed, cannot process frames
     }
 
+    // #107 zero-copy GPU path: if the capture hands us a ready GL texture
+    // (DMABUF imported via EGL), use it directly and skip the CPU upload.
+    {
+        uint32_t gw = 0, gh = 0;
+        const unsigned int gpuTex = capture->getGpuTexture(gw, gh);
+        if (gpuTex != 0 && gw > 0 && gh > 0)
+        {
+            m_externalTexture = gpuTex;
+            m_textureWidth    = gw;
+            m_textureHeight   = gh;
+            m_hasValidFrame   = true;
+            return true;
+        }
+        m_externalTexture = 0; // not on the GPU path this frame
+    }
+
     Frame frame;
     // Usar captureLatestFrame para descartar frames antigos e pegar apenas o mais recente
     bool captured = capture->captureLatestFrame(frame);

--- a/src/processing/FrameProcessor.cpp
+++ b/src/processing/FrameProcessor.cpp
@@ -3,6 +3,12 @@
 #include "../renderer/OpenGLRenderer.h"
 #include "../utils/Logger.h"
 #include <iostream>
+
+// Core GL since 1.2; define defensively in case the active loader header
+// didn't expose it (used by the screen-capture 32-bit upload path).
+#ifndef GL_BGRA
+#define GL_BGRA 0x80E1
+#endif
 #ifdef __linux__
 #include <linux/videodev2.h>
 #ifndef V4L2_PIX_FMT_MJPEG
@@ -166,6 +172,21 @@ bool FrameProcessor::processFrame(IVideoCapture *capture)
         {
             glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, frame.width, frame.height, GL_RGB, GL_UNSIGNED_BYTE, frame.data);
         }
+    }
+    else if (frame.format == RC_PIXFMT_BGRA || frame.format == RC_PIXFMT_RGBA ||
+             frame.size == static_cast<size_t>(frame.width) * frame.height * 4)
+    {
+        // Packed 32-bit (screen capture, #107). Hand it to GL with the
+        // matching source format and let the driver swizzle into the RGB
+        // texture — no CPU colour conversion, which is what keeps a full
+        // monitor / 4K grab at the compositor's frame rate.
+        const GLenum srcFmt = (frame.format == RC_PIXFMT_RGBA) ? GL_RGBA : GL_BGRA;
+        if (textureCreated)
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, frame.width, frame.height, 0,
+                         srcFmt, GL_UNSIGNED_BYTE, frame.data);
+        else
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, frame.width, frame.height,
+                            srcFmt, GL_UNSIGNED_BYTE, frame.data);
     }
     else
     {

--- a/src/processing/FrameProcessor.h
+++ b/src/processing/FrameProcessor.h
@@ -41,7 +41,9 @@ public:
      * 
      * @return OpenGL texture ID, or 0 if no texture exists
      */
-    GLuint getTexture() const { return m_texture; }
+    // Returns the external (zero-copy DMABUF) texture when the capture
+    // provided one this frame, else the internally-uploaded texture.
+    GLuint getTexture() const { return m_externalTexture ? m_externalTexture : m_texture; }
 
     /**
      * Get the texture width.
@@ -84,6 +86,9 @@ public:
 private:
     OpenGLRenderer* m_renderer = nullptr;
     GLuint m_texture = 0;
+    // Externally-owned texture (capture's DMABUF zero-copy path, #107).
+    // When non-zero, getTexture() returns it and we never delete it.
+    GLuint m_externalTexture = 0;
     uint32_t m_textureWidth = 0;
     uint32_t m_textureHeight = 0;
     bool m_hasValidFrame = false;

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -838,8 +838,16 @@ void UIConfigurationSource::renderScreenControls()
         m_screenRegionSeeded = true;
     }
 
-    ImGui::InputInt2("x, y", &m_screenRegion[0]);
-    ImGui::InputInt2("w, h", &m_screenRegion[2]);
+    // Spin edits (±1 / ±10 with the step buttons) so fine adjustments
+    // are easy without dragging. Pairs on a line to stay compact.
+    ImGui::PushItemWidth(130.0f);
+    ImGui::InputInt("X", &m_screenRegion[0], 1, 10);
+    ImGui::SameLine();
+    ImGui::InputInt("Y", &m_screenRegion[1], 1, 10);
+    ImGui::InputInt("W", &m_screenRegion[2], 1, 10);
+    ImGui::SameLine();
+    ImGui::InputInt("H", &m_screenRegion[3], 1, 10);
+    ImGui::PopItemWidth();
     for (int i = 0; i < 4; ++i) if (m_screenRegion[i] < 0) m_screenRegion[i] = 0;
 
     if (ImGui::Button("Apply region"))

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -3,6 +3,7 @@
 #include "UISectionHeader.h"
 #include "../utils/TranslationManager.h"
 #include "../capture/IVideoCapture.h"
+#include "../capture/VideoCaptureScreen.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cstring>
@@ -47,6 +48,12 @@ void UIConfigurationSource::render()
     if (sourceType == UIManager::SourceType::Remote)
     {
         renderRemoteControls();
+        ImGui::End();
+        return;
+    }
+    if (sourceType == UIManager::SourceType::Screen)
+    {
+        renderScreenControls();
         ImGui::End();
         return;
     }
@@ -98,25 +105,30 @@ void UIConfigurationSource::renderSourceTypeSelection()
     // ('Remote → Connect to Remote...') with a dedicated window for URL
     // and interpolation. The Source tab focuses only on physical capture
     // options local to the machine.
+    // 'Screen' (#107) is cross-platform and offered everywhere.
 #ifdef __linux__
-    const char *sourceTypeNames[] = {"None", "V4L2"};
+    const char *sourceTypeNames[] = {"None", "V4L2", "Screen"};
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
-        UIManager::SourceType::V4L2};
+        UIManager::SourceType::V4L2,
+        UIManager::SourceType::Screen};
 #elif defined(_WIN32)
-    const char *sourceTypeNames[] = {"None", "DirectShow"};
+    const char *sourceTypeNames[] = {"None", "DirectShow", "Screen"};
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
-        UIManager::SourceType::DS};
+        UIManager::SourceType::DS,
+        UIManager::SourceType::Screen};
 #elif defined(__APPLE__)
-    const char *sourceTypeNames[] = {"None", "AVFoundation"};
+    const char *sourceTypeNames[] = {"None", "AVFoundation", "Screen"};
     UIManager::SourceType sourceTypeMap[] = {
         UIManager::SourceType::None,
-        UIManager::SourceType::AVFoundation};
+        UIManager::SourceType::AVFoundation,
+        UIManager::SourceType::Screen};
 #else
-    const char *sourceTypeNames[] = {"None"};
+    const char *sourceTypeNames[] = {"None", "Screen"};
     UIManager::SourceType sourceTypeMap[] = {
-        UIManager::SourceType::None};
+        UIManager::SourceType::None,
+        UIManager::SourceType::Screen};
 #endif
 
     // Encontrar índice atual baseado no SourceType
@@ -745,6 +757,93 @@ void UIConfigurationSource::renderRemoteControls()
     else
     {
         ImGui::TextDisabled("not connected");
+    }
+}
+
+void UIConfigurationSource::renderScreenControls()
+{
+    ui_section_header("Screen Capture",
+                      "Capture the desktop — a whole monitor, a window, "
+                      "or a cropped region — as the source.");
+
+    // Target enumeration. Cached so we don't re-enumerate every frame;
+    // a Refresh re-scans (windows come and go). On Wayland the portal's
+    // own picker ultimately decides, so this list may be a single entry.
+    if (!m_screenTargetsLoaded)
+    {
+        VideoCaptureScreen probe;
+        m_screenTargets       = probe.listDevices();
+        m_screenTargetsLoaded = true;
+    }
+
+    if (ImGui::Button("Refresh targets"))
+    {
+        VideoCaptureScreen probe;
+        m_screenTargets = probe.listDevices();
+    }
+
+    const std::string current = m_uiManager->getCurrentDevice();
+    std::string preview = current.empty() ? "(none)" : current;
+    for (const auto &d : m_screenTargets)
+        if (d.id == current) { preview = d.name; break; }
+
+    ImGui::SetNextItemWidth(-1);
+    if (ImGui::BeginCombo("##screenTarget", preview.c_str()))
+    {
+        for (const auto &d : m_screenTargets)
+        {
+            const bool selected = (d.id == current);
+            if (ImGui::Selectable(d.name.c_str(), selected))
+            {
+                m_uiManager->triggerDeviceChange(d.id);
+                m_uiManager->saveConfig();
+            }
+            if (selected) ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("Target");
+
+    if (!current.empty())
+    {
+        if (ImGui::Button("Stop capture"))
+        {
+            m_uiManager->triggerDeviceChange("");
+            m_uiManager->saveConfig();
+        }
+    }
+
+    ImGui::Separator();
+    ui_section_header("Region (crop)",
+                      "Limit the captured area, in target pixels. "
+                      "All zero = capture the full target.");
+
+    // Seed the ImGui scratch from persisted config once.
+    if (!m_screenRegionSeeded)
+    {
+        m_screenRegion[0] = static_cast<int>(m_uiManager->getScreenRegionX());
+        m_screenRegion[1] = static_cast<int>(m_uiManager->getScreenRegionY());
+        m_screenRegion[2] = static_cast<int>(m_uiManager->getScreenRegionW());
+        m_screenRegion[3] = static_cast<int>(m_uiManager->getScreenRegionH());
+        m_screenRegionSeeded = true;
+    }
+
+    ImGui::InputInt2("x, y", &m_screenRegion[0]);
+    ImGui::InputInt2("w, h", &m_screenRegion[2]);
+    for (int i = 0; i < 4; ++i) if (m_screenRegion[i] < 0) m_screenRegion[i] = 0;
+
+    if (ImGui::Button("Apply region"))
+    {
+        m_uiManager->triggerScreenRegionChange(
+            static_cast<uint32_t>(m_screenRegion[0]), static_cast<uint32_t>(m_screenRegion[1]),
+            static_cast<uint32_t>(m_screenRegion[2]), static_cast<uint32_t>(m_screenRegion[3]));
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Clear region"))
+    {
+        m_screenRegion[0] = m_screenRegion[1] = m_screenRegion[2] = m_screenRegion[3] = 0;
+        m_uiManager->triggerScreenRegionChange(0, 0, 0, 0);
     }
 }
 

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -154,6 +154,15 @@ void UIConfigurationSource::renderSourceTypeSelection()
 
 void UIConfigurationSource::renderV4L2Controls()
 {
+    // Re-fetch the live capture pointer. render() caches it at the top
+    // of the frame, but renderSourceTypeSelection() (called just before
+    // the dispatch here) can switch the source type and rebuild the
+    // backend mid-frame — leaving the cached pointer dangling at the
+    // just-destroyed instance. renderDSControls/AVFoundation already
+    // re-fetch for the same reason; V4L2 didn't, and dereferencing the
+    // stale pointer below segfaulted right after a Screen→V4L2 switch.
+    m_capture = m_uiManager->getCapture();
+
     // Sempre mostrar controles, mesmo sem dispositivo
     // Se não houver dispositivo, mostrar mensagem informativa
     if (!m_capture || !m_capture->isOpen())

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -862,6 +862,129 @@ void UIConfigurationSource::renderScreenControls()
         m_screenRegion[0] = m_screenRegion[1] = m_screenRegion[2] = m_screenRegion[3] = 0;
         m_uiManager->triggerScreenRegionChange(0, 0, 0, 0);
     }
+
+    ImGui::Spacing();
+    if (ImGui::Button("Select region visually…"))
+    {
+        // Remember the current crop, then show the full (uncropped) frame
+        // live so the user marquees against the whole target.
+        for (int i = 0; i < 4; ++i) m_savedRegion[i] = m_screenRegion[i];
+        m_uiManager->applyScreenRegionLive(0, 0, 0, 0);
+        m_haveSelection   = false;
+        m_marqueeActive   = false;
+        m_regionSelectorOpen = true;
+    }
+
+    renderRegionSelector();
+}
+
+void UIConfigurationSource::renderRegionSelector()
+{
+    if (!m_regionSelectorOpen) return;
+
+    ImGui::SetNextWindowSize(ImVec2(820, 640), ImGuiCond_FirstUseEver);
+    bool open = true;
+    if (ImGui::Begin("Select capture region", &open, ImGuiWindowFlags_NoSavedSettings))
+    {
+        const unsigned int tex = m_uiManager->getCaptureTextureId();
+        const float fullW = static_cast<float>(m_uiManager->getCaptureTextureWidth());
+        const float fullH = static_cast<float>(m_uiManager->getCaptureTextureHeight());
+
+        if (tex == 0 || fullW < 1.0f || fullH < 1.0f)
+        {
+            ImGui::TextWrapped("Waiting for a frame — make sure a screen target is "
+                               "being captured.");
+        }
+        else
+        {
+            ImGui::TextDisabled("Drag on the image to mark the region. Full frame: %d x %d",
+                                static_cast<int>(fullW), static_cast<int>(fullH));
+
+            float availW = ImGui::GetContentRegionAvail().x;
+            if (availW < 64.0f) availW = 720.0f;
+            float scale = availW / fullW;
+            if (scale > 1.0f) scale = 1.0f;
+            const float dispW = fullW * scale;
+            const float dispH = fullH * scale;
+
+            const ImVec2 imgPos = ImGui::GetCursorScreenPos();
+            ImGui::Image(static_cast<ImTextureID>(tex), ImVec2(dispW, dispH));
+
+            const ImVec2 mouse = ImGui::GetIO().MousePos;
+            auto clampf = [](float v, float hi) { return v < 0.0f ? 0.0f : (v > hi ? hi : v); };
+            if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(0))
+            {
+                m_selX0 = clampf(mouse.x - imgPos.x, dispW);
+                m_selY0 = clampf(mouse.y - imgPos.y, dispH);
+                m_selX1 = m_selX0;
+                m_selY1 = m_selY0;
+                m_marqueeActive = true;
+                m_haveSelection = true;
+            }
+            if (m_marqueeActive && ImGui::IsMouseDown(0))
+            {
+                m_selX1 = clampf(mouse.x - imgPos.x, dispW);
+                m_selY1 = clampf(mouse.y - imgPos.y, dispH);
+            }
+            if (m_marqueeActive && ImGui::IsMouseReleased(0)) m_marqueeActive = false;
+
+            if (m_haveSelection)
+            {
+                ImDrawList *dl = ImGui::GetWindowDrawList();
+                const ImVec2 a(imgPos.x + std::min(m_selX0, m_selX1),
+                               imgPos.y + std::min(m_selY0, m_selY1));
+                const ImVec2 b(imgPos.x + std::max(m_selX0, m_selX1),
+                               imgPos.y + std::max(m_selY0, m_selY1));
+                dl->AddRectFilled(a, b, IM_COL32(64, 160, 255, 40));
+                dl->AddRect(a, b, IM_COL32(64, 160, 255, 255), 0.0f, 0, 2.0f);
+            }
+
+            const int rx = static_cast<int>(std::min(m_selX0, m_selX1) / scale);
+            const int ry = static_cast<int>(std::min(m_selY0, m_selY1) / scale);
+            const int rw = static_cast<int>((std::max(m_selX0, m_selX1) - std::min(m_selX0, m_selX1)) / scale);
+            const int rh = static_cast<int>((std::max(m_selY0, m_selY1) - std::min(m_selY0, m_selY1)) / scale);
+            ImGui::Text("X %d   Y %d   W %d   H %d", rx, ry, rw, rh);
+
+            const bool valid = m_haveSelection && rw >= 8 && rh >= 8;
+            ImGui::BeginDisabled(!valid);
+            if (ImGui::Button("Apply"))
+            {
+                m_screenRegion[0] = rx; m_screenRegion[1] = ry;
+                m_screenRegion[2] = rw; m_screenRegion[3] = rh;
+                m_uiManager->triggerScreenRegionChange(
+                    static_cast<uint32_t>(rx), static_cast<uint32_t>(ry),
+                    static_cast<uint32_t>(rw), static_cast<uint32_t>(rh));
+                m_regionSelectorOpen = false;
+            }
+            ImGui::EndDisabled();
+            ImGui::SameLine();
+            if (ImGui::Button("Use full frame"))
+            {
+                for (int i = 0; i < 4; ++i) m_screenRegion[i] = 0;
+                m_uiManager->triggerScreenRegionChange(0, 0, 0, 0);
+                m_regionSelectorOpen = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel"))
+            {
+                m_uiManager->triggerScreenRegionChange(
+                    static_cast<uint32_t>(m_savedRegion[0]), static_cast<uint32_t>(m_savedRegion[1]),
+                    static_cast<uint32_t>(m_savedRegion[2]), static_cast<uint32_t>(m_savedRegion[3]));
+                m_regionSelectorOpen = false;
+            }
+        }
+    }
+    ImGui::End();
+
+    // Closed via the window's X → treat as Cancel: restore the crop the
+    // user had before opening the selector.
+    if (!open && m_regionSelectorOpen)
+    {
+        m_uiManager->triggerScreenRegionChange(
+            static_cast<uint32_t>(m_savedRegion[0]), static_cast<uint32_t>(m_savedRegion[1]),
+            static_cast<uint32_t>(m_savedRegion[2]), static_cast<uint32_t>(m_savedRegion[3]));
+        m_regionSelectorOpen = false;
+    }
 }
 
 #ifdef __APPLE__

--- a/src/ui/UIConfigurationSource.cpp
+++ b/src/ui/UIConfigurationSource.cpp
@@ -908,11 +908,19 @@ void UIConfigurationSource::renderRegionSelector()
             const float dispH = fullH * scale;
 
             const ImVec2 imgPos = ImGui::GetCursorScreenPos();
-            ImGui::Image(static_cast<ImTextureID>(tex), ImVec2(dispW, dispH));
+            // Cover the frame with an InvisibleButton so the marquee drag
+            // is captured here instead of moving the window (ImGui::Image
+            // doesn't capture drags, so dragging on it would drag the
+            // window). The texture is drawn underneath via the draw list;
+            // the window then only moves from its title bar.
+            ImGui::InvisibleButton("##regionCanvas", ImVec2(dispW, dispH));
+            ImGui::GetWindowDrawList()->AddImage(
+                static_cast<ImTextureID>(tex), imgPos,
+                ImVec2(imgPos.x + dispW, imgPos.y + dispH));
 
             const ImVec2 mouse = ImGui::GetIO().MousePos;
             auto clampf = [](float v, float hi) { return v < 0.0f ? 0.0f : (v > hi ? hi : v); };
-            if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(0))
+            if (ImGui::IsItemActivated())
             {
                 m_selX0 = clampf(mouse.x - imgPos.x, dispW);
                 m_selY0 = clampf(mouse.y - imgPos.y, dispH);
@@ -921,12 +929,12 @@ void UIConfigurationSource::renderRegionSelector()
                 m_marqueeActive = true;
                 m_haveSelection = true;
             }
-            if (m_marqueeActive && ImGui::IsMouseDown(0))
+            if (m_marqueeActive && ImGui::IsItemActive())
             {
                 m_selX1 = clampf(mouse.x - imgPos.x, dispW);
                 m_selY1 = clampf(mouse.y - imgPos.y, dispH);
             }
-            if (m_marqueeActive && ImGui::IsMouseReleased(0)) m_marqueeActive = false;
+            if (ImGui::IsItemDeactivated()) m_marqueeActive = false;
 
             if (m_haveSelection)
             {

--- a/src/ui/UIConfigurationSource.h
+++ b/src/ui/UIConfigurationSource.h
@@ -73,6 +73,15 @@ private:
     int  m_screenRegion[4] = {0, 0, 0, 0};   // x, y, w, h ImGui input scratch
     bool m_screenRegionSeeded = false;
 
+    // Visual region selector: a window that shows the full (uncropped)
+    // frame and lets the user marquee-drag the crop rectangle.
+    void renderRegionSelector();
+    bool  m_regionSelectorOpen   = false;
+    int   m_savedRegion[4]       = {0, 0, 0, 0}; // restore on cancel
+    bool  m_marqueeActive        = false;        // mid-drag
+    bool  m_haveSelection        = false;
+    float m_selX0 = 0, m_selY0 = 0, m_selX1 = 0, m_selY1 = 0; // image-widget px
+
     // Persistent buffer for the URL ImGui input. Static-on-stack inside
     // render() would lose the typed value across re-renders, so keep it
     // here.

--- a/src/ui/UIConfigurationSource.h
+++ b/src/ui/UIConfigurationSource.h
@@ -4,16 +4,13 @@
 #include <cstdint>
 #include <vector>
 
-#ifdef __APPLE__
-// Pulled in (not forward-declared) because m_avfDevices and
-// m_avfFormats below are std::vector instantiations and need the
-// complete type for size/destructor.
+// Pulled in (not forward-declared) because several members below are
+// std::vector<DeviceInfo> instantiations that need the complete type —
+// m_avfDevices (macOS) and m_screenTargets (#107, all platforms).
 #include "../capture/IVideoCapture.h"
-#endif
 
 // Forward declarations
 class UIManager;
-class IVideoCapture;
 
 /**
  * Source configuration window — was a tab inside the unified
@@ -67,6 +64,14 @@ private:
     // text input + Connect / Disconnect buttons that drive the existing
     // OnDeviceChanged callback flow in Application.
     void renderRemoteControls();
+
+    // #107 — screen-capture source UI: target picker (monitor/window)
+    // plus region-crop fields.
+    void renderScreenControls();
+    std::vector<DeviceInfo> m_screenTargets; // cached enumeration
+    bool m_screenTargetsLoaded = false;
+    int  m_screenRegion[4] = {0, 0, 0, 0};   // x, y, w, h ImGui input scratch
+    bool m_screenRegionSeeded = false;
 
     // Persistent buffer for the URL ImGui input. Static-on-stack inside
     // render() would lose the typed value across re-renders, so keep it

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -40,12 +40,14 @@
 #ifdef USE_SDL2
 #include <SDL2/SDL.h>
 #include <imgui.h>
+#include <imgui_internal.h> // #107 follow-up: clamp off-screen windows back in
 #include <imgui_impl_sdl2.h>
 #include <imgui_impl_opengl3.h>
 #else
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <imgui.h>
+#include <imgui_internal.h> // #107 follow-up: clamp off-screen windows back in
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 #endif
@@ -371,6 +373,48 @@ void UIManager::shutdown()
     m_initialized = false;
 }
 
+// Keep every movable top-level window reachable: if its position drifted
+// outside the viewport (stale imgui.ini after a resolution/monitor change,
+// etc.) nudge it back so at least a grabbable strip of the title bar stays
+// on screen. Runs each frame on last frame's positions and applies before
+// the windows are submitted this frame, so they never paint off-screen.
+static void clampImGuiWindowsToViewport()
+{
+    ImGuiContext *gp = ImGui::GetCurrentContext();
+    if (!gp) return;
+    ImGuiContext &g = *gp;
+
+    const ImGuiViewport *vp = ImGui::GetMainViewport();
+    if (!vp) return;
+    const float minX0 = vp->WorkPos.x;
+    const float minY0 = vp->WorkPos.y;
+    const float maxX0 = vp->WorkPos.x + vp->WorkSize.x;
+    const float maxY0 = vp->WorkPos.y + vp->WorkSize.y;
+    const float keep  = 48.0f; // px of the window that must remain on-screen
+
+    for (ImGuiWindow *w : g.Windows)
+    {
+        if (!w || !w->WasActive) continue;
+        if (w->Flags & (ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_Tooltip |
+                        ImGuiWindowFlags_Popup | ImGuiWindowFlags_NoMove))
+            continue; // children/popups/pinned OSD overlays manage themselves
+        if (w->Size.x <= 0.0f || w->Size.y <= 0.0f) continue;
+
+        ImVec2 pos = w->Pos;
+        const float minX = minX0 - w->Size.x + keep; // allow off the left/right
+        const float maxX = maxX0 - keep;             // edges, keep `keep` visible
+        const float minY = minY0;                    // title must stay below top
+        const float maxY = maxY0 - keep;
+        if (pos.x < minX) pos.x = minX;
+        if (pos.x > maxX) pos.x = maxX;
+        if (pos.y < minY) pos.y = minY;
+        if (pos.y > maxY) pos.y = maxY;
+
+        if (pos.x != w->Pos.x || pos.y != w->Pos.y)
+            ImGui::SetWindowPos(w, pos, ImGuiCond_Always);
+    }
+}
+
 void UIManager::beginFrame()
 {
     if (!m_initialized)
@@ -422,6 +466,10 @@ void UIManager::beginFrame()
         io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
         io.MousePosPrev = ImVec2(-FLT_MAX, -FLT_MAX);
     }
+
+    // Pull any window that drifted off-screen back into the viewport so it
+    // can't get lost at a position that no longer exists on screen.
+    clampImGuiWindowsToViewport();
 }
 
 void UIManager::endFrame()

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -2392,6 +2392,13 @@ void UIManager::triggerRemoteInterpolationChange(const std::string &v)
     saveConfig();
 }
 
+void UIManager::triggerScreenRegionChange(uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+{
+    m_screenRegionX = x; m_screenRegionY = y; m_screenRegionW = w; m_screenRegionH = h;
+    if (m_onScreenRegionChanged) m_onScreenRegionChanged(x, y, w, h);
+    saveConfig();
+}
+
 void UIManager::triggerRemoteAudioVolumeChange(float volume)
 {
     if (volume < 0.0f) volume = 0.0f;
@@ -2986,6 +2993,7 @@ void UIManager::loadConfig()
                 const bool isPlatformNative =
                     loaded == SourceType::None ||
                     loaded == SourceType::Remote ||
+                    loaded == SourceType::Screen ||   // #107 cross-platform
 #ifdef __linux__
                     loaded == SourceType::V4L2;
 #elif defined(_WIN32)
@@ -3022,6 +3030,28 @@ void UIManager::loadConfig()
             {
                 m_currentDevice = ds["device"].get<std::string>();
             }
+        }
+
+        // #107 — screen-capture target + region crop. Region always
+        // round-trips; the target only seeds m_currentDevice when the
+        // active source is Screen (m_currentDevice is shared and the
+        // v4l2/ds blocks above also write it).
+        if (config.contains("screen"))
+        {
+            auto &screen = config["screen"];
+            if (m_sourceType == SourceType::Screen &&
+                screen.contains("target") && !screen["target"].is_null())
+            {
+                m_currentDevice = screen["target"].get<std::string>();
+            }
+            auto getU = [&](const char *k, uint32_t &dst) {
+                if (screen.contains(k) && screen[k].is_number_unsigned())
+                    dst = screen[k].get<uint32_t>();
+            };
+            getU("regionX", m_screenRegionX);
+            getU("regionY", m_screenRegionY);
+            getU("regionW", m_screenRegionW);
+            getU("regionH", m_screenRegionH);
         }
 
         // Carregar configurações de áudio
@@ -3270,6 +3300,14 @@ void UIManager::saveConfig()
         // Salvar dispositivo DirectShow
         config["directshow"] = {
             {"device", m_currentDevice.empty() ? "" : m_currentDevice}};
+
+        // #107 — screen-capture target + region crop.
+        config["screen"] = {
+            {"target",  (m_sourceType == SourceType::Screen) ? m_currentDevice : std::string()},
+            {"regionX", m_screenRegionX},
+            {"regionY", m_screenRegionY},
+            {"regionW", m_screenRegionW},
+            {"regionH", m_screenRegionH}};
 
         // Salvar configurações de áudio
         config["audio"] = {

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -142,6 +142,11 @@ bool UIManager::init(void *window)
     ImGui::CreateContext();
     ImGuiIO &io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    // Move windows only by dragging their title bar (standard desktop
+    // window behaviour). Without this, dragging anywhere in a window's
+    // body moves it — which fought the region-selector marquee and is
+    // generally surprising. Applies to every RetroCapture window.
+    io.ConfigWindowsMoveFromTitleBarOnly = true;
 
     // Anchor the ImGui ini to the user-data dir so window
     // positions/sizes/collapse state survive across runs regardless

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -165,7 +165,8 @@ public:
         V4L2 = 1,
         DS = 2,           // DirectShow (Windows)
         Remote = 3,       // Remote /raw MPEG-TS from another RetroCapture (Phase 3 of #47)
-        AVFoundation = 4  // AVFoundation (macOS)
+        AVFoundation = 4, // AVFoundation (macOS)
+        Screen = 5        // Desktop / window / region screen capture (#107)
     };
 
     // Source type setter (para uso pelas classes de abas)

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -510,6 +510,16 @@ public:
     // #77 client-side volume for the incoming remote audio stream.
     float getRemoteAudioVolume() const { return m_remoteAudioVolume; }
     bool  getRemoteAudioMuted()  const { return m_remoteAudioMuted; }
+    // #107 screen-capture region crop (target pixels; 0,0,0,0 = full).
+    uint32_t getScreenRegionX() const { return m_screenRegionX; }
+    uint32_t getScreenRegionY() const { return m_screenRegionY; }
+    uint32_t getScreenRegionW() const { return m_screenRegionW; }
+    uint32_t getScreenRegionH() const { return m_screenRegionH; }
+    void triggerScreenRegionChange(uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+    void setOnScreenRegionChanged(std::function<void(uint32_t, uint32_t, uint32_t, uint32_t)> cb)
+    {
+        m_onScreenRegionChanged = cb;
+    }
 
     // Streaming setters com callbacks (para uso pelas classes de abas)
     void triggerStreamingPortChange(uint16_t port);
@@ -1210,6 +1220,8 @@ private:
     // preserving the level so unmuting restores it.
     float m_remoteAudioVolume = 1.0f;
     bool  m_remoteAudioMuted  = false;
+    // #107 screen-capture region crop, target pixels (0,0,0,0 = full target).
+    uint32_t m_screenRegionX = 0, m_screenRegionY = 0, m_screenRegionW = 0, m_screenRegionH = 0;
     bool m_streamingActive = false;
     std::string m_streamUrl = "";
     uint32_t m_streamClientCount = 0;
@@ -1333,6 +1345,7 @@ private:
     std::function<void(const std::string &)> m_onStreamingAmfQualityChanged;
     std::function<void(const std::string &)> m_onRemoteInterpolationChanged;
     std::function<void(float)> m_onRemoteAudioVolumeChanged;
+    std::function<void(uint32_t, uint32_t, uint32_t, uint32_t)> m_onScreenRegionChanged;
     std::function<void(size_t)> m_onStreamingMaxVideoBufferSizeChanged;
     std::function<void(size_t)> m_onStreamingMaxAudioBufferSizeChanged;
     std::function<void(int64_t)> m_onStreamingMaxBufferTimeSecondsChanged;

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -520,6 +520,23 @@ public:
     {
         m_onScreenRegionChanged = cb;
     }
+    // Apply a region to the live capture WITHOUT persisting or updating
+    // the stored values — used by the visual region selector to show the
+    // full (uncropped) frame while picking. saveConfig happens only on
+    // the final triggerScreenRegionChange().
+    void applyScreenRegionLive(uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+    {
+        if (m_onScreenRegionChanged) m_onScreenRegionChanged(x, y, w, h);
+    }
+    // Live capture GL texture, published each frame by Application so the
+    // region selector can draw the current frame. 0 == none.
+    void setCaptureTexture(unsigned int tex, uint32_t w, uint32_t h)
+    {
+        m_captureTex = tex; m_captureTexW = w; m_captureTexH = h;
+    }
+    unsigned int getCaptureTextureId() const { return m_captureTex; }
+    uint32_t getCaptureTextureWidth() const  { return m_captureTexW; }
+    uint32_t getCaptureTextureHeight() const { return m_captureTexH; }
 
     // Streaming setters com callbacks (para uso pelas classes de abas)
     void triggerStreamingPortChange(uint16_t port);
@@ -1222,6 +1239,10 @@ private:
     bool  m_remoteAudioMuted  = false;
     // #107 screen-capture region crop, target pixels (0,0,0,0 = full target).
     uint32_t m_screenRegionX = 0, m_screenRegionY = 0, m_screenRegionW = 0, m_screenRegionH = 0;
+    // Live capture texture published by Application for the region selector.
+    unsigned int m_captureTex  = 0;
+    uint32_t     m_captureTexW = 0;
+    uint32_t     m_captureTexH = 0;
     bool m_streamingActive = false;
     std::string m_streamUrl = "";
     uint32_t m_streamClientCount = 0;


### PR DESCRIPTION
Closes #107. Also resolves #97 (source-switch backend reuse) as a side effect.

Adds **screen capture** as a video source across all three platforms, feeding the desktop — a monitor, a window, or a cropped region — into the normal pipeline (shaders / streaming / recording / virtual camera).

## Architecture
- New `VideoCaptureScreen` (`IVideoCapture`) + `SourceType::Screen`, special-cased in `Application` like Remote (not in the platform factory).
- Platform grabbing behind a `ScreenBackend` (pimpl) + `IScreenFrameSink`; backends deliver packed-32-bit frames, the sink crops to the region and uploads with `GL_BGRA`/`GL_RGBA` (driver swizzles to the RGB texture — no CPU colour conversion on the hot path). A test-pattern stub stands in when no real backend is built.

## Per-platform backends
- **Linux** — PipeWire + `xdg-desktop-portal` ScreenCast over libdbus (no GLib). The portal dialog picks the target. Optional **DMABUF zero-copy** via EGL (`eglCreateImage(EGL_LINUX_DMA_BUF)` + `glEGLImageTargetTexture2DOES`), opt-in with `RC_SCREEN_DMABUF=1` while validated. **Validated.**
- **macOS** — ScreenCaptureKit (12.3+): `SCShareableContent` enumerates displays **and** windows; `SCStream` delivers BGRA `CMSampleBuffer`s. Window capture scales by the display's backing factor so Retina windows are grabbed at native pixels (fixes shaders spacing wrong). Needs the `.app` bundle for the Screen-Recording (TCC) permission. **Validated.**
- **Windows** — DXGI Desktop Duplication (D3D11, monitor capture): `AcquireNextFrame` → staging texture → BGRA. **Compiles/links via MXE; runtime validation pending a Windows machine.**

## UI / config
- "Screen" in the source picker (all platforms); target dropdown.
- Region crop: numeric **spin-edits** (±1/±10) **and** a **visual marquee selector** that draws the live full frame and lets you drag the rectangle.
- Persisted under `config["screen"]` (target + region).

## Fixes bundled
- `#97` generalized: `OnSourceTypeChanged` rebuilds the correct backend and clears the stale device — fixes a Screen→V4L2 segfault and a dangling capture pointer in the Source tab (`renderV4L2Controls` now re-fetches).
- ImGui: off-screen windows clamped back into the viewport; windows move only from the title bar.

## Known limitations / follow-ups (non-blocking)
- Linux fps on a **static** screen is bounded by the compositor's damage-driven `wlr-screencopy` rate (labwc + xdg-desktop-portal-wlr), not by RetroCapture — OBS hits the same ceiling on the same setup.
- Windows: cursor compositing + window capture (WGC). GPU-side crop on the DMABUF fast path. Windows runtime validation.

## Testing
- Linux x86_64 + Windows x86_64 (Docker) build clean; macOS native build clean.
- Manually validated on Linux (PipeWire) and macOS (ScreenCaptureKit, display + window + region + shaders).