### PR TITLE
fix(capture): rebuild local capture when switching from Remote/Screen (#97)

### DIFF
--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -2985,7 +2985,22 @@ bool Application::initUI()
             // Disable dummy mode when trying to open real device
             m_capture->setDummyMode(false);
         }
-        
+
+        // #97 — if we're coming from a Remote (or Screen) session, m_capture
+        // is still that backend; calling open("/dev/videoN") on it routes the
+        // device path through the wrong demuxer ("connecting to remote base
+        // URL /dev/videoN"). Rebuild as the local factory capture (V4L2 /
+        // DirectShow / AVFoundation) before opening the device.
+        if (m_capture &&
+            (dynamic_cast<VideoCaptureRemote *>(m_capture.get()) ||
+             dynamic_cast<VideoCaptureScreen *>(m_capture.get())))
+        {
+            LOG_INFO("Device change: active capture is not a local device backend — rebuilding via factory (#97)");
+            if (m_remoteMetaSync) { m_remoteMetaSync->stop(); m_remoteMetaSync.reset(); }
+            m_capture = VideoCaptureFactory::create();
+            if (m_ui) m_ui->setCaptureControls(m_capture.get());
+        }
+
         // Update device path
         m_devicePath = devicePath;
         


### PR DESCRIPTION
Switching Remote → V4L2 then picking a device reused the leftover
`VideoCaptureRemote`, so `open("/dev/videoN")` went through the remote
demuxer (`/dev/videoN/raw` → failure). The device-change callback now
rebuilds `m_capture` via `VideoCaptureFactory` (and tears down the `/meta`
poller) when the active backend is Remote/Screen, before opening a local
device. Same-type switches still reuse the instance.

Linux + Windows build clean.

Closes #97