### PR TITLE
feat(audio): capture system output (monitor/loopback) as an audio source (#109)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,7 @@ if(PLATFORM_LINUX)
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureScreen_mac\\.(mm|h)$") # #107 macOS SCK backend
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*SystemAudioCaptureSCK\\.(mm|h)$") 
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
 
@@ -601,6 +602,7 @@ elseif(PLATFORM_WINDOWS)
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureAVFoundation.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*VideoCaptureScreen_mac\\.(mm|h)$") # #107 macOS SCK backend
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioCaptureCoreAudio.*\\.(mm|h)$")
+    list(FILTER SOURCES EXCLUDE REGEX ".*SystemAudioCaptureSCK\\.(mm|h)$") 
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioOutputCoreAudio.*\\.(mm|h)$")
     list(FILTER SOURCES EXCLUDE REGEX ".*AudioPlaybackCoreAudio\\.(cpp|h)$")
 

--- a/src/audio/AudioCaptureCoreAudio.h
+++ b/src/audio/AudioCaptureCoreAudio.h
@@ -3,6 +3,7 @@
 #include "IAudioCapture.h"
 #include "AudioBus.h"
 #include "IAudioOutput.h"
+#include "SystemAudioCaptureSCK.h" // #109 system-audio (output) capture
 #include <atomic>
 #include <cstdint>
 #include <vector>
@@ -93,6 +94,12 @@ private:
     std::unique_ptr<IAudioOutput>  m_monitor;
     std::shared_ptr<AudioBus::Tap> m_monitorTap;
     std::atomic<bool>              m_monitorRunning{false};
+
+    // #109 — system-audio (output) capture via ScreenCaptureKit. Active
+    // when the synthetic "system-audio" device is selected; the mic
+    // AudioUnit path is bypassed and the local monitor is left off.
+    bool                                  m_systemAudio = false;
+    std::unique_ptr<SystemAudioCaptureSCK> m_sckAudio;
     std::atomic<bool>              m_monitorResyncPending{false};
     std::thread                    m_monitorThread;
 

--- a/src/audio/AudioCaptureCoreAudio.h
+++ b/src/audio/AudioCaptureCoreAudio.h
@@ -3,7 +3,7 @@
 #include "IAudioCapture.h"
 #include "AudioBus.h"
 #include "IAudioOutput.h"
-#include "SystemAudioCaptureSCK.h" // #109 system-audio (output) capture
+#include "SckSystemAudioHub.h" // #109 system-audio (output) capture coordinator
 #include <atomic>
 #include <cstdint>
 #include <vector>
@@ -95,11 +95,11 @@ private:
     std::shared_ptr<AudioBus::Tap> m_monitorTap;
     std::atomic<bool>              m_monitorRunning{false};
 
-    // #109 — system-audio (output) capture via ScreenCaptureKit. Active
-    // when the synthetic "system-audio" device is selected; the mic
-    // AudioUnit path is bypassed and the local monitor is left off.
-    bool                                  m_systemAudio = false;
-    std::unique_ptr<SystemAudioCaptureSCK> m_sckAudio;
+    // #109 — system-audio (output) capture via ScreenCaptureKit, brokered
+    // by SckSystemAudioHub (single-SCStream). Active when the synthetic
+    // "system-audio" device is selected; the mic AudioUnit path is
+    // bypassed and the local monitor is left off.
+    bool m_systemAudio = false;
     std::atomic<bool>              m_monitorResyncPending{false};
     std::thread                    m_monitorThread;
 

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -42,7 +42,7 @@ static OSStatus audioInputCallback(void *inRefCon,
     const unsigned h = ++hitCount;
     if (h <= 3 || (h % 1000) == 0)
     {
-        LOG_INFO("Core Audio input callback HIT #" + std::to_string(h) +
+        LOG_DEBUG("Core Audio input callback HIT #" + std::to_string(h) +
                  " (inNumberFrames=" + std::to_string(inNumberFrames) + ")");
     }
 
@@ -78,7 +78,7 @@ static OSStatus audioInputCallback(void *inRefCon,
         const unsigned n = ++cbCount;
         if (n <= 3 || (n % 1000) == 0)
         {
-            LOG_INFO("Core Audio input callback #" + std::to_string(n) +
+            LOG_DEBUG("Core Audio input callback #" + std::to_string(n) +
                      " — pushed " + std::to_string(tempBuffer.size()) + " samples");
         }
     }
@@ -816,7 +816,7 @@ void AudioCaptureCoreAudio::monitorWriterLoop()
             const unsigned n = ++wCount;
             if (n <= 3 || (n % 1000) == 0)
             {
-                LOG_INFO("Monitor writer iter #" + std::to_string(n) +
+                LOG_DEBUG("Monitor writer iter #" + std::to_string(n) +
                          " — pulled " + std::to_string(got) +
                          " samples, wrote " + std::to_string(written));
             }

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -126,12 +126,28 @@ AudioComponentInstance AudioCaptureCoreAudio::getAudioUnit() const
 }
 #endif
 
+// #109 — synthetic device id for capturing the system audio output.
+static const char *kSystemAudioId = "system-audio";
+
 bool AudioCaptureCoreAudio::open(const std::string &deviceName)
 {
     if (m_isOpen)
     {
         LOG_WARN("Dispositivo de áudio já aberto, fechando primeiro");
         close();
+    }
+
+    // #109 — system audio (output) uses ScreenCaptureKit, not the mic
+    // AudioUnit. No mic permission, no local monitor playback (the user
+    // already hears the system; playing it back would feed back). The
+    // SCStream is started in startCapture().
+    m_systemAudio = (deviceName == kSystemAudioId);
+    if (m_systemAudio)
+    {
+        m_isOpen = true;
+        LOG_INFO("AudioCaptureCoreAudio: system-audio source (ScreenCaptureKit) — "
+                 "local monitor disabled to avoid feedback");
+        return true;
     }
 
 #ifdef __APPLE__
@@ -360,6 +376,18 @@ std::vector<AudioDeviceInfo> AudioCaptureCoreAudio::listDevices()
         defaultDevice.available = true;
         devices.push_back(defaultDevice);
     }
+
+    // #109 — synthetic "system audio" capture (ScreenCaptureKit loopback
+    // of the whole computer's output). Flagged isMonitor so the UI groups
+    // it and shows the feedback note.
+    {
+        AudioDeviceInfo sysAudio;
+        sysAudio.id        = kSystemAudioId;
+        sysAudio.name      = "System audio (ScreenCaptureKit)";
+        sysAudio.available = true;
+        sysAudio.isMonitor = true;
+        devices.push_back(sysAudio);
+    }
 #endif
 
     return devices;
@@ -376,6 +404,18 @@ bool AudioCaptureCoreAudio::startCapture()
     {
         LOG_ERROR("Dispositivo de áudio não aberto");
         return false;
+    }
+
+    if (m_systemAudio)
+    {
+        m_sckAudio = std::make_unique<SystemAudioCaptureSCK>();
+        if (!m_sckAudio->start(m_bus.get(), m_sampleRate, m_channels))
+        {
+            m_sckAudio.reset();
+            return false;
+        }
+        m_isCapturing = true;
+        return true;
     }
 
 #ifdef __APPLE__
@@ -399,6 +439,12 @@ bool AudioCaptureCoreAudio::startCapture()
 void AudioCaptureCoreAudio::stopCapture()
 {
     m_isCapturing = false;
+    if (m_sckAudio)
+    {
+        m_sckAudio->stop();
+        m_sckAudio.reset();
+        return;
+    }
 #ifdef __APPLE__
     if (m_audioUnit)
     {

--- a/src/audio/AudioCaptureCoreAudio.mm
+++ b/src/audio/AudioCaptureCoreAudio.mm
@@ -144,6 +144,10 @@ bool AudioCaptureCoreAudio::open(const std::string &deviceName)
     m_systemAudio = (deviceName == kSystemAudioId);
     if (m_systemAudio)
     {
+        // ScreenCaptureKit delivers 48 kHz stereo float; report that so
+        // the encoder/muxer and the SCStream(s) all agree on the rate.
+        m_sampleRate = 48000;
+        m_channels   = 2;
         m_isOpen = true;
         LOG_INFO("AudioCaptureCoreAudio: system-audio source (ScreenCaptureKit) — "
                  "local monitor disabled to avoid feedback");
@@ -408,12 +412,10 @@ bool AudioCaptureCoreAudio::startCapture()
 
     if (m_systemAudio)
     {
-        m_sckAudio = std::make_unique<SystemAudioCaptureSCK>();
-        if (!m_sckAudio->start(m_bus.get(), m_sampleRate, m_channels))
-        {
-            m_sckAudio.reset();
-            return false;
-        }
+        // Brokered by the hub: routes the screen-capture stream's audio
+        // when screen capture is active, else runs its own audio-only
+        // SCStream — never two SCStreams at once (#109).
+        SckSystemAudioHub::instance().requestSystemAudio(m_bus.get(), m_sampleRate, m_channels);
         m_isCapturing = true;
         return true;
     }
@@ -439,10 +441,9 @@ bool AudioCaptureCoreAudio::startCapture()
 void AudioCaptureCoreAudio::stopCapture()
 {
     m_isCapturing = false;
-    if (m_sckAudio)
+    if (m_systemAudio)
     {
-        m_sckAudio->stop();
-        m_sckAudio.reset();
+        SckSystemAudioHub::instance().releaseSystemAudio();
         return;
     }
 #ifdef __APPLE__

--- a/src/audio/AudioCapturePulse.cpp
+++ b/src/audio/AudioCapturePulse.cpp
@@ -13,6 +13,18 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+namespace
+{
+// PulseAudio names a sink's monitor source "<sink>.monitor". Used to
+// recognise a system-output capture so we can skip local playback (#109).
+bool isMonitorSourceName(const std::string &name)
+{
+    const std::string suffix = ".monitor";
+    return name.size() >= suffix.size() &&
+           name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+} // namespace
+
 AudioCapturePulse::AudioCapturePulse()
     : m_mainloop(nullptr), m_mainloopApi(nullptr), m_context(nullptr), m_stream(nullptr),
       m_sampleRate(44100), m_channels(2), m_bytesPerSample(2),
@@ -284,23 +296,27 @@ bool AudioCapturePulse::open(const std::string &deviceName)
                  "other apps will not see it in the PulseAudio graph");
     }
 
+    // #109 — when capturing an output device's MONITOR (system audio),
+    // do NOT play it back through the default sink: that would feed the
+    // captured output straight back into itself → feedback (microfonia).
+    // The user already hears the system audio from the system, so local
+    // monitoring is simply skipped for monitor sources.
+    const bool capturingSystemOutput = isMonitorSourceName(deviceName);
+
     // Open the host-side monitor playback (the "output" half of the
     // RetroCapture I/O pair). ~2 s tap slack matches the other taps.
     // The two hardware clocks (capture device + default sink) will
     // drift in ppm over long sessions, accumulating in this tap; the
     // bus drop-oldest at the cap is the current safety net. Smooth
     // sample-rate-matching is a follow-up.
+    if (capturingSystemOutput)
     {
-        const size_t monitorCapacity =
-            static_cast<size_t>(m_sampleRate) * m_channels * 2;
-        auto monitorTap = m_bus->createTap(monitorCapacity);
-        m_monitor = std::make_unique<MonitorPlayback>();
-        if (!m_monitor->start(std::move(monitorTap), m_sampleRate, m_channels))
-        {
-            LOG_WARN("AudioCapture: monitor playback failed to start; "
-                     "user will not hear the input through the default sink");
-            m_monitor.reset();
-        }
+        LOG_INFO("AudioCapture: capturing system output '" + deviceName +
+                 "' — local monitor playback disabled to avoid feedback");
+    }
+    else
+    {
+        startMonitorPlayback();
     }
 
     m_isOpen = true;
@@ -566,19 +582,25 @@ void AudioCapturePulse::sourceInfoCallback(pa_context *c, const pa_source_info *
 
     if (i)
     {
-        // Only include non-monitor sources (monitors are virtual sources for sinks)
-        // We want actual audio sources that can be connected to our sink
-        if (i->monitor_of_sink == PA_INVALID_INDEX)
-        {
-            AudioDeviceInfo info;
-            info.id = i->name ? i->name : "";
-            info.name = i->description ? i->description : info.id;
-            info.description = i->description ? i->description : "";
-            info.available = (i->state == PA_SOURCE_RUNNING || i->state == PA_SOURCE_IDLE);
+        // #109 — list BOTH real inputs and sink monitors. Monitors
+        // (monitor_of_sink set) are the "system audio" of an output
+        // device; we flag them so the UI groups them and the capture
+        // skips local playback (feedback). Skip our own published
+        // virtual source's monitor so the user can't capture us.
+        const bool isMonitor = (i->monitor_of_sink != PA_INVALID_INDEX);
+        const std::string name = i->name ? i->name : "";
+        if (isMonitor && name.rfind("RetroCapture", 0) == 0)
+            return; // don't offer capturing our own virtual source
 
-            std::lock_guard<std::mutex> lock(g_sourcesMutex);
-            g_availableSources.push_back(info);
-        }
+        AudioDeviceInfo info;
+        info.id = name;
+        info.name = i->description ? i->description : info.id;
+        info.description = i->description ? i->description : "";
+        info.available = (i->state == PA_SOURCE_RUNNING || i->state == PA_SOURCE_IDLE);
+        info.isMonitor = isMonitor;
+
+        std::lock_guard<std::mutex> lock(g_sourcesMutex);
+        g_availableSources.push_back(info);
     }
 }
 
@@ -735,6 +757,24 @@ static void unloadModuleCallback(pa_context *c, int success, void *userdata)
     g_sinkOperationSuccess = (success == 0);
 }
 
+void AudioCapturePulse::startMonitorPlayback()
+{
+    // ~2 s tap slack matches the other taps. The two hardware clocks
+    // (capture device + default sink) drift in ppm over long sessions,
+    // accumulating in this tap; the bus drop-oldest at the cap is the
+    // current safety net. Smooth sample-rate-matching is a follow-up.
+    const size_t monitorCapacity =
+        static_cast<size_t>(m_sampleRate) * m_channels * 2;
+    auto monitorTap = m_bus->createTap(monitorCapacity);
+    m_monitor = std::make_unique<MonitorPlayback>();
+    if (!m_monitor->start(std::move(monitorTap), m_sampleRate, m_channels))
+    {
+        LOG_WARN("AudioCapture: monitor playback failed to start; "
+                 "user will not hear the input through the default sink");
+        m_monitor.reset();
+    }
+}
+
 bool AudioCapturePulse::connectInputSource(const std::string &sourceName)
 {
     if (sourceName.empty())
@@ -754,6 +794,20 @@ bool AudioCapturePulse::connectInputSource(const std::string &sourceName)
     if (!connectRecordStream(sourceName))
     {
         return false;
+    }
+
+    // #109 — keep the local monitor in sync with the source kind on a
+    // live switch: stop it when moving to a system-output monitor (else
+    // feedback), (re)start it when moving back to a real input.
+    if (isMonitorSourceName(sourceName))
+    {
+        if (m_monitor) { m_monitor->stop(); m_monitor.reset(); }
+        LOG_INFO("AudioCapture: switched to system output '" + sourceName +
+                 "' — local monitor disabled to avoid feedback");
+    }
+    else if (!m_monitor)
+    {
+        startMonitorPlayback();
     }
 
     if (wasCapturing)

--- a/src/audio/AudioCapturePulse.h
+++ b/src/audio/AudioCapturePulse.h
@@ -84,6 +84,11 @@ private:
     static void sourceInfoCallback(pa_context *c, const pa_source_info *i, int eol, void *userdata);
     static void operationCallback(pa_context *c, uint32_t index, void *userdata);
 
+    // #109 — start the local monitor playback (taps the bus to the
+    // default sink). Skipped / stopped when capturing a system-output
+    // monitor source, to avoid a feedback loop.
+    void startMonitorPlayback();
+
     // Internal methods
     void contextStateChanged();
     void streamStateChanged();

--- a/src/audio/AudioCaptureWASAPI.cpp
+++ b/src/audio/AudioCaptureWASAPI.cpp
@@ -99,6 +99,38 @@ bool AudioCaptureWASAPI::selectDevice(const std::string &deviceName)
 
     HRESULT hr = S_OK;
 
+    // #109 — when an explicit endpoint id is given, open exactly that
+    // device and infer loopback from its data flow: a render (output)
+    // endpoint → system-audio loopback; a capture endpoint → normal mic.
+    // This handles selecting a specific output monitor (the old TODO).
+    if (!deviceName.empty() && deviceName != "default")
+    {
+        int wlen = MultiByteToWideChar(CP_UTF8, 0, deviceName.c_str(), -1, nullptr, 0);
+        if (wlen > 0)
+        {
+            std::wstring wid(static_cast<size_t>(wlen), L'\0');
+            MultiByteToWideChar(CP_UTF8, 0, deviceName.c_str(), -1, &wid[0], wlen);
+            IMMDevice *byId = nullptr;
+            if (SUCCEEDED(m_deviceEnumerator->GetDevice(wid.c_str(), &byId)) && byId)
+            {
+                IMMEndpoint *ep = nullptr;
+                EDataFlow flow = eCapture;
+                if (SUCCEEDED(byId->QueryInterface(__uuidof(IMMEndpoint), (void **)&ep)) && ep)
+                {
+                    ep->GetDataFlow(&flow);
+                    SafeRelease(&ep);
+                }
+                m_useLoopback = (flow == eRender);
+                m_device = byId;     // takes ownership
+                m_deviceId = deviceName;
+                LOG_INFO(std::string("AudioCapture: opening endpoint by id (") +
+                         (m_useLoopback ? "render/loopback" : "capture") + ")");
+                return true;
+            }
+        }
+        // Fall through to the legacy name/default matching below.
+    }
+
     // Se usar loopback, obter dispositivo de renderização (output)
     // Caso contrário, obter dispositivo de captura (input/microfone)
     if (m_useLoopback)
@@ -561,79 +593,78 @@ std::vector<AudioDeviceInfo> AudioCaptureWASAPI::listDevices()
         return devices;
     }
 
-    IMMDeviceCollection *deviceCollection = nullptr;
-    HRESULT hr = m_deviceEnumerator->EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE, &deviceCollection);
-    if (FAILED(hr))
-    {
-        return devices;
-    }
+    // #109 — list real inputs (eCapture) AND output endpoints (eRender),
+    // the latter flagged as monitors so they can be captured via WASAPI
+    // loopback (system audio).
+    struct Kind { EDataFlow flow; bool monitor; };
+    const Kind kinds[] = { {eCapture, false}, {eRender, true} };
 
-    UINT deviceCount = 0;
-    hr = deviceCollection->GetCount(&deviceCount);
-    if (FAILED(hr))
+    for (const Kind &k : kinds)
     {
-        SafeRelease(&deviceCollection);
-        return devices;
-    }
+        IMMDeviceCollection *deviceCollection = nullptr;
+        HRESULT hr = m_deviceEnumerator->EnumAudioEndpoints(k.flow, DEVICE_STATE_ACTIVE,
+                                                            &deviceCollection);
+        if (FAILED(hr) || !deviceCollection) continue;
 
-    for (UINT i = 0; i < deviceCount; i++)
-    {
-        IMMDevice *device = nullptr;
-        hr = deviceCollection->Item(i, &device);
-        if (FAILED(hr))
+        UINT deviceCount = 0;
+        if (FAILED(deviceCollection->GetCount(&deviceCount)))
         {
+            SafeRelease(&deviceCollection);
             continue;
         }
 
-        AudioDeviceInfo info;
+        for (UINT i = 0; i < deviceCount; i++)
+        {
+            IMMDevice *device = nullptr;
+            if (FAILED(deviceCollection->Item(i, &device))) continue;
 
-        // Get device ID
-        LPWSTR deviceId = nullptr;
-        hr = device->GetId(&deviceId);
-        if (SUCCEEDED(hr))
-        {
-            char idBuffer[512];
-            WideCharToMultiByte(CP_UTF8, 0, deviceId, -1, idBuffer, sizeof(idBuffer), nullptr, nullptr);
-            info.id = std::string(idBuffer);
-            CoTaskMemFree(deviceId);
-        }
-        else
-        {
-            info.id = std::to_string(i);
-        }
+            AudioDeviceInfo info;
+            info.isMonitor = k.monitor;
 
-        // Get friendly name
-        IPropertyStore *properties = nullptr;
-        hr = device->OpenPropertyStore(STGM_READ, &properties);
-        if (SUCCEEDED(hr))
-        {
-            PROPVARIANT friendlyName;
-            PropVariantInit(&friendlyName);
-            hr = properties->GetValue(PKEY_Device_FriendlyName, &friendlyName);
-            if (SUCCEEDED(hr))
+            LPWSTR deviceId = nullptr;
+            if (SUCCEEDED(device->GetId(&deviceId)))
             {
-                char nameBuffer[512];
-                WideCharToMultiByte(CP_UTF8, 0, friendlyName.pwszVal, -1, nameBuffer, sizeof(nameBuffer), nullptr, nullptr);
-                info.name = std::string(nameBuffer);
-                PropVariantClear(&friendlyName);
+                char idBuffer[512];
+                WideCharToMultiByte(CP_UTF8, 0, deviceId, -1, idBuffer, sizeof(idBuffer), nullptr, nullptr);
+                info.id = std::string(idBuffer);
+                CoTaskMemFree(deviceId);
             }
             else
             {
-                info.name = "Dispositivo " + std::to_string(i);
+                info.id = std::to_string(i);
             }
-            SafeRelease(&properties);
-        }
-        else
-        {
-            info.name = "Dispositivo " + std::to_string(i);
+
+            IPropertyStore *properties = nullptr;
+            if (SUCCEEDED(device->OpenPropertyStore(STGM_READ, &properties)))
+            {
+                PROPVARIANT friendlyName;
+                PropVariantInit(&friendlyName);
+                if (SUCCEEDED(properties->GetValue(PKEY_Device_FriendlyName, &friendlyName)))
+                {
+                    char nameBuffer[512];
+                    WideCharToMultiByte(CP_UTF8, 0, friendlyName.pwszVal, -1, nameBuffer, sizeof(nameBuffer), nullptr, nullptr);
+                    info.name = std::string(nameBuffer);
+                    PropVariantClear(&friendlyName);
+                }
+                else
+                {
+                    info.name = "Device " + std::to_string(i);
+                }
+                SafeRelease(&properties);
+            }
+            else
+            {
+                info.name = "Device " + std::to_string(i);
+            }
+
+            info.available = true;
+            devices.push_back(info);
+            SafeRelease(&device);
         }
 
-        info.available = true;
-        devices.push_back(info);
-        SafeRelease(&device);
+        SafeRelease(&deviceCollection);
     }
 
-    SafeRelease(&deviceCollection);
     return devices;
 }
 

--- a/src/audio/IAudioCapture.h
+++ b/src/audio/IAudioCapture.h
@@ -11,6 +11,11 @@ struct AudioDeviceInfo
     std::string name;        // Human-readable name
     std::string description; // Device description (optional)
     bool available = true;   // Whether device is available
+    // #109 — true when this entry is an output device's monitor/loopback
+    // (system audio) rather than a real input. The UI groups these
+    // separately and the capture skips local monitor playback for them
+    // to avoid a feedback loop.
+    bool isMonitor = false;
 };
 
 /**

--- a/src/audio/SckSystemAudioHub.cpp
+++ b/src/audio/SckSystemAudioHub.cpp
@@ -49,6 +49,14 @@ void SckSystemAudioHub::forwardRealAudioLocked(const int16_t *samples, std::size
         LOG_INFO("SckSystemAudioHub: first real system-audio samples reached the bus");
     }
     m_lastRealPushUs = monotonicUs();
+    m_realSamplesWindow += sampleCount;
+    // Is this buffer actually carrying sound, or did SCK hand us silence?
+    // Peek a few samples so the telemetry can say "real audio but silent"
+    // vs "genuinely no real audio reaching the hub".
+    for (std::size_t i = 0; i < sampleCount; ++i)
+    {
+        if (samples[i] != 0) { m_nonZeroSamplesWindow++; break; }
+    }
     m_consumer->push(samples, sampleCount);
 }
 
@@ -163,6 +171,7 @@ void SckSystemAudioHub::stopKeepaliveAndJoin()
 void SckSystemAudioHub::keepaliveLoop()
 {
     std::vector<int16_t> silence;
+    int64_t lastReportUs = monotonicUs();
     while (m_keepaliveRun.load())
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(kSilenceChunkMs));
@@ -171,19 +180,39 @@ void SckSystemAudioHub::keepaliveLoop()
         if (!m_consumer) continue;
 
         const int64_t now = monotonicUs();
-        if (m_lastRealPushUs != 0 && (now - m_lastRealPushUs) < kSilenceGapUs)
+        const bool realFlowing =
+            (m_lastRealPushUs != 0 && (now - m_lastRealPushUs) < kSilenceGapUs);
+
+        if (!realFlowing)
         {
-            continue; // real audio is flowing; don't double-fill
+            // Fill one chunk of silence so the audio timeline keeps advancing.
+            const size_t frames  = static_cast<size_t>(m_rate) * kSilenceChunkMs / 1000;
+            const size_t samples = frames * m_channels;
+            if (samples != 0)
+            {
+                if (silence.size() != samples) silence.assign(samples, 0);
+                m_consumer->push(silence.data(), silence.size());
+                m_silenceSamplesWindow += samples;
+            }
+            // Note: do NOT update m_lastRealPushUs — that tracks *real* audio
+            // only, so the keepalive keeps filling while silence lasts.
         }
 
-        // Fill one chunk of silence so the audio timeline keeps advancing.
-        const size_t frames  = static_cast<size_t>(m_rate) * kSilenceChunkMs / 1000;
-        const size_t samples = frames * m_channels;
-        if (samples == 0) continue;
-        if (silence.size() != samples) silence.assign(samples, 0);
-        m_consumer->push(silence.data(), silence.size());
-        // Note: do NOT update m_lastRealPushUs — that tracks *real* audio
-        // only, so the keepalive keeps filling for as long as silence lasts.
+        // Telemetry: every ~2 s say what actually reached the bus, so we can
+        // tell real audio from keepalive silence without guessing (#109).
+        if (now - lastReportUs >= 2'000'000)
+        {
+            LOG_INFO("SckSystemAudioHub: last 2s — real=" +
+                     std::to_string(m_realSamplesWindow) + " (nonzero buffers=" +
+                     std::to_string(m_nonZeroSamplesWindow) + "), silence=" +
+                     std::to_string(m_silenceSamplesWindow) +
+                     ", screenActive=" + std::to_string(m_screenActive ? 1 : 0) +
+                     ", ownStream=" + std::to_string(m_ownStream ? 1 : 0));
+            m_realSamplesWindow = 0;
+            m_nonZeroSamplesWindow = 0;
+            m_silenceSamplesWindow = 0;
+            lastReportUs = now;
+        }
     }
 }
 

--- a/src/audio/SckSystemAudioHub.cpp
+++ b/src/audio/SckSystemAudioHub.cpp
@@ -202,7 +202,7 @@ void SckSystemAudioHub::keepaliveLoop()
         // tell real audio from keepalive silence without guessing (#109).
         if (now - lastReportUs >= 2'000'000)
         {
-            LOG_INFO("SckSystemAudioHub: last 2s — real=" +
+            LOG_DEBUG("SckSystemAudioHub: last 2s — real=" +
                      std::to_string(m_realSamplesWindow) + " (nonzero buffers=" +
                      std::to_string(m_nonZeroSamplesWindow) + "), silence=" +
                      std::to_string(m_silenceSamplesWindow) +

--- a/src/audio/SckSystemAudioHub.cpp
+++ b/src/audio/SckSystemAudioHub.cpp
@@ -11,11 +11,14 @@
 
 namespace
 {
-// Inject silence in ~20 ms chunks; treat the timeline as silent once no
-// real audio has arrived for ~60 ms (three chunks). Continuous real audio
-// keeps m_lastRealPushUs fresh so the keepalive never fires mid-playback.
+// Inject silence in ~20 ms chunks, but only as a genuine safety net: once
+// SCK is the producer it delivers continuous audio buffers (even during
+// silence), so the keepalive must never fight real-audio jitter or flood
+// at startup before the first real buffer arrives. We therefore only fill
+// after a longer gap (~250 ms) with no real audio at all — covering a real
+// SCK stall/pause, not normal per-buffer spacing.
 constexpr int64_t kSilenceChunkMs = 20;
-constexpr int64_t kSilenceGapUs   = 60'000; // 60 ms
+constexpr int64_t kSilenceGapUs   = 250'000; // 250 ms
 
 int64_t monotonicUs()
 {
@@ -55,9 +58,11 @@ void SckSystemAudioHub::requestSystemAudio(AudioBus *bus, uint32_t sampleRate, u
     m_consumer = bus;
     m_rate     = sampleRate ? sampleRate : 48000;
     m_channels = channels ? channels : 2;
-    // Reset recency so the keepalive starts filling immediately until the
-    // first real buffer (if any) arrives.
-    m_lastRealPushUs = 0;
+    // Treat the timeline as fresh so the keepalive waits a full gap before
+    // assuming silence — this avoids flooding the bus with silence at
+    // startup (which collided with the first real buffers and overflowed
+    // the audio sync buffer).
+    m_lastRealPushUs = monotonicUs();
     m_loggedFirstReal = false;
 
     if (m_screenActive)

--- a/src/audio/SckSystemAudioHub.cpp
+++ b/src/audio/SckSystemAudioHub.cpp
@@ -1,0 +1,89 @@
+#include "SckSystemAudioHub.h"
+
+#ifdef __APPLE__
+
+#include "AudioBus.h"
+#include "../utils/Logger.h"
+
+SckSystemAudioHub &SckSystemAudioHub::instance()
+{
+    static SckSystemAudioHub hub;
+    return hub;
+}
+
+void SckSystemAudioHub::requestSystemAudio(AudioBus *bus, uint32_t sampleRate, uint32_t channels)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_consumer = bus;
+    m_rate     = sampleRate;
+    m_channels = channels;
+
+    if (m_screenActive)
+    {
+        // Screen capture is already producing audio — route it through
+        // onScreenAudio(); no separate stream (would conflict).
+        LOG_INFO("SckSystemAudioHub: routing screen-capture audio to system-audio source");
+        return;
+    }
+    // No screen stream → run our own audio-only SCStream (the case that
+    // works on its own, e.g. camera + system audio).
+    if (!m_ownStream)
+    {
+        m_ownStream = std::make_unique<SystemAudioCaptureSCK>();
+        if (!m_ownStream->start(bus, sampleRate, channels))
+        {
+            m_ownStream.reset();
+            LOG_WARN("SckSystemAudioHub: audio-only SCStream failed to start");
+        }
+    }
+}
+
+void SckSystemAudioHub::releaseSystemAudio()
+{
+    std::unique_ptr<SystemAudioCaptureSCK> toStop;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_consumer = nullptr;
+        toStop = std::move(m_ownStream); // stop outside the lock
+    }
+    if (toStop) toStop->stop();
+}
+
+void SckSystemAudioHub::setScreenProducerActive(bool active)
+{
+    std::unique_ptr<SystemAudioCaptureSCK> toStop;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_screenActive = active;
+        if (active)
+        {
+            // Screen now provides audio — drop our redundant own stream
+            // (two SCStreams conflict). Its audio arrives via onScreenAudio.
+            toStop = std::move(m_ownStream);
+        }
+        else if (m_consumer && !m_ownStream)
+        {
+            // Screen stopped but a consumer still wants system audio —
+            // bring our own audio-only stream back up.
+            m_ownStream = std::make_unique<SystemAudioCaptureSCK>();
+            if (!m_ownStream->start(m_consumer, m_rate, m_channels))
+            {
+                m_ownStream.reset();
+            }
+        }
+    }
+    if (toStop) toStop->stop();
+}
+
+void SckSystemAudioHub::onScreenAudio(const int16_t *samples, std::size_t sampleCount)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    // Only forward while the screen stream is the active producer (when
+    // it isn't, the own audio-only stream pushes to the bus directly).
+    if (m_consumer && m_screenActive && samples && sampleCount)
+    {
+        m_consumer->push(samples, sampleCount);
+    }
+}
+
+#endif // __APPLE__

--- a/src/audio/SckSystemAudioHub.cpp
+++ b/src/audio/SckSystemAudioHub.cpp
@@ -5,37 +5,85 @@
 #include "AudioBus.h"
 #include "../utils/Logger.h"
 
+#include <chrono>
+#include <ctime>
+#include <vector>
+
+namespace
+{
+// Inject silence in ~20 ms chunks; treat the timeline as silent once no
+// real audio has arrived for ~60 ms (three chunks). Continuous real audio
+// keeps m_lastRealPushUs fresh so the keepalive never fires mid-playback.
+constexpr int64_t kSilenceChunkMs = 20;
+constexpr int64_t kSilenceGapUs   = 60'000; // 60 ms
+
+int64_t monotonicUs()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<int64_t>(ts.tv_sec) * 1'000'000LL +
+           static_cast<int64_t>(ts.tv_nsec) / 1'000LL;
+}
+} // namespace
+
 SckSystemAudioHub &SckSystemAudioHub::instance()
 {
     static SckSystemAudioHub hub;
     return hub;
 }
 
+SckSystemAudioHub::~SckSystemAudioHub()
+{
+    stopKeepaliveAndJoin();
+}
+
+void SckSystemAudioHub::forwardRealAudioLocked(const int16_t *samples, std::size_t sampleCount)
+{
+    if (!m_consumer || !samples || !sampleCount) return;
+    if (!m_loggedFirstReal)
+    {
+        m_loggedFirstReal = true;
+        LOG_INFO("SckSystemAudioHub: first real system-audio samples reached the bus");
+    }
+    m_lastRealPushUs = monotonicUs();
+    m_consumer->push(samples, sampleCount);
+}
+
 void SckSystemAudioHub::requestSystemAudio(AudioBus *bus, uint32_t sampleRate, uint32_t channels)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_consumer = bus;
-    m_rate     = sampleRate;
-    m_channels = channels;
+    m_rate     = sampleRate ? sampleRate : 48000;
+    m_channels = channels ? channels : 2;
+    // Reset recency so the keepalive starts filling immediately until the
+    // first real buffer (if any) arrives.
+    m_lastRealPushUs = 0;
+    m_loggedFirstReal = false;
 
     if (m_screenActive)
     {
         // Screen capture is already producing audio — route it through
         // onScreenAudio(); no separate stream (would conflict).
         LOG_INFO("SckSystemAudioHub: routing screen-capture audio to system-audio source");
-        return;
     }
-    // No screen stream → run our own audio-only SCStream (the case that
-    // works on its own, e.g. camera + system audio).
-    if (!m_ownStream)
+    else if (!m_ownStream)
     {
+        // No screen stream → run our own audio-only SCStream (the case that
+        // works on its own, e.g. camera + system audio).
         m_ownStream = std::make_unique<SystemAudioCaptureSCK>();
-        if (!m_ownStream->start(bus, sampleRate, channels))
+        if (!m_ownStream->start(
+                [this](const int16_t *s, std::size_t n) {
+                    std::lock_guard<std::mutex> l(m_mutex);
+                    forwardRealAudioLocked(s, n);
+                },
+                m_rate, m_channels))
         {
             m_ownStream.reset();
             LOG_WARN("SckSystemAudioHub: audio-only SCStream failed to start");
         }
     }
+
+    startKeepaliveLocked();
 }
 
 void SckSystemAudioHub::releaseSystemAudio()
@@ -46,6 +94,7 @@ void SckSystemAudioHub::releaseSystemAudio()
         m_consumer = nullptr;
         toStop = std::move(m_ownStream); // stop outside the lock
     }
+    stopKeepaliveAndJoin();
     if (toStop) toStop->stop();
 }
 
@@ -66,7 +115,12 @@ void SckSystemAudioHub::setScreenProducerActive(bool active)
             // Screen stopped but a consumer still wants system audio —
             // bring our own audio-only stream back up.
             m_ownStream = std::make_unique<SystemAudioCaptureSCK>();
-            if (!m_ownStream->start(m_consumer, m_rate, m_channels))
+            if (!m_ownStream->start(
+                    [this](const int16_t *s, std::size_t n) {
+                        std::lock_guard<std::mutex> l(m_mutex);
+                        forwardRealAudioLocked(s, n);
+                    },
+                    m_rate, m_channels))
             {
                 m_ownStream.reset();
             }
@@ -79,10 +133,52 @@ void SckSystemAudioHub::onScreenAudio(const int16_t *samples, std::size_t sample
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     // Only forward while the screen stream is the active producer (when
-    // it isn't, the own audio-only stream pushes to the bus directly).
-    if (m_consumer && m_screenActive && samples && sampleCount)
+    // it isn't, the own audio-only stream pushes through forwardRealAudio).
+    if (m_screenActive)
     {
-        m_consumer->push(samples, sampleCount);
+        forwardRealAudioLocked(samples, sampleCount);
+    }
+}
+
+void SckSystemAudioHub::startKeepaliveLocked()
+{
+    if (m_keepaliveRun.load()) return;
+    m_keepaliveRun.store(true);
+    m_keepalive = std::thread(&SckSystemAudioHub::keepaliveLoop, this);
+}
+
+void SckSystemAudioHub::stopKeepaliveAndJoin()
+{
+    if (m_keepaliveRun.exchange(false))
+    {
+        if (m_keepalive.joinable()) m_keepalive.join();
+    }
+}
+
+void SckSystemAudioHub::keepaliveLoop()
+{
+    std::vector<int16_t> silence;
+    while (m_keepaliveRun.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(kSilenceChunkMs));
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (!m_consumer) continue;
+
+        const int64_t now = monotonicUs();
+        if (m_lastRealPushUs != 0 && (now - m_lastRealPushUs) < kSilenceGapUs)
+        {
+            continue; // real audio is flowing; don't double-fill
+        }
+
+        // Fill one chunk of silence so the audio timeline keeps advancing.
+        const size_t frames  = static_cast<size_t>(m_rate) * kSilenceChunkMs / 1000;
+        const size_t samples = frames * m_channels;
+        if (samples == 0) continue;
+        if (silence.size() != samples) silence.assign(samples, 0);
+        m_consumer->push(silence.data(), silence.size());
+        // Note: do NOT update m_lastRealPushUs — that tracks *real* audio
+        // only, so the keepalive keeps filling for as long as silence lasts.
     }
 }
 

--- a/src/audio/SckSystemAudioHub.h
+++ b/src/audio/SckSystemAudioHub.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// macOS-only. Coordinates ScreenCaptureKit system-audio so there is only
+// ever ONE SCStream alive — running two (the screen-capture video stream
+// + a separate audio stream) makes the audio one go silent (#109).
+//
+// - The screen-capture SCStream (VideoCaptureScreen_mac) captures audio
+//   too and feeds it here (onScreenAudio + setScreenProducerActive).
+// - The system-audio capture (AudioCaptureCoreAudio) asks the hub for
+//   audio (requestSystemAudio). The hub routes the screen stream's audio
+//   to it when screen capture is active; otherwise it spins up its own
+//   audio-only SCStream (the camera + system-audio case, which works).
+#ifdef __APPLE__
+
+#include "SystemAudioCaptureSCK.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+
+class AudioBus;
+
+class SckSystemAudioHub
+{
+public:
+    static SckSystemAudioHub &instance();
+
+    // Screen-capture side (the video SCStream that also captures audio).
+    void setScreenProducerActive(bool active);
+    void onScreenAudio(const int16_t *samples, std::size_t sampleCount);
+
+    // System-audio consumer side (the audio capture wanting system audio).
+    void requestSystemAudio(AudioBus *bus, uint32_t sampleRate, uint32_t channels);
+    void releaseSystemAudio();
+
+private:
+    SckSystemAudioHub() = default;
+
+    std::mutex                              m_mutex;
+    AudioBus                               *m_consumer = nullptr;
+    uint32_t                                m_rate = 48000;
+    uint32_t                                m_channels = 2;
+    bool                                    m_screenActive = false;
+    std::unique_ptr<SystemAudioCaptureSCK>  m_ownStream; // audio-only fallback
+};
+
+#endif // __APPLE__

--- a/src/audio/SckSystemAudioHub.h
+++ b/src/audio/SckSystemAudioHub.h
@@ -69,6 +69,11 @@ private:
     std::atomic<bool>                       m_keepaliveRun{false};
     int64_t                                 m_lastRealPushUs = 0;
     bool                                    m_loggedFirstReal = false;
+
+    // Telemetry (real vs keepalive silence reaching the bus), reset every 2s.
+    uint64_t                                m_realSamplesWindow = 0;
+    uint64_t                                m_nonZeroSamplesWindow = 0;
+    uint64_t                                m_silenceSamplesWindow = 0;
 };
 
 #endif // __APPLE__

--- a/src/audio/SckSystemAudioHub.h
+++ b/src/audio/SckSystemAudioHub.h
@@ -10,14 +10,25 @@
 //   audio (requestSystemAudio). The hub routes the screen stream's audio
 //   to it when screen capture is active; otherwise it spins up its own
 //   audio-only SCStream (the camera + system-audio case, which works).
+//
+// Silence keepalive: system output can be genuinely silent, and SCK does
+// not always deliver buffers while nothing is playing. The mic path never
+// hit this because a mic always produces samples. Without a steady audio
+// timeline the stream's MediaSynchronizer holds video waiting for audio,
+// overflows, and the encoder serves nothing (the "stream dies after a
+// while" symptom). So whenever a system-audio consumer is active and no
+// real audio has arrived recently, the hub injects silence into the bus
+// to keep the timeline advancing exactly like a mic would.
 #ifdef __APPLE__
 
 #include "SystemAudioCaptureSCK.h"
 
+#include <atomic>
 #include <cstdint>
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <thread>
 
 class AudioBus;
 
@@ -36,6 +47,15 @@ public:
 
 private:
     SckSystemAudioHub() = default;
+    ~SckSystemAudioHub();
+
+    // Forward real captured audio to the consumer and mark the timeline
+    // alive so the silence keepalive backs off. Caller must hold m_mutex.
+    void forwardRealAudioLocked(const int16_t *samples, std::size_t sampleCount);
+
+    void startKeepaliveLocked();
+    void stopKeepaliveAndJoin();
+    void keepaliveLoop();
 
     std::mutex                              m_mutex;
     AudioBus                               *m_consumer = nullptr;
@@ -43,6 +63,12 @@ private:
     uint32_t                                m_channels = 2;
     bool                                    m_screenActive = false;
     std::unique_ptr<SystemAudioCaptureSCK>  m_ownStream; // audio-only fallback
+
+    // Silence keepalive.
+    std::thread                             m_keepalive;
+    std::atomic<bool>                       m_keepaliveRun{false};
+    int64_t                                 m_lastRealPushUs = 0;
+    bool                                    m_loggedFirstReal = false;
 };
 
 #endif // __APPLE__

--- a/src/audio/SystemAudioCaptureSCK.h
+++ b/src/audio/SystemAudioCaptureSCK.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+class AudioBus;
+
+/**
+ * macOS system-audio capture via ScreenCaptureKit (macOS 13+), #109.
+ *
+ * Captures the computer's output audio (a loopback there is none of
+ * natively in Core Audio) by running an audio-only SCStream and pushing
+ * the PCM into the shared AudioBus, same as the mic path. Isolated from
+ * AudioCaptureCoreAudio's AudioUnit code so it can't disturb mic capture.
+ *
+ * Feedback (microfonia) is avoided two ways: the caller disables the
+ * local monitor playback when capturing system audio, and the stream is
+ * configured with excludesCurrentProcessAudio so our own output never
+ * appears in the captured mix.
+ */
+class SystemAudioCaptureSCK
+{
+public:
+    SystemAudioCaptureSCK();
+    ~SystemAudioCaptureSCK();
+
+    // Begin capturing system audio into `bus` at the given format. The
+    // bus outlives this object (owned by AudioCaptureCoreAudio). Returns
+    // false on an immediate setup failure (frames still arrive async).
+    bool start(AudioBus *bus, uint32_t sampleRate, uint32_t channels);
+    void stop();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};

--- a/src/audio/SystemAudioCaptureSCK.h
+++ b/src/audio/SystemAudioCaptureSCK.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
-
-class AudioBus;
 
 /**
  * macOS system-audio capture via ScreenCaptureKit (macOS 13+), #109.
@@ -24,10 +24,15 @@ public:
     SystemAudioCaptureSCK();
     ~SystemAudioCaptureSCK();
 
-    // Begin capturing system audio into `bus` at the given format. The
-    // bus outlives this object (owned by AudioCaptureCoreAudio). Returns
-    // false on an immediate setup failure (frames still arrive async).
-    bool start(AudioBus *bus, uint32_t sampleRate, uint32_t channels);
+    // Interleaved int16 PCM sink, invoked on SCK's audio queue for each
+    // captured buffer. Routed through SckSystemAudioHub so it can track
+    // recency and run the silence keepalive.
+    using SampleSink = std::function<void(const int16_t *, std::size_t)>;
+
+    // Begin capturing system audio, delivering samples to `sink` at the
+    // given format. Returns false on an immediate setup failure (buffers
+    // still arrive async).
+    bool start(SampleSink sink, uint32_t sampleRate, uint32_t channels);
     void stop();
 
 private:

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -1,0 +1,188 @@
+#include "SystemAudioCaptureSCK.h"
+
+// Compiled only on macOS (the CMake glob excludes it elsewhere). Guarded
+// anyway for safety.
+#ifdef __APPLE__
+
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#import <CoreMedia/CoreMedia.h>
+
+#include "AudioBus.h"
+#include "../utils/Logger.h"
+
+#include <vector>
+
+// ── delegate: pulls float PCM out of the audio sample buffers ────────
+API_AVAILABLE(macos(13.0))
+@interface RCSystemAudioDelegate : NSObject <SCStreamOutput, SCStreamDelegate>
+{
+@public
+    AudioBus *bus;
+    uint32_t  channels;
+}
+@end
+
+@implementation RCSystemAudioDelegate
+- (void)stream:(SCStream *)stream
+    didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+                   ofType:(SCStreamOutputType)type
+{
+    (void)stream;
+    if (type != SCStreamOutputTypeAudio || bus == nullptr) return;
+    if (!CMSampleBufferIsValid(sampleBuffer)) return;
+
+    AudioBufferList abl;
+    CMBlockBufferRef block = nullptr;
+    const OSStatus s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+        sampleBuffer, nullptr, &abl, sizeof(abl), nullptr, nullptr,
+        kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block);
+    if (s != noErr || !block) return;
+
+    if (abl.mNumberBuffers == 1)
+    {
+        // Interleaved float already — push as-is.
+        const float *src = static_cast<const float *>(abl.mBuffers[0].mData);
+        const size_t n   = abl.mBuffers[0].mDataByteSize / sizeof(float);
+        if (src && n) bus->push(src, n);
+    }
+    else
+    {
+        // Planar float (one buffer per channel) — interleave for the bus.
+        const uint32_t ch     = abl.mNumberBuffers;
+        const uint32_t frames = abl.mBuffers[0].mDataByteSize / sizeof(float);
+        if (frames)
+        {
+            std::vector<float> inter(static_cast<size_t>(frames) * ch);
+            for (uint32_t c = 0; c < ch; ++c)
+            {
+                const float *src = static_cast<const float *>(abl.mBuffers[c].mData);
+                if (!src) continue;
+                for (uint32_t f = 0; f < frames; ++f)
+                    inter[static_cast<size_t>(f) * ch + c] = src[f];
+            }
+            bus->push(inter.data(), inter.size());
+        }
+    }
+    CFRelease(block);
+}
+
+- (void)stream:(SCStream *)stream didStopWithError:(NSError *)error
+{
+    (void)stream;
+    LOG_WARN(std::string("SystemAudioCaptureSCK: stream stopped — ") +
+             (error ? error.localizedDescription.UTF8String : "?"));
+}
+@end
+
+struct SystemAudioCaptureSCK::Impl
+{
+    SCStream             *stream   = nil;
+    RCSystemAudioDelegate *delegate = nil;
+};
+
+SystemAudioCaptureSCK::SystemAudioCaptureSCK() : m_impl(new Impl) {}
+SystemAudioCaptureSCK::~SystemAudioCaptureSCK() { stop(); }
+
+bool SystemAudioCaptureSCK::start(AudioBus *bus, uint32_t sampleRate, uint32_t channels)
+{
+    if (@available(macOS 13.0, *))
+    {
+        // Fetch shareable content (need a display for the filter). The
+        // completion runs on a background queue, so blocking here is safe.
+        __block SCShareableContent *content = nil;
+        dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+        [SCShareableContent getShareableContentWithCompletionHandler:
+            ^(SCShareableContent *c, NSError *e) {
+                if (c) content = [c retain];
+                (void)e;
+                dispatch_semaphore_signal(sem);
+            }];
+        dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW,
+                                                   (int64_t)(5 * NSEC_PER_SEC)));
+        if (!content || content.displays.count == 0)
+        {
+            LOG_ERROR("SystemAudioCaptureSCK: no shareable content "
+                      "(screen-recording permission?)");
+            [content release];
+            return false;
+        }
+
+        SCContentFilter *filter =
+            [[SCContentFilter alloc] initWithDisplay:content.displays[0]
+                                    excludingWindows:@[]];
+
+        SCStreamConfiguration *cfg = [[SCStreamConfiguration alloc] init];
+        cfg.capturesAudio = YES;
+        cfg.sampleRate    = (NSInteger)sampleRate;
+        cfg.channelCount  = (NSInteger)channels;
+        cfg.excludesCurrentProcessAudio = YES; // never capture ourselves
+        // Minimal video — we only consume audio, but a filter/stream
+        // always has a video plane. Keep it tiny and slow.
+        cfg.width  = 2;
+        cfg.height = 2;
+        cfg.minimumFrameInterval = CMTimeMake(1, 1);
+
+        m_impl->delegate = [[RCSystemAudioDelegate alloc] init];
+        m_impl->delegate->bus      = bus;
+        m_impl->delegate->channels = channels;
+
+        m_impl->stream = [[SCStream alloc] initWithFilter:filter
+                                            configuration:cfg
+                                                 delegate:m_impl->delegate];
+        [filter release];
+        [cfg release];
+
+        dispatch_queue_t q = dispatch_queue_create("com.retrocapture.sck.audio",
+                                                   DISPATCH_QUEUE_SERIAL);
+        NSError *addErr = nil;
+        const BOOL added = [m_impl->stream addStreamOutput:m_impl->delegate
+                                                      type:SCStreamOutputTypeAudio
+                                        sampleHandlerQueue:q
+                                                     error:&addErr];
+        dispatch_release(q);
+        if (!added)
+        {
+            LOG_ERROR(std::string("SystemAudioCaptureSCK: addStreamOutput(audio) failed — ") +
+                      (addErr ? addErr.localizedDescription.UTF8String : "?"));
+            [m_impl->stream release]; m_impl->stream = nil;
+            [m_impl->delegate release]; m_impl->delegate = nil;
+            [content release];
+            return false;
+        }
+
+        [m_impl->stream startCaptureWithCompletionHandler:^(NSError *e) {
+            if (e)
+                LOG_ERROR(std::string("SystemAudioCaptureSCK: startCapture failed — ") +
+                          e.localizedDescription.UTF8String);
+            else
+                LOG_INFO("SystemAudioCaptureSCK: capturing system audio " +
+                         std::to_string(sampleRate) + " Hz x " +
+                         std::to_string(channels) + " ch");
+        }];
+
+        [content release];
+        return true;
+    }
+    LOG_ERROR("SystemAudioCaptureSCK: system-audio capture needs macOS 13+");
+    return false;
+}
+
+void SystemAudioCaptureSCK::stop()
+{
+    if (@available(macOS 13.0, *))
+    {
+        if (m_impl && m_impl->stream)
+        {
+            [m_impl->stream stopCaptureWithCompletionHandler:^(NSError *e) { (void)e; }];
+            [m_impl->stream release];
+            m_impl->stream = nil;
+        }
+        if (m_impl && m_impl->delegate)
+        {
+            [m_impl->delegate release];
+            m_impl->delegate = nil;
+        }
+    }
+}
+
+#endif // __APPLE__

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -63,7 +63,7 @@ API_AVAILABLE(macos(13.0))
     if (!loggedFmt)
     {
         loggedFmt = true;
-        LOG_INFO("SystemAudioCaptureSCK: extracted audio, buffers=" +
+        LOG_DEBUG("SystemAudioCaptureSCK: extracted audio, buffers=" +
                  std::to_string(abl->mNumberBuffers));
     }
 

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -7,9 +7,9 @@
 #import <ScreenCaptureKit/ScreenCaptureKit.h>
 #import <CoreMedia/CoreMedia.h>
 
-#include "AudioBus.h"
 #include "../utils/Logger.h"
 
+#include <functional>
 #include <vector>
 
 // ── delegate: pulls float PCM out of the audio sample buffers ────────
@@ -17,8 +17,10 @@ API_AVAILABLE(macos(13.0))
 @interface RCSystemAudioDelegate : NSObject <SCStreamOutput, SCStreamDelegate>
 {
 @public
-    AudioBus *bus;
-    uint32_t  channels;
+    // Pointer to the std::function owned by Impl (trivial ivar — avoids a
+    // non-trivial C++ ivar in a non-ARC ObjC object).
+    SystemAudioCaptureSCK::SampleSink *sink;
+    uint32_t                           channels;
 }
 @end
 
@@ -28,7 +30,7 @@ API_AVAILABLE(macos(13.0))
                    ofType:(SCStreamOutputType)type
 {
     (void)stream;
-    if (type != SCStreamOutputTypeAudio || bus == nullptr) return;
+    if (type != SCStreamOutputTypeAudio || sink == nullptr || !*sink) return;
     if (!CMSampleBufferIsValid(sampleBuffer)) return;
 
     static bool loggedFirst = false;
@@ -62,7 +64,7 @@ API_AVAILABLE(macos(13.0))
         {
             std::vector<int16_t> out(n);
             for (size_t i = 0; i < n; ++i) out[i] = toI16(src[i]);
-            bus->push(out.data(), out.size());
+            (*sink)(out.data(), out.size());
         }
     }
     else
@@ -80,7 +82,7 @@ API_AVAILABLE(macos(13.0))
                 for (uint32_t f = 0; f < frames; ++f)
                     inter[static_cast<size_t>(f) * ch + c] = toI16(src[f]);
             }
-            bus->push(inter.data(), inter.size());
+            (*sink)(inter.data(), inter.size());
         }
     }
     CFRelease(block);
@@ -96,14 +98,15 @@ API_AVAILABLE(macos(13.0))
 
 struct SystemAudioCaptureSCK::Impl
 {
-    SCStream             *stream   = nil;
+    SCStream              *stream   = nil;
     RCSystemAudioDelegate *delegate = nil;
+    SampleSink             sink;     // owned here; delegate holds a pointer
 };
 
 SystemAudioCaptureSCK::SystemAudioCaptureSCK() : m_impl(new Impl) {}
 SystemAudioCaptureSCK::~SystemAudioCaptureSCK() { stop(); }
 
-bool SystemAudioCaptureSCK::start(AudioBus *bus, uint32_t sampleRate, uint32_t channels)
+bool SystemAudioCaptureSCK::start(SampleSink sink, uint32_t sampleRate, uint32_t channels)
 {
     if (@available(macOS 13.0, *))
     {
@@ -143,8 +146,10 @@ bool SystemAudioCaptureSCK::start(AudioBus *bus, uint32_t sampleRate, uint32_t c
         cfg.height = 72;
         cfg.minimumFrameInterval = CMTimeMake(1, 1);
 
+        m_impl->sink = std::move(sink);
+
         m_impl->delegate = [[RCSystemAudioDelegate alloc] init];
-        m_impl->delegate->bus      = bus;
+        m_impl->delegate->sink     = &m_impl->sink;
         m_impl->delegate->channels = channels;
 
         m_impl->stream = [[SCStream alloc] initWithFilter:filter

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -38,27 +38,40 @@ API_AVAILABLE(macos(13.0))
         kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block);
     if (s != noErr || !block) return;
 
+    // The AudioBus stores interleaved int16; SCK delivers float32. Convert
+    // (clamp + scale) into int16 before pushing.
+    auto toI16 = [](float f) -> int16_t {
+        if (f >  1.0f) f =  1.0f;
+        if (f < -1.0f) f = -1.0f;
+        return static_cast<int16_t>(f * 32767.0f);
+    };
+
     if (abl.mNumberBuffers == 1)
     {
-        // Interleaved float already — push as-is.
+        // Single buffer: interleaved float for all channels.
         const float *src = static_cast<const float *>(abl.mBuffers[0].mData);
         const size_t n   = abl.mBuffers[0].mDataByteSize / sizeof(float);
-        if (src && n) bus->push(src, n);
+        if (src && n)
+        {
+            std::vector<int16_t> out(n);
+            for (size_t i = 0; i < n; ++i) out[i] = toI16(src[i]);
+            bus->push(out.data(), out.size());
+        }
     }
     else
     {
-        // Planar float (one buffer per channel) — interleave for the bus.
+        // Planar float (one buffer per channel) — interleave to int16.
         const uint32_t ch     = abl.mNumberBuffers;
         const uint32_t frames = abl.mBuffers[0].mDataByteSize / sizeof(float);
         if (frames)
         {
-            std::vector<float> inter(static_cast<size_t>(frames) * ch);
+            std::vector<int16_t> inter(static_cast<size_t>(frames) * ch);
             for (uint32_t c = 0; c < ch; ++c)
             {
                 const float *src = static_cast<const float *>(abl.mBuffers[c].mData);
                 if (!src) continue;
                 for (uint32_t f = 0; f < frames; ++f)
-                    inter[static_cast<size_t>(f) * ch + c] = src[f];
+                    inter[static_cast<size_t>(f) * ch + c] = toI16(src[f]);
             }
             bus->push(inter.data(), inter.size());
         }

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -31,6 +31,13 @@ API_AVAILABLE(macos(13.0))
     if (type != SCStreamOutputTypeAudio || bus == nullptr) return;
     if (!CMSampleBufferIsValid(sampleBuffer)) return;
 
+    static bool loggedFirst = false;
+    if (!loggedFirst)
+    {
+        loggedFirst = true;
+        LOG_INFO("SystemAudioCaptureSCK: first audio buffer received");
+    }
+
     AudioBufferList abl;
     CMBlockBufferRef block = nullptr;
     const OSStatus s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
@@ -129,10 +136,11 @@ bool SystemAudioCaptureSCK::start(AudioBus *bus, uint32_t sampleRate, uint32_t c
         cfg.sampleRate    = (NSInteger)sampleRate;
         cfg.channelCount  = (NSInteger)channels;
         cfg.excludesCurrentProcessAudio = YES; // never capture ourselves
-        // Minimal video — we only consume audio, but a filter/stream
-        // always has a video plane. Keep it tiny and slow.
-        cfg.width  = 2;
-        cfg.height = 2;
+        // We only consume audio, but an SCStream always has a video plane.
+        // Keep it small but valid (2x2 can be rejected and stop the stream
+        // from starting) and slow.
+        cfg.width  = 128;
+        cfg.height = 72;
         cfg.minimumFrameInterval = CMTimeMake(1, 1);
 
         m_impl->delegate = [[RCSystemAudioDelegate alloc] init];

--- a/src/audio/SystemAudioCaptureSCK.mm
+++ b/src/audio/SystemAudioCaptureSCK.mm
@@ -40,12 +40,32 @@ API_AVAILABLE(macos(13.0))
         LOG_INFO("SystemAudioCaptureSCK: first audio buffer received");
     }
 
-    AudioBufferList abl;
+    // SCK delivers stereo, frequently as PLANAR float (one buffer per
+    // channel). A fixed `AudioBufferList abl; sizeof(abl)` only has room for
+    // ONE buffer, so the extract call fails ("array too small") for planar
+    // stereo and we silently dropped every real audio buffer (#109). Query
+    // the needed size first, then allocate an AudioBufferList that big.
+    size_t ablSize = 0;
+    OSStatus s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+        sampleBuffer, &ablSize, nullptr, 0, nullptr, nullptr,
+        kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, nullptr);
+    if (s != noErr || ablSize == 0) return;
+
+    AudioBufferList *abl = static_cast<AudioBufferList *>(malloc(ablSize));
+    if (!abl) return;
     CMBlockBufferRef block = nullptr;
-    const OSStatus s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
-        sampleBuffer, nullptr, &abl, sizeof(abl), nullptr, nullptr,
+    s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+        sampleBuffer, nullptr, abl, ablSize, nullptr, nullptr,
         kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block);
-    if (s != noErr || !block) return;
+    if (s != noErr || !block) { free(abl); return; }
+
+    static bool loggedFmt = false;
+    if (!loggedFmt)
+    {
+        loggedFmt = true;
+        LOG_INFO("SystemAudioCaptureSCK: extracted audio, buffers=" +
+                 std::to_string(abl->mNumberBuffers));
+    }
 
     // The AudioBus stores interleaved int16; SCK delivers float32. Convert
     // (clamp + scale) into int16 before pushing.
@@ -55,11 +75,11 @@ API_AVAILABLE(macos(13.0))
         return static_cast<int16_t>(f * 32767.0f);
     };
 
-    if (abl.mNumberBuffers == 1)
+    if (abl->mNumberBuffers == 1)
     {
         // Single buffer: interleaved float for all channels.
-        const float *src = static_cast<const float *>(abl.mBuffers[0].mData);
-        const size_t n   = abl.mBuffers[0].mDataByteSize / sizeof(float);
+        const float *src = static_cast<const float *>(abl->mBuffers[0].mData);
+        const size_t n   = abl->mBuffers[0].mDataByteSize / sizeof(float);
         if (src && n)
         {
             std::vector<int16_t> out(n);
@@ -70,14 +90,14 @@ API_AVAILABLE(macos(13.0))
     else
     {
         // Planar float (one buffer per channel) — interleave to int16.
-        const uint32_t ch     = abl.mNumberBuffers;
-        const uint32_t frames = abl.mBuffers[0].mDataByteSize / sizeof(float);
+        const uint32_t ch     = abl->mNumberBuffers;
+        const uint32_t frames = abl->mBuffers[0].mDataByteSize / sizeof(float);
         if (frames)
         {
             std::vector<int16_t> inter(static_cast<size_t>(frames) * ch);
             for (uint32_t c = 0; c < ch; ++c)
             {
-                const float *src = static_cast<const float *>(abl.mBuffers[c].mData);
+                const float *src = static_cast<const float *>(abl->mBuffers[c].mData);
                 if (!src) continue;
                 for (uint32_t f = 0; f < frames; ++f)
                     inter[static_cast<size_t>(f) * ch + c] = toI16(src[f]);
@@ -86,6 +106,7 @@ API_AVAILABLE(macos(13.0))
         }
     }
     CFRelease(block);
+    free(abl);
 }
 
 - (void)stream:(SCStream *)stream didStopWithError:(NSError *)error

--- a/src/capture/VideoCaptureAVFoundation.mm
+++ b/src/capture/VideoCaptureAVFoundation.mm
@@ -1171,7 +1171,7 @@ bool VideoCaptureAVFoundation::setFramerate(uint32_t fps)
                              "framerate padrão do dispositivo");
                 }
                 
-                LOG_INFO("==============================");
+                LOG_DEBUG("==============================");
                 
                 [m_captureDevice unlockForConfiguration];
                 
@@ -1271,16 +1271,16 @@ bool VideoCaptureAVFoundation::captureLatestFrame(Frame &frame)
         static int conversionLogCount = 0;
         if (conversionLogCount++ % 150 == 0) // Log every 150 frames (~5 seconds at 30fps)
         {
-            LOG_INFO("=== CONVERSION PERFORMANCE ===");
-            LOG_INFO("BGRA→YUYV conversion time: " + std::to_string(duration) + " ms");
-            LOG_INFO("Frame size: " + std::to_string(m_width) + "x" + std::to_string(m_height));
+            LOG_DEBUG("=== CONVERSION PERFORMANCE ===");
+            LOG_DEBUG("BGRA→YUYV conversion time: " + std::to_string(duration) + " ms");
+            LOG_DEBUG("Frame size: " + std::to_string(m_width) + "x" + std::to_string(m_height));
             if (duration > 33) // More than 1 frame at 30fps
             {
                 LOG_WARN("Conversion is taking too long! This will limit framerate.");
                 LOG_WARN("At " + std::to_string(duration) + " ms per frame, max FPS is ~" + 
                          std::to_string(1000 / duration) + " fps");
             }
-            LOG_INFO("=============================");
+            LOG_DEBUG("=============================");
         }
         
         CVPixelBufferRelease(pb);
@@ -1882,7 +1882,7 @@ bool VideoCaptureAVFoundation::startCapture()
                         double devMinFps = 1.0 / CMTimeGetSeconds(devMin);
                         double devMaxFps = 1.0 / CMTimeGetSeconds(devMax);
                         LOG_INFO("Device framerate: " + std::to_string(devMinFps) + " - " + std::to_string(devMaxFps) + " fps");
-                        LOG_INFO("==============================");
+                        LOG_DEBUG("==============================");
                     }
                     else
                     {
@@ -2129,22 +2129,22 @@ bool VideoCaptureAVFoundation::convertPixelBufferToFrame(CVPixelBufferRef pixelB
     static int dimensionLogCount = 0;
     if (dimensionLogCount++ < 5)
     {
-        LOG_INFO("=== PIXEL BUFFER DIMENSIONS ===");
-        LOG_INFO("PixelBuffer: " + std::to_string(width) + "x" + std::to_string(height));
-        LOG_INFO("Requested (m_width/m_height): " + std::to_string(m_width) + "x" + std::to_string(m_height));
+        LOG_DEBUG("=== PIXEL BUFFER DIMENSIONS ===");
+        LOG_DEBUG("PixelBuffer: " + std::to_string(width) + "x" + std::to_string(height));
+        LOG_DEBUG("Requested (m_width/m_height): " + std::to_string(m_width) + "x" + std::to_string(m_height));
         if (m_width > 0 && m_height > 0)
         {
             float requestedAspect = static_cast<float>(m_width) / static_cast<float>(m_height);
             float actualAspect = static_cast<float>(width) / static_cast<float>(height);
-            LOG_INFO("Requested aspect: " + std::to_string(requestedAspect));
-            LOG_INFO("Actual aspect: " + std::to_string(actualAspect));
+            LOG_DEBUG("Requested aspect: " + std::to_string(requestedAspect));
+            LOG_DEBUG("Actual aspect: " + std::to_string(actualAspect));
             if (std::abs(requestedAspect - actualAspect) > 0.01f)
             {
                 LOG_WARN("Aspect ratio mismatch! Requested: " + std::to_string(requestedAspect) + 
                          ", Actual: " + std::to_string(actualAspect));
             }
         }
-        LOG_INFO("==============================");
+        LOG_DEBUG("==============================");
     }
     
     // Converter BGRA para YUYV
@@ -2670,7 +2670,7 @@ bool VideoCaptureAVFoundation::applyFormatAndFramerate(AVCaptureDeviceFormat* fo
                     }
                 }
                 
-                LOG_INFO("================================================");
+                LOG_DEBUG("================================================");
             }
             
             [m_captureDevice unlockForConfiguration];

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -43,6 +43,12 @@ API_AVAILABLE(macos(12.3))
     // hands it to the system-audio source.
     if (type == SCStreamOutputTypeAudio)
     {
+        static bool loggedFirstScreenAudio = false;
+        if (!loggedFirstScreenAudio)
+        {
+            loggedFirstScreenAudio = true;
+            LOG_INFO("VideoCaptureScreen(sck): first audio buffer received from screen stream");
+        }
         AudioBufferList abl;
         CMBlockBufferRef block = nullptr;
         if (CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
@@ -231,6 +237,12 @@ private:
         // window's filter is built from.
         SCContentFilter *filter = nil;
         uint32_t capW = 0, capH = 0;
+        // ScreenCaptureKit only captures system audio with a DISPLAY filter;
+        // capturesAudio is silently ignored for desktop-independent window
+        // capture (#109). So we only let the screen stream act as the audio
+        // producer when grabbing a full display — otherwise the hub runs its
+        // own audio-only display stream.
+        bool isDisplayCapture = false;
 
         if (target.rfind("window:", 0) == 0)
         {
@@ -288,6 +300,7 @@ private:
                                             excludingWindows:@[]];
             capW = (uint32_t)display.width;
             capH = (uint32_t)display.height;
+            isDisplayCapture = true;
         }
 
         if (!filter || capW == 0 || capH == 0)
@@ -307,17 +320,29 @@ private:
         cfg.queueDepth = 5;
         cfg.showsCursor = captureCursor ? YES : NO;
 
-        // #109 — capture system audio on this same stream (macOS 13+) so
-        // the system-audio source doesn't need a second SCStream (two
-        // conflict). 48 kHz stereo to match the audio bus.
+        // #109 — capture system audio on this same stream (macOS 13+) when
+        // grabbing a full display, so the system-audio source doesn't need a
+        // second SCStream. For window capture SCK won't deliver audio, so we
+        // leave it off and the hub falls back to its own display-filter
+        // audio stream. 48 kHz stereo to match the audio bus.
         bool wantAudio = false;
         if (@available(macOS 13.0, *))
         {
-            cfg.capturesAudio = YES;
-            cfg.sampleRate    = 48000;
-            cfg.channelCount  = 2;
-            cfg.excludesCurrentProcessAudio = YES; // never capture ourselves
-            wantAudio = true;
+            if (isDisplayCapture)
+            {
+                cfg.capturesAudio = YES;
+                cfg.sampleRate    = 48000;
+                cfg.channelCount  = 2;
+                cfg.excludesCurrentProcessAudio = YES; // never capture ourselves
+                wantAudio = true;
+            }
+            LOG_INFO(std::string("VideoCaptureScreen(sck): macOS 13+, ") +
+                     (isDisplayCapture ? "display capture — system audio ON this stream"
+                                       : "window capture — system audio via separate stream"));
+        }
+        else
+        {
+            LOG_INFO("VideoCaptureScreen(sck): macOS < 13 — no SCK audio on this stream");
         }
 
         m_delegate = [[RCScreenDelegate alloc] init];
@@ -348,6 +373,7 @@ private:
                            sampleHandlerQueue:aq
                                         error:&aErr])
                 {
+                    LOG_INFO("VideoCaptureScreen(sck): audio output added — screen stream is the system-audio producer");
                     SckSystemAudioHub::instance().setScreenProducerActive(true);
                 }
                 else

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -14,6 +14,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 
 #include "../utils/Logger.h"
+#include "../audio/SckSystemAudioHub.h" // #109 route screen audio → system-audio
 
 #include <atomic>
 #include <cstdint>
@@ -35,8 +36,59 @@ API_AVAILABLE(macos(12.3))
                    ofType:(SCStreamOutputType)type
 {
     (void)stream;
-    if (type != SCStreamOutputTypeScreen || sink == nullptr) return;
     if (!CMSampleBufferIsValid(sampleBuffer)) return;
+
+    // #109 — audio rides on the same SCStream (running a second stream
+    // just for audio makes it go silent). Forward it to the hub, which
+    // hands it to the system-audio source.
+    if (type == SCStreamOutputTypeAudio)
+    {
+        AudioBufferList abl;
+        CMBlockBufferRef block = nullptr;
+        if (CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+                sampleBuffer, nullptr, &abl, sizeof(abl), nullptr, nullptr,
+                kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block) == noErr &&
+            block)
+        {
+            auto toI16 = [](float f) -> int16_t {
+                if (f >  1.0f) f =  1.0f;
+                if (f < -1.0f) f = -1.0f;
+                return static_cast<int16_t>(f * 32767.0f);
+            };
+            if (abl.mNumberBuffers == 1)
+            {
+                const float *src = static_cast<const float *>(abl.mBuffers[0].mData);
+                const size_t n   = abl.mBuffers[0].mDataByteSize / sizeof(float);
+                if (src && n)
+                {
+                    std::vector<int16_t> out(n);
+                    for (size_t i = 0; i < n; ++i) out[i] = toI16(src[i]);
+                    SckSystemAudioHub::instance().onScreenAudio(out.data(), out.size());
+                }
+            }
+            else
+            {
+                const uint32_t ch     = abl.mNumberBuffers;
+                const uint32_t frames = abl.mBuffers[0].mDataByteSize / sizeof(float);
+                if (frames)
+                {
+                    std::vector<int16_t> inter(static_cast<size_t>(frames) * ch);
+                    for (uint32_t c = 0; c < ch; ++c)
+                    {
+                        const float *src = static_cast<const float *>(abl.mBuffers[c].mData);
+                        if (!src) continue;
+                        for (uint32_t f = 0; f < frames; ++f)
+                            inter[static_cast<size_t>(f) * ch + c] = toI16(src[f]);
+                    }
+                    SckSystemAudioHub::instance().onScreenAudio(inter.data(), inter.size());
+                }
+            }
+            CFRelease(block);
+        }
+        return;
+    }
+
+    if (type != SCStreamOutputTypeScreen || sink == nullptr) return;
 
     CVImageBufferRef px = CMSampleBufferGetImageBuffer(sampleBuffer);
     if (!px) return;
@@ -107,6 +159,9 @@ public:
     void stop() override
     {
         if (!m_running.exchange(false)) return;
+        // #109 — tell the hub the screen audio producer is gone (it will
+        // fall back to its own audio-only stream if a consumer remains).
+        SckSystemAudioHub::instance().setScreenProducerActive(false);
         if (@available(macOS 12.3, *))
         {
             if (m_stream)
@@ -252,6 +307,19 @@ private:
         cfg.queueDepth = 5;
         cfg.showsCursor = captureCursor ? YES : NO;
 
+        // #109 — capture system audio on this same stream (macOS 13+) so
+        // the system-audio source doesn't need a second SCStream (two
+        // conflict). 48 kHz stereo to match the audio bus.
+        bool wantAudio = false;
+        if (@available(macOS 13.0, *))
+        {
+            cfg.capturesAudio = YES;
+            cfg.sampleRate    = 48000;
+            cfg.channelCount  = 2;
+            cfg.excludesCurrentProcessAudio = YES; // never capture ourselves
+            wantAudio = true;
+        }
+
         m_delegate = [[RCScreenDelegate alloc] init];
         m_delegate->sink = &m_sink;
 
@@ -268,6 +336,28 @@ private:
                                           type:SCStreamOutputTypeScreen
                             sampleHandlerQueue:q
                                          error:&addErr];
+        if (added && wantAudio)
+        {
+            if (@available(macOS 13.0, *))
+            {
+                dispatch_queue_t aq = dispatch_queue_create("com.retrocapture.sck.audio",
+                                                           DISPATCH_QUEUE_SERIAL);
+                NSError *aErr = nil;
+                if ([m_stream addStreamOutput:m_delegate
+                                         type:SCStreamOutputTypeAudio
+                           sampleHandlerQueue:aq
+                                        error:&aErr])
+                {
+                    SckSystemAudioHub::instance().setScreenProducerActive(true);
+                }
+                else
+                {
+                    LOG_WARN(std::string("VideoCaptureScreen(sck): audio output add failed — ") +
+                             (aErr ? aErr.localizedDescription.UTF8String : "?"));
+                }
+                dispatch_release(aq);
+            }
+        }
         dispatch_release(q);
         if (!added)
         {

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -72,7 +72,7 @@ API_AVAILABLE(macos(12.3))
             if (!loggedFmt)
             {
                 loggedFmt = true;
-                LOG_INFO("VideoCaptureScreen(sck): extracted screen audio, buffers=" +
+                LOG_DEBUG("VideoCaptureScreen(sck): extracted screen audio, buffers=" +
                          std::to_string(abl->mNumberBuffers));
             }
             auto toI16 = [](float f) -> int16_t {

--- a/src/capture/VideoCaptureScreen_mac.mm
+++ b/src/capture/VideoCaptureScreen_mac.mm
@@ -49,22 +49,41 @@ API_AVAILABLE(macos(12.3))
             loggedFirstScreenAudio = true;
             LOG_INFO("VideoCaptureScreen(sck): first audio buffer received from screen stream");
         }
-        AudioBufferList abl;
+        // SCK stereo audio is often PLANAR float (one buffer per channel);
+        // a fixed sizeof(AudioBufferList) only fits ONE buffer, so the
+        // extract call fails for planar stereo and we silently dropped all
+        // real audio (telemetry showed real=0, only keepalive silence) — the
+        // client got video with a silent audio track (#109). Query the size,
+        // then allocate an AudioBufferList big enough for every channel.
+        size_t ablSize = 0;
+        OSStatus s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer, &ablSize, nullptr, 0, nullptr, nullptr,
+            kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, nullptr);
+        if (s != noErr || ablSize == 0) return;
+        AudioBufferList *abl = static_cast<AudioBufferList *>(malloc(ablSize));
+        if (!abl) return;
         CMBlockBufferRef block = nullptr;
-        if (CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
-                sampleBuffer, nullptr, &abl, sizeof(abl), nullptr, nullptr,
-                kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block) == noErr &&
-            block)
+        s = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer, nullptr, abl, ablSize, nullptr, nullptr,
+            kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &block);
+        if (s == noErr && block)
         {
+            static bool loggedFmt = false;
+            if (!loggedFmt)
+            {
+                loggedFmt = true;
+                LOG_INFO("VideoCaptureScreen(sck): extracted screen audio, buffers=" +
+                         std::to_string(abl->mNumberBuffers));
+            }
             auto toI16 = [](float f) -> int16_t {
                 if (f >  1.0f) f =  1.0f;
                 if (f < -1.0f) f = -1.0f;
                 return static_cast<int16_t>(f * 32767.0f);
             };
-            if (abl.mNumberBuffers == 1)
+            if (abl->mNumberBuffers == 1)
             {
-                const float *src = static_cast<const float *>(abl.mBuffers[0].mData);
-                const size_t n   = abl.mBuffers[0].mDataByteSize / sizeof(float);
+                const float *src = static_cast<const float *>(abl->mBuffers[0].mData);
+                const size_t n   = abl->mBuffers[0].mDataByteSize / sizeof(float);
                 if (src && n)
                 {
                     std::vector<int16_t> out(n);
@@ -74,14 +93,14 @@ API_AVAILABLE(macos(12.3))
             }
             else
             {
-                const uint32_t ch     = abl.mNumberBuffers;
-                const uint32_t frames = abl.mBuffers[0].mDataByteSize / sizeof(float);
+                const uint32_t ch     = abl->mNumberBuffers;
+                const uint32_t frames = abl->mBuffers[0].mDataByteSize / sizeof(float);
                 if (frames)
                 {
                     std::vector<int16_t> inter(static_cast<size_t>(frames) * ch);
                     for (uint32_t c = 0; c < ch; ++c)
                     {
-                        const float *src = static_cast<const float *>(abl.mBuffers[c].mData);
+                        const float *src = static_cast<const float *>(abl->mBuffers[c].mData);
                         if (!src) continue;
                         for (uint32_t f = 0; f < frames; ++f)
                             inter[static_cast<size_t>(f) * ch + c] = toI16(src[f]);
@@ -91,6 +110,7 @@ API_AVAILABLE(macos(12.3))
             }
             CFRelease(block);
         }
+        free(abl);
         return;
     }
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -4181,11 +4181,11 @@ void Application::run()
             static int originalCaptureLogCount = 0;
             if (originalCaptureLogCount++ < 3)
             {
-                LOG_INFO("=== ORIGINAL CAPTURE TEXTURE ===");
-                LOG_INFO("Original capture texture: " + std::to_string(m_frameProcessor->getTexture()) +
+                LOG_DEBUG("=== ORIGINAL CAPTURE TEXTURE ===");
+                LOG_DEBUG("Original capture texture: " + std::to_string(m_frameProcessor->getTexture()) +
                          ", Size: " + std::to_string(m_frameProcessor->getTextureWidth()) + "x" + 
                          std::to_string(m_frameProcessor->getTextureHeight()));
-                LOG_INFO("================================");
+                LOG_DEBUG("================================");
             }
             
             // Apply shader if active
@@ -4329,11 +4329,11 @@ void Application::run()
                 static int shaderOutputLogCount = 0;
                 if (shaderOutputLogCount++ < 3)
                 {
-                    LOG_INFO("=== SHADER OUTPUT ===");
-                    LOG_INFO("Shader output texture: " + std::to_string(textureToRender) +
+                    LOG_DEBUG("=== SHADER OUTPUT ===");
+                    LOG_DEBUG("Shader output texture: " + std::to_string(textureToRender) +
                              ", Output size: " + std::to_string(m_shaderEngine->getOutputWidth()) + "x" + 
                              std::to_string(m_shaderEngine->getOutputHeight()));
-                    LOG_INFO("=====================");
+                    LOG_DEBUG("=====================");
                 }
 
                 // DEBUG: Check returned texture
@@ -4443,18 +4443,18 @@ void Application::run()
             static int pipelineResLogCount = 0;
             if (pipelineResLogCount++ < 3)
             {
-                LOG_INFO("=== PIPELINE RESOLUTIONS ===");
-                LOG_INFO("Original capture: " + 
+                LOG_DEBUG("=== PIPELINE RESOLUTIONS ===");
+                LOG_DEBUG("Original capture: " + 
                          std::to_string(m_frameProcessor->getTextureWidth()) + "x" + std::to_string(m_frameProcessor->getTextureHeight()));
-                LOG_INFO("Shader output (renderWidth/Height): " + std::to_string(renderWidth) + "x" + std::to_string(renderHeight));
+                LOG_DEBUG("Shader output (renderWidth/Height): " + std::to_string(renderWidth) + "x" + std::to_string(renderHeight));
                 if (isShaderTexture)
                 {
-                    LOG_INFO("Shader engine output: " + std::to_string(m_shaderEngine->getOutputWidth()) + "x" + 
+                    LOG_DEBUG("Shader engine output: " + std::to_string(m_shaderEngine->getOutputWidth()) + "x" + 
                              std::to_string(m_shaderEngine->getOutputHeight()));
                 }
-                LOG_INFO("Output resolution (m_outputWidth/Height): " + std::to_string(m_outputWidth) + "x" + std::to_string(m_outputHeight));
-                LOG_INFO("textureToRender: " + std::to_string(textureToRender) + ", isShaderTexture: " + std::string(isShaderTexture ? "yes" : "no"));
-                LOG_INFO("===========================");
+                LOG_DEBUG("Output resolution (m_outputWidth/Height): " + std::to_string(m_outputWidth) + "x" + std::to_string(m_outputHeight));
+                LOG_DEBUG("textureToRender: " + std::to_string(textureToRender) + ", isShaderTexture: " + std::string(isShaderTexture ? "yes" : "no"));
+                LOG_DEBUG("===========================");
             }
             
             // Garantir que renderWidth e renderHeight são válidos (não 0)
@@ -4579,7 +4579,7 @@ void Application::run()
             static int finalResLogCount = 0;
             if (finalResLogCount++ < 3)
             {
-                LOG_INFO("Final texture resolutions - finalTexture: " + std::to_string(finalTexture) +
+                LOG_DEBUG("Final texture resolutions - finalTexture: " + std::to_string(finalTexture) +
                          ", finalRenderWidth: " + std::to_string(finalRenderWidth) +
                          ", finalRenderHeight: " + std::to_string(finalRenderHeight));
             }
@@ -4650,7 +4650,7 @@ void Application::run()
             static int finalTextureSizeLogCount = 0;
             if (needsFrameCapture && finalTextureSizeLogCount++ < 3)
             {
-                LOG_INFO("Frame capture: finalTexture=" + std::to_string(finalTexture) + 
+                LOG_DEBUG("Frame capture: finalTexture=" + std::to_string(finalTexture) + 
                          ", finalRenderWidth=" + std::to_string(finalRenderWidth) + 
                          ", finalRenderHeight=" + std::to_string(finalRenderHeight) +
                          ", renderWidth=" + std::to_string(renderWidth) +
@@ -4760,17 +4760,17 @@ void Application::run()
                             static int captureSourceLogCount = 0;
                             if (captureSourceLogCount++ < 3)
                             {
-                                LOG_INFO("=== FRAME CAPTURE DEBUG ===");
-                                LOG_INFO("Original capture: " + 
+                                LOG_DEBUG("=== FRAME CAPTURE DEBUG ===");
+                                LOG_DEBUG("Original capture: " + 
                                          std::to_string(m_frameProcessor->getTextureWidth()) + "x" + std::to_string(m_frameProcessor->getTextureHeight()));
                                 if (isShaderTexture)
                                 {
-                                    LOG_INFO("Shader engine output: " + 
+                                    LOG_DEBUG("Shader engine output: " + 
                                              std::to_string(m_shaderEngine->getOutputWidth()) + "x" + std::to_string(m_shaderEngine->getOutputHeight()));
                                 }
                                 LOG_INFO("renderWidth/Height: " + std::to_string(renderWidth) + "x" + std::to_string(renderHeight));
                                 LOG_INFO("finalRenderWidth/Height: " + std::to_string(finalRenderWidth) + "x" + std::to_string(finalRenderHeight));
-                                LOG_INFO("Output resolution: " + std::to_string(m_outputWidth) + "x" + std::to_string(m_outputHeight));
+                                LOG_DEBUG("Output resolution: " + std::to_string(m_outputWidth) + "x" + std::to_string(m_outputHeight));
                                 
                                 if (m_recordingManager && m_recordingManager->isRecording())
                                 {
@@ -4782,11 +4782,11 @@ void Application::run()
                                     LOG_INFO("Streaming resolution: " + std::to_string(m_ui->getStreamingWidth()) + "x" + std::to_string(m_ui->getStreamingHeight()));
                                 }
                                 
-                                LOG_INFO("Selected - textureToCapture: " + std::to_string(textureToCapture) +
+                                LOG_DEBUG("Selected - textureToCapture: " + std::to_string(textureToCapture) +
                                          ", size: " + std::to_string(captureTextureWidth) + "x" + std::to_string(captureTextureHeight));
-                                LOG_INFO("Textures - textureToRender: " + std::to_string(textureToRender) +
+                                LOG_DEBUG("Textures - textureToRender: " + std::to_string(textureToRender) +
                                          ", finalTexture: " + std::to_string(finalTexture));
-                                LOG_INFO("===========================");
+                                LOG_DEBUG("===========================");
                             }
                         }
                         
@@ -4955,7 +4955,7 @@ void Application::run()
                                 static int formatLogCount = 0;
                                 if (formatLogCount++ < 3)
                                 {
-                                    LOG_INFO("Frame capture: Using format " + std::string(isShaderTexture ? "RGBA" : "RGB") +
+                                    LOG_DEBUG("Frame capture: Using format " + std::string(isShaderTexture ? "RGBA" : "RGB") +
                                              " for texture " + std::to_string(finalTexture) +
                                              " (shader active: " + std::string(isShaderTexture ? "yes" : "no") + ")");
                                 }
@@ -4972,25 +4972,25 @@ void Application::run()
                                              (m_streamManager && m_streamManager->isActive()));
                             if (shouldLog)
                             {
-                                LOG_INFO("=== CAPTURE DETAILS ===");
-                                LOG_INFO("Capturing from texture: " + std::to_string(textureToCapture) +
+                                LOG_DEBUG("=== CAPTURE DETAILS ===");
+                                LOG_DEBUG("Capturing from texture: " + std::to_string(textureToCapture) +
                                          ", Size: " + std::to_string(textureWidth) + "x" + std::to_string(textureHeight));
                                 if (m_recordingManager && m_recordingManager->isRecording())
                                 {
                                     RecordingSettings recSettings = m_recordingManager->getRecordingSettings();
                                     LOG_INFO("Recording target: " + 
                                              std::to_string(recSettings.width) + "x" + std::to_string(recSettings.height));
-                                    LOG_INFO("Will resize for recording: " + std::string(
+                                    LOG_DEBUG("Will resize for recording: " + std::string(
                                         (textureWidth != recSettings.width || textureHeight != recSettings.height) ? "YES" : "NO"));
                                 }
                                 if (m_streamManager && m_streamManager->isActive() && m_ui)
                                 {
-                                    LOG_INFO("Streaming target: " + 
+                                    LOG_DEBUG("Streaming target: " + 
                                              std::to_string(m_ui->getStreamingWidth()) + "x" + std::to_string(m_ui->getStreamingHeight()));
-                                    LOG_INFO("Will resize for streaming: " + std::string(
+                                    LOG_DEBUG("Will resize for streaming: " + std::string(
                                         (textureWidth != m_ui->getStreamingWidth() || textureHeight != m_ui->getStreamingHeight()) ? "YES" : "NO"));
                                 }
-                                LOG_INFO("======================");
+                                LOG_DEBUG("======================");
                             }
                             
                             size_t rgbDataSize = static_cast<size_t>(textureWidth) * static_cast<size_t>(textureHeight) * 3;
@@ -5004,7 +5004,7 @@ void Application::run()
                             {
                                 GLint currentViewport[4];
                                 glGetIntegerv(GL_VIEWPORT, currentViewport);
-                                LOG_INFO("Frame capture: Viewport set to " +
+                                LOG_DEBUG("Frame capture: Viewport set to " +
                                              std::to_string(textureWidth) + "x" + std::to_string(textureHeight) +
                                              ", actual viewport: [" + std::to_string(currentViewport[0]) + "," +
                                              std::to_string(currentViewport[1]) + "," +
@@ -5253,11 +5253,11 @@ void Application::run()
                                     static int streamPushLogCount = 0;
                                     if (streamPushLogCount++ < 3 && m_ui)
                                     {
-                                        LOG_INFO("--- PUSHING FRAME TO STREAMING ---");
-                                        LOG_INFO("Frame size being pushed: " + std::to_string(useSource ? sourceFrameW : actualCaptureWidth) + "x" + std::to_string(useSource ? sourceFrameH : actualCaptureHeight) +
+                                        LOG_DEBUG("--- PUSHING FRAME TO STREAMING ---");
+                                        LOG_DEBUG("Frame size being pushed: " + std::to_string(useSource ? sourceFrameW : actualCaptureWidth) + "x" + std::to_string(useSource ? sourceFrameH : actualCaptureHeight) +
                                                  (useSource ? " (raw source — shader bypassed)" : ""));
-                                        LOG_INFO("Streaming target resolution: " + std::to_string(m_ui->getStreamingWidth()) + "x" + std::to_string(m_ui->getStreamingHeight()));
-                                        LOG_INFO("----------------------------------");
+                                        LOG_DEBUG("Streaming target resolution: " + std::to_string(m_ui->getStreamingWidth()) + "x" + std::to_string(m_ui->getStreamingHeight()));
+                                        LOG_DEBUG("----------------------------------");
                                     }
                                     if (useSource)
                                     {
@@ -5302,12 +5302,12 @@ void Application::run()
                                     static int recordingPushLogCount = 0;
                                     if (recordingPushLogCount++ < 3)
                                     {
-                                        LOG_INFO("=== PUSHING FRAME TO RECORDING ===");
-                                        LOG_INFO("Frame size being pushed: " + std::to_string(useSource ? sourceFrameW : actualCaptureWidth) + "x" + std::to_string(useSource ? sourceFrameH : actualCaptureHeight) +
+                                        LOG_DEBUG("=== PUSHING FRAME TO RECORDING ===");
+                                        LOG_DEBUG("Frame size being pushed: " + std::to_string(useSource ? sourceFrameW : actualCaptureWidth) + "x" + std::to_string(useSource ? sourceFrameH : actualCaptureHeight) +
                                                  (useSource ? " (raw source — shader bypassed)" : ""));
                                         RecordingSettings recSettings = m_recordingManager->getRecordingSettings();
                                         LOG_INFO("Recording target resolution: " + std::to_string(recSettings.width) + "x" + std::to_string(recSettings.height));
-                                        LOG_INFO("===================================");
+                                        LOG_DEBUG("===================================");
                                     }
                                     if (useSource)
                                     {

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -1328,8 +1328,23 @@ int64_t MediaEncoder::calculateAudioPTS(int64_t captureTimestampUs, size_t /* sa
 
     AVRational timeBase = codecCtx->time_base;
     int64_t calculatedPTS = 0;
-    if (m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
+    if (m_forStreaming)
     {
+        // Live streaming: wall-clock PTS, same clock source as the video
+        // PTS (both come from HTTPTSStreamer::getTimestampUs at push time),
+        // so audio and video share one timeline. Sample-count PTS assumes
+        // zero dropped chunks; the lossy live audio bus *does* drop chunks
+        // (esp. system-audio bursts), so sample-count drifts behind real
+        // time and the client ended up playing video with no usable audio
+        // (#109). Wall-clock tracks real time regardless of drops.
+        int64_t relativeTimeUs = captureTimestampUs - m_firstAudioTimestampUs;
+        if (relativeTimeUs < 0) relativeTimeUs = 0;
+        calculatedPTS = (relativeTimeUs * timeBase.den) / (timeBase.num * 1000000LL);
+    }
+    else if (m_audioConfig.sampleRate > 0 && m_audioConfig.channels > 0)
+    {
+        // File recording: sample-count PTS — smooth and jitter-free, and the
+        // recording drain doesn't drop chunks, so the count matches duration.
         int64_t samplesPerChannel = m_totalAudioSamplesProcessed / m_audioConfig.channels;
         calculatedPTS = (samplesPerChannel * timeBase.den) / (m_audioConfig.sampleRate * timeBase.num);
     }

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -1119,7 +1119,7 @@ int64_t MediaEncoder::calculateVideoPTS(int64_t captureTimestampUs)
     ptsLogCounter++;
     if (ptsLogCounter == 1 || ptsLogCounter % 300 == 0) // Every 5 seconds at 60fps
     {
-        LOG_INFO("MediaEncoder: Video PTS - calculated: " + std::to_string(calculatedPTS) + 
+        LOG_DEBUG("MediaEncoder: Video PTS - calculated: " + std::to_string(calculatedPTS) + 
                  ", relativeTimeUs: " + std::to_string(relativeTimeUs) + 
                  ", relativeTimeSeconds: " + std::to_string(relativeTimeSeconds) +
                  ", timeBase: " + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den) +
@@ -1178,7 +1178,7 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
     if (debugLogCounter == 1 || debugLogCounter % 100 == 0)
     {
         std::lock_guard<std::mutex> lock(m_audioAccumulatorMutex);
-        LOG_INFO("MediaEncoder: Audio accumulator - size: " + std::to_string(m_audioAccumulator.size()) + 
+        LOG_DEBUG("MediaEncoder: Audio accumulator - size: " + std::to_string(m_audioAccumulator.size()) + 
                  ", needed: " + std::to_string(totalSamplesNeeded) + 
                  ", frame_size: " + std::to_string(samplesPerFrame) +
                  ", channels: " + std::to_string(m_audioConfig.channels));
@@ -1227,7 +1227,7 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
         frameLogCounter++;
         if (frameLogCounter == 1 || frameLogCounter % 50 == 0)
         {
-            LOG_INFO("MediaEncoder: Processing audio frame - actual: " + std::to_string(actualFrameSamples) + 
+            LOG_DEBUG("MediaEncoder: Processing audio frame - actual: " + std::to_string(actualFrameSamples) + 
                      ", expected: " + std::to_string(samplesPerFrame) + 
                      ", input consumed: " + std::to_string(totalSamplesNeeded));
         }
@@ -1259,7 +1259,7 @@ bool MediaEncoder::encodeAudio(const int16_t *samples, size_t sampleCount,
 
             if (frameLogCounter == 1 || frameLogCounter % 50 == 0)
             {
-                LOG_INFO("MediaEncoder: After processing - accumulator: " + std::to_string(sizeBefore) +
+                LOG_DEBUG("MediaEncoder: After processing - accumulator: " + std::to_string(sizeBefore) +
                          " -> " + std::to_string(sizeAfter) +
                          " (removed " + std::to_string(totalSamplesNeeded) + ")");
             }

--- a/src/encoding/MediaMuxer.cpp
+++ b/src/encoding/MediaMuxer.cpp
@@ -758,7 +758,7 @@ void MediaMuxer::convertPTS(const MediaEncoder::EncodedPacket &packet, int64_t &
     timeBaseLogCounter++;
     if (timeBaseLogCounter == 1 || timeBaseLogCounter % 300 == 0)
     {
-        LOG_INFO("MediaMuxer: PTS conversion - codec time_base: " + std::to_string(codecTimeBase.num) + "/" + std::to_string(codecTimeBase.den) +
+        LOG_DEBUG("MediaMuxer: PTS conversion - codec time_base: " + std::to_string(codecTimeBase.num) + "/" + std::to_string(codecTimeBase.den) +
                  ", stream time_base: " + std::to_string(streamTimeBase.num) + "/" + std::to_string(streamTimeBase.den) +
                  ", original PTS: " + std::to_string(pts));
     }
@@ -772,7 +772,7 @@ void MediaMuxer::convertPTS(const MediaEncoder::EncodedPacket &packet, int64_t &
 
         if (timeBaseLogCounter == 1 || timeBaseLogCounter % 300 == 0)
         {
-            LOG_INFO("MediaMuxer: PTS converted - original: " + std::to_string(originalPTS) +
+            LOG_DEBUG("MediaMuxer: PTS converted - original: " + std::to_string(originalPTS) +
                      ", converted: " + std::to_string(pts));
         }
     }
@@ -816,7 +816,7 @@ void MediaMuxer::ensureMonotonicPTS(int64_t &pts, int64_t &dts, bool isVideo)
             muxLogCounter++;
             if (muxLogCounter == 1 || muxLogCounter % 300 == 0)
             {
-                LOG_INFO("MediaMuxer: Video PTS - current: " + std::to_string(pts) +
+                LOG_DEBUG("MediaMuxer: Video PTS - current: " + std::to_string(pts) +
                          ", last: " + std::to_string(m_lastVideoPTS) +
                          ", delta: " + std::to_string(pts - m_lastVideoPTS));
             }

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -123,7 +123,7 @@ void UIConfigurationAudio::refreshInputSources()
             }
         }
     }
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(_WIN32)
     // Core Audio devices via IAudioCapture::listDevices — same listing
     // used elsewhere. On macOS the saved id comes from
     // `getAudioInputSourceId()`, same field reused.
@@ -284,10 +284,10 @@ void UIConfigurationAudio::renderInputSourceSelection()
                            "RetroCapture will record from it and publish "
                            "the audio as the 'RetroCapture' source.");
     }
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(_WIN32)
     if (m_inputSourceNames.empty())
     {
-        ImGui::TextWrapped("No Core Audio input devices found.");
+        ImGui::TextWrapped("No audio devices found.");
         return;
     }
 
@@ -318,10 +318,19 @@ void UIConfigurationAudio::renderInputSourceSelection()
             else
             {
                 ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-                                   "Failed to open Core Audio device");
+                                   "Failed to open audio device");
                 m_selectedInputSourceIndex = prev;
             }
         }
+    }
+
+    // #109 — flag system-audio (output monitor) selections.
+    if (m_selectedInputSourceIndex >= 0 &&
+        m_selectedInputSourceIndex < static_cast<int>(m_inputSourceIsMonitor.size()) &&
+        m_inputSourceIsMonitor[m_selectedInputSourceIndex])
+    {
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f),
+                           "Capturing system audio (loopback).");
     }
 
     ImGui::Spacing();
@@ -332,6 +341,7 @@ void UIConfigurationAudio::renderInputSourceSelection()
                     m_audioCapture->getChannels(),
                     m_audioCapture->getChannels() == 1 ? "" : "s");
 
+#ifdef __APPLE__
         if (ImGui::Button("Resync monitor"))
         {
             if (auto *caCapture = dynamic_cast<AudioCaptureCoreAudio *>(m_audioCapture))
@@ -339,6 +349,7 @@ void UIConfigurationAudio::renderInputSourceSelection()
                 caCapture->resyncMonitor();
             }
         }
+#endif
     }
 #endif
 }

--- a/src/ui/UIConfigurationAudio.cpp
+++ b/src/ui/UIConfigurationAudio.cpp
@@ -60,6 +60,7 @@ void UIConfigurationAudio::refreshInputSources()
 {
     m_inputSourceNames.clear();
     m_inputSourceIds.clear();
+    m_inputSourceIsMonitor.clear();
     m_selectedInputSourceIndex = -1;
 
     if (!m_audioCapture)
@@ -71,13 +72,24 @@ void UIConfigurationAudio::refreshInputSources()
     AudioCapturePulse *pulseCapture = dynamic_cast<AudioCapturePulse *>(m_audioCapture);
     if (pulseCapture)
     {
-        // Get list of available input sources
+        // Get list of available sources — real inputs and output monitors
+        // (system audio, #109). Group inputs first, then monitors, and
+        // prefix the monitors so they read as "system audio".
         std::vector<AudioDeviceInfo> sources = pulseCapture->listInputSources();
 
-        for (const auto &source : sources)
+        for (const auto &source : sources) // inputs first
         {
+            if (source.isMonitor) continue;
             m_inputSourceNames.push_back(source.name);
             m_inputSourceIds.push_back(source.id);
+            m_inputSourceIsMonitor.push_back(false);
+        }
+        for (const auto &source : sources) // then system-audio monitors
+        {
+            if (!source.isMonitor) continue;
+            m_inputSourceNames.push_back("[System audio] " + source.name);
+            m_inputSourceIds.push_back(source.id);
+            m_inputSourceIsMonitor.push_back(true);
         }
 
         // Try to find current input source
@@ -118,8 +130,9 @@ void UIConfigurationAudio::refreshInputSources()
     const auto devices = m_audioCapture->listDevices();
     for (const auto &d : devices)
     {
-        m_inputSourceNames.push_back(d.name);
+        m_inputSourceNames.push_back(d.isMonitor ? "[System audio] " + d.name : d.name);
         m_inputSourceIds.push_back(d.id);
+        m_inputSourceIsMonitor.push_back(d.isMonitor);
     }
 
     const std::string saved = m_uiManager
@@ -220,6 +233,18 @@ void UIConfigurationAudio::renderInputSourceSelection()
                 m_selectedInputSourceIndex = prevSelectedIndex;
             }
         }
+    }
+
+    // #109 — when a system-audio (output monitor) source is selected,
+    // local monitoring is turned off to avoid a feedback loop. Make that
+    // explicit so the user isn't surprised they don't hear it through us.
+    if (m_selectedInputSourceIndex >= 0 &&
+        m_selectedInputSourceIndex < static_cast<int>(m_inputSourceIsMonitor.size()) &&
+        m_inputSourceIsMonitor[m_selectedInputSourceIndex])
+    {
+        ImGui::TextColored(ImVec4(0.95f, 0.7f, 0.3f, 1.0f),
+                           "Capturing system audio — local monitoring is off "
+                           "(prevents feedback). You still hear it from the system.");
     }
 
     ImGui::Spacing();

--- a/src/ui/UIConfigurationAudio.h
+++ b/src/ui/UIConfigurationAudio.h
@@ -29,9 +29,10 @@ private:
     UIManager *m_uiManager = nullptr;
     IAudioCapture *m_audioCapture = nullptr;
     
-    // Input sources
+    // Input sources (and, #109, output monitors flagged via m_inputSourceIsMonitor)
     std::vector<std::string> m_inputSourceNames;
     std::vector<std::string> m_inputSourceIds;
+    std::vector<bool>        m_inputSourceIsMonitor; // true = system-audio monitor
     int m_selectedInputSourceIndex = -1;
     bool m_inputSourcesListNeedsRefresh = true;
     

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -3,8 +3,12 @@
 #include <iostream>
 #include <fstream>
 #include <mutex>
+#include <cstdlib>
+#include <algorithm>
+#include <cctype>
 
 bool Logger::s_initialized = false;
+Logger::Level Logger::s_level = Logger::Level::Info;
 
 namespace
 {
@@ -33,6 +37,20 @@ void Logger::init()
         return;
     }
     s_initialized = true;
+
+    // Allow raising verbosity without a rebuild: RETROCAPTURE_LOG_LEVEL =
+    // debug | info | warn | error. Default stays Info so per-frame Debug
+    // diagnostics don't flood the console / log file.
+    if (const char *env = std::getenv("RETROCAPTURE_LOG_LEVEL"))
+    {
+        std::string lvl(env);
+        std::transform(lvl.begin(), lvl.end(), lvl.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (lvl == "debug")      s_level = Level::Debug;
+        else if (lvl == "info")  s_level = Level::Info;
+        else if (lvl == "warn")  s_level = Level::Warn;
+        else if (lvl == "error") s_level = Level::Error;
+    }
 
     // getUserDataDir() creates the directory (ensureDir), so the file can
     // be opened directly. Failure is non-fatal — console logging still works.
@@ -67,22 +85,36 @@ void Logger::shutdown()
     }
 }
 
+void Logger::setLevel(Level level)
+{
+    s_level = level;
+}
+
+Logger::Level Logger::getLevel()
+{
+    return s_level;
+}
+
 void Logger::info(const std::string &message)
 {
+    if (s_level > Level::Info) return;
     writeLine(std::cout, "[INFO] ", message);
 }
 
 void Logger::error(const std::string &message)
 {
+    if (s_level > Level::Error) return;
     writeLine(std::cerr, "[ERROR] ", message);
 }
 
 void Logger::warn(const std::string &message)
 {
+    if (s_level > Level::Warn) return;
     writeLine(std::cout, "[WARN] ", message);
 }
 
 void Logger::debug(const std::string &message)
 {
+    if (s_level > Level::Debug) return;
     writeLine(std::cout, "[DEBUG] ", message);
 }

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -1,10 +1,30 @@
 #include "Logger.h"
+#include "Paths.h"
 #include <iostream>
-#include <iomanip>
-#include <chrono>
-#include <ctime>
+#include <fstream>
+#include <mutex>
 
 bool Logger::s_initialized = false;
+
+namespace
+{
+// Mirror every log line to a file as well as the console, so GUI / .app
+// launches (which have no terminal — e.g. macOS bundles needed for the
+// Screen-Recording permission) are still debuggable. Truncated each run.
+std::ofstream g_logFile;
+std::mutex    g_logMutex;
+
+void writeLine(std::ostream &console, const char *level, const std::string &message)
+{
+    std::lock_guard<std::mutex> lock(g_logMutex);
+    console << level << message << std::endl;
+    if (g_logFile.is_open())
+    {
+        g_logFile << level << message << "\n";
+        g_logFile.flush();
+    }
+}
+} // namespace
 
 void Logger::init()
 {
@@ -13,7 +33,24 @@ void Logger::init()
         return;
     }
     s_initialized = true;
+
+    // getUserDataDir() creates the directory (ensureDir), so the file can
+    // be opened directly. Failure is non-fatal — console logging still works.
+    std::string logPath;
+    try
+    {
+        logPath = Paths::getUserDataDir() + "/retrocapture.log";
+        g_logFile.open(logPath, std::ios::out | std::ios::trunc);
+    }
+    catch (...)
+    {
+    }
+
     info("Logger initialized");
+    if (g_logFile.is_open())
+    {
+        info("Log file: " + logPath);
+    }
 }
 
 void Logger::shutdown()
@@ -23,24 +60,29 @@ void Logger::shutdown()
         return;
     }
     s_initialized = false;
+    std::lock_guard<std::mutex> lock(g_logMutex);
+    if (g_logFile.is_open())
+    {
+        g_logFile.close();
+    }
 }
 
 void Logger::info(const std::string &message)
 {
-    std::cout << "[INFO] " << message << std::endl;
+    writeLine(std::cout, "[INFO] ", message);
 }
 
 void Logger::error(const std::string &message)
 {
-    std::cerr << "[ERROR] " << message << std::endl;
+    writeLine(std::cerr, "[ERROR] ", message);
 }
 
 void Logger::warn(const std::string &message)
 {
-    std::cout << "[WARN] " << message << std::endl;
+    writeLine(std::cout, "[WARN] ", message);
 }
 
 void Logger::debug(const std::string &message)
 {
-    std::cout << "[DEBUG] " << message << std::endl;
+    writeLine(std::cout, "[DEBUG] ", message);
 }

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -4,16 +4,25 @@
 
 class Logger {
 public:
+    enum class Level { Debug = 0, Info = 1, Warn = 2, Error = 3 };
+
     static void init();
     static void shutdown();
-    
+
     static void info(const std::string& message);
     static void error(const std::string& message);
     static void warn(const std::string& message);
     static void debug(const std::string& message);
-    
+
+    // Minimum level actually emitted. Defaults to Info, so per-frame Debug
+    // diagnostics stay out of the console/log file unless explicitly asked
+    // for (env RETROCAPTURE_LOG_LEVEL=debug, parsed in init()).
+    static void setLevel(Level level);
+    static Level getLevel();
+
 private:
     static bool s_initialized;
+    static Level s_level;
 };
 
 // Macros de conveniência
@@ -21,4 +30,3 @@ private:
 #define LOG_ERROR(msg) Logger::error(msg)
 #define LOG_WARN(msg) Logger::warn(msg)
 #define LOG_DEBUG(msg) Logger::debug(msg)
-


### PR DESCRIPTION
## Summary

Adds capture of the computer's **system audio output** (monitor/loopback)
as an audio source, alongside microphone/input devices, across Linux,
Windows and macOS. Pairs naturally with the screen-capture source (#108):
share the screen *and* the audio it's producing. Feedback (microfonia) is
avoided by disabling the local monitor playback while a system-audio
source is selected. Closes #109.

## Per-platform

- **Linux (PulseAudio/PipeWire)** — output sinks' `.monitor` sources are
  listed as capturable "System audio" sources and captured in-process via
  `pa_simple` (no `module-loopback`/`module-null-sink`, per the project's
  audio policy). Self-prefixed `RetroCapture` monitors are skipped.
- **Windows (WASAPI)** — render endpoints captured via loopback
  (`eRender` + `AUDCLNT_STREAMFLAGS_LOOPBACK`); device selected by id with
  `IMMEndpoint::GetDataFlow` choosing loopback for render devices.
- **macOS (ScreenCaptureKit, 13+)** — `SCStreamConfiguration.capturesAudio`
  on the screen-capture stream, brokered by a new `SckSystemAudioHub` so
  only ONE SCStream is ever alive (two conflict and silence the audio).

## macOS implementation notes (the tricky bits)

- **Single SCStream**: running the screen video stream + a separate audio
  stream makes the audio one go silent. The hub routes the screen stream's
  audio to the system-audio source, and falls back to its own audio-only
  display-filter stream when there's no screen capture.
- **Display vs window**: SCK only captures audio with a *display* filter —
  `capturesAudio` is silently ignored for desktop-independent window
  capture, so the hub runs its own display-filter audio stream in that case.
- **Silence keepalive**: the live encoder gates video on audio presence, so
  a genuinely silent system output could stall the stream; the hub keeps
  the audio timeline alive as a gentle safety net (250 ms gap, no startup
  flood) without fighting real audio.
- **Wall-clock audio PTS for streaming**: the lossy live bus drops chunks,
  which made sample-count PTS drift off the wall-clock video PTS (client
  played video with no audible audio). Streaming now derives audio PTS from
  the same capture clock as video; file recording keeps sample-count PTS.
- **AudioBufferList sizing (root cause of "video but no audio")**: SCK
  delivers stereo as planar float (2 buffers); a fixed
  `sizeof(AudioBufferList)` only fits one, so extraction failed and only
  keepalive silence reached the bus. Now the buffer list is sized to the
  channel count.

## Feedback prevention

When a system-audio source is selected, the in-app local monitor is
disabled and (where supported) the current process is excluded from the
captured mix (`excludesCurrentProcessAudio` on macOS), so we never capture
our own playback.

## Logging cleanup

The `Logger` had no level filter and wrote everything. Added a minimum
level (default `Info`; `RETROCAPTURE_LOG_LEVEL=debug` to raise it without a
rebuild) and downgraded the high-frequency per-frame/per-chunk diagnostics
(encoder/muxer PTS, frame-capture banners, audio-hub telemetry) to `Debug`.
One-time lifecycle logs stay at `Info`.

## Status / test plan

- Builds clean on Linux + Windows (Docker) and macOS (.app bundle).
- macOS: screen + system audio verified end-to-end — client receives video
  **and** audible system audio, stream stable.
- Linux + Windows: implemented and build; runtime validation pending.