### PR TITLE
fix(av-sync): remote client A/V sync — reconnect, shared epoch, anchor gate, /stream gating (#93, #109)

### DIFF
--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -607,35 +607,6 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
                              (locked ? " [audio-locked]" : " [wall-clock fallback]"));
                 }
             }
-            // #93 stage 3 — automatic resync. Don't wait for the drift to
-            // blow past the ±500 ms lock gate (a half-second lip-sync error
-            // is already obvious): once it's been beyond ±250 ms for a
-            // sustained 2 s, ask the decode thread to drop the stale audio
-            // and re-jump to live. Hysteresis (5 s cooldown) keeps it from
-            // thrashing while a resync settles, and the 2 s dwell ignores
-            // the harmless transient spike right after (re)connect. Timers
-            // use the raw wall clock (nowWallUs is overwritten by the lock
-            // just below). Consumer-thread-only state — no atomics needed.
-            if (drift <= -250'000 || drift >= 250'000)
-            {
-                if (m_driftOutOfGateSinceUs == 0)
-                {
-                    m_driftOutOfGateSinceUs = nowWallUs;
-                }
-                else if (nowWallUs - m_driftOutOfGateSinceUs > 2'000'000 &&
-                         nowWallUs - m_lastResyncUs          > 5'000'000)
-                {
-                    m_resyncRequested.store(true);
-                    m_lastResyncUs          = nowWallUs;
-                    m_driftOutOfGateSinceUs = 0;
-                    LOG_INFO("VideoCaptureRemote: A/V drift " + std::to_string(drift / 1000) +
-                             " ms sustained — requesting resync (drop stale audio + jump to live)");
-                }
-            }
-            else
-            {
-                m_driftOutOfGateSinceUs = 0;
-            }
             if (locked)
             {
                 nowWallUs = audioNowWall;
@@ -840,16 +811,6 @@ void VideoCaptureRemote::decodeLoop()
             LOG_INFO(std::string("VideoCaptureRemote: ") +
                      (m_everReceivedFrame.load() ? "reconnected to " : "connected to ") +
                      m_url);
-        }
-
-        // #93 stage 3 — mid-stream resync requested by the consumer thread
-        // after sustained A/V drift (stale audio backlog or runaway drift).
-        // Drop the divergent state and re-settle at the live edge instead
-        // of staying in wall-clock fallback forever.
-        if (m_resyncRequested.exchange(false))
-        {
-            LOG_INFO("VideoCaptureRemote: A/V resync — dropping stale audio + queued video, re-anchoring to live");
-            resyncToLive();
         }
 
         int rc = av_read_frame(m_formatCtx, packet);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -917,6 +917,23 @@ void VideoCaptureRemote::decodeLoop()
                         // corrupted A/V clock.
                         const AVRational tb = m_formatCtx->streams[m_audioStreamIdx]->time_base;
                         const int64_t ptsUs = static_cast<int64_t>(static_cast<double>(aFrame->pts) * av_q2d(tb) * 1e6);
+                        // #109 — never submit audio older than the live video
+                        // anchor. The drain drops the video backlog and anchors
+                        // video at the live edge, but on a reconnect the MPEG-TS
+                        // (esp. through the relay) is loosely interleaved: a
+                        // burst of stale audio packets can arrive AFTER the drain
+                        // ended, with PTS seconds behind the live video. Feeding
+                        // those plays the audio seconds behind the picture (the
+                        // measured ~14 s reconnect desync). Anchor-relative gate
+                        // with 300 ms tolerance for normal A/V interleave jitter;
+                        // once the backlog is past, live audio PTS sits far above
+                        // the anchor so this never trips in steady state.
+                        const int64_t anchorUs = m_firstPtsUs.load();
+                        if (m_streamAnchored.load() && ptsUs + 300'000 < anchorUs)
+                        {
+                            av_frame_unref(aFrame);
+                            continue;
+                        }
                         m_audioPlayback->submit(m_audioScratch.data(),
                                                 static_cast<size_t>(produced),
                                                 ptsUs);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -590,18 +590,26 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
             // queue fills (the user-observed
             // 'decoded=60/s consumed=30/s drops=30/s queueDepth=20').
             const int64_t drift = audioNowWall - nowWallUs;
+            // #93 stage 3 — periodically log the live A/V offset (the audio
+            // clock minus wall clock) so we can see its SHAPE: a small
+            // constant value = fixed offset (host epoch mismatch); a value
+            // that keeps growing = progressive drift; a huge/bouncing value
+            // = transient sink warmup / bogus clock. The right resync depends
+            // on which. Throttled to ~once / 2 s.
+            {
+                static int64_t lastDriftLogUs = 0;
+                if (nowWallUs - lastDriftLogUs >= 2'000'000)
+                {
+                    lastDriftLogUs = nowWallUs;
+                    LOG_INFO("VideoCaptureRemote: A/V offset (audio-wall) = " +
+                             std::to_string(drift / 1000) + " ms" +
+                             (drift > -500'000 && drift < 500'000 ? " [audio-locked]"
+                                                                  : " [wall-clock fallback]"));
+                }
+            }
             if (drift > -500'000 && drift < 500'000)
             {
                 nowWallUs = audioNowWall;
-            }
-            else
-            {
-                static int driftLogCount = 0;
-                if (driftLogCount++ < 5)
-                {
-                    LOG_WARN("VideoCaptureRemote: audio clock drift=" + std::to_string(drift) +
-                             "us — falling back to wall clock for A/V sync");
-                }
             }
         }
     }

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -781,6 +781,11 @@ void VideoCaptureRemote::decodeLoop()
                 m_frameQueue.clear();
             }
             rgbW = 0; rgbH = 0; rgbBuf.clear();
+            // #93 stage 1 — start draining the host's pre-connect backlog so
+            // we anchor at the live edge instead of ~1 s in the past.
+            m_drainToLive.store(true);
+            m_drainStartWallUs = 0;
+            m_lastDecodeWallUs = 0;
             // Reconnect succeeded — drop backoff state so the next
             // hiccup starts from the 2 s slot again.
             m_consecutiveReconnectFailures.store(0);
@@ -979,6 +984,39 @@ void VideoCaptureRemote::decodeLoop()
             // the initial-connect-failing state and marks subsequent
             // drops as reconnects rather than first-connect failures.
             m_everReceivedFrame.store(true);
+
+            // #93 stage 1 — jump-to-live: drop the connect backlog burst.
+            // Frames decoded back-to-back (much faster than the stream's
+            // frame interval) are the host's buffered backlog; skip them and
+            // only resume once a near-real-time gap appears (the live edge),
+            // so we anchor at "now" instead of replaying ~1 s of old frames.
+            if (m_drainToLive.load())
+            {
+                if (m_drainStartWallUs == 0) m_drainStartWallUs = nowWallUs;
+                int64_t frameIntervalUs = 16666; // default ~60 fps
+                if (m_formatCtx && m_videoStreamIdx >= 0)
+                {
+                    AVRational fr = m_formatCtx->streams[m_videoStreamIdx]->avg_frame_rate;
+                    if (fr.num > 0 && fr.den > 0)
+                        frameIntervalUs = static_cast<int64_t>(1e6 * fr.den / fr.num);
+                }
+                const int64_t liveGap = std::max<int64_t>(frameIntervalUs * 6 / 10, 8000);
+                const int64_t gap = (m_lastDecodeWallUs > 0) ? (nowWallUs - m_lastDecodeWallUs) : 0;
+                m_lastDecodeWallUs = nowWallUs;
+                const bool liveReached = (gap >= liveGap);
+                const bool timeout     = (nowWallUs - m_drainStartWallUs) >= 2'000'000; // 2 s safety
+                if (!liveReached && !timeout)
+                {
+                    ++m_statProduced;
+                    ++m_statDropped; // dropped a backlog frame
+                    continue;        // keep draining; do not enqueue/anchor
+                }
+                m_drainToLive.store(false);
+                LOG_INFO("VideoCaptureRemote: reached live edge — dropped connect backlog");
+                // m_streamAnchored is still false, so the block below anchors
+                // this live-edge frame at 'now'.
+            }
+
             if (!m_streamAnchored.load())
             {
                 m_streamAnchored.store(true);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -602,9 +602,17 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
                 if (nowWallUs - lastDriftLogUs >= 2'000'000)
                 {
                     lastDriftLogUs = nowWallUs;
+                    // #109 — also log the video queue depth so we can tell
+                    // WHY the video lags when drift is negative: a near-full
+                    // queue means video is held back by a lagging audio clock
+                    // (client-side audio buffer growth); a near-empty queue
+                    // means the host isn't delivering video fast enough and
+                    // the client is starved (host-side throughput).
                     LOG_INFO("VideoCaptureRemote: A/V offset (audio-wall) = " +
                              std::to_string(drift / 1000) + " ms" +
-                             (locked ? " [audio-locked]" : " [wall-clock fallback]"));
+                             (locked ? " [audio-locked]" : " [wall-clock fallback]") +
+                             " vqueue=" + std::to_string(m_frameQueue.size()) + "/" +
+                             std::to_string(kMaxQueued));
                 }
             }
             if (locked)

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -596,6 +596,7 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
             // that keeps growing = progressive drift; a huge/bouncing value
             // = transient sink warmup / bogus clock. The right resync depends
             // on which. Throttled to ~once / 2 s.
+            const bool locked = (drift > -500'000 && drift < 500'000);
             {
                 static int64_t lastDriftLogUs = 0;
                 if (nowWallUs - lastDriftLogUs >= 2'000'000)
@@ -603,11 +604,39 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
                     lastDriftLogUs = nowWallUs;
                     LOG_INFO("VideoCaptureRemote: A/V offset (audio-wall) = " +
                              std::to_string(drift / 1000) + " ms" +
-                             (drift > -500'000 && drift < 500'000 ? " [audio-locked]"
-                                                                  : " [wall-clock fallback]"));
+                             (locked ? " [audio-locked]" : " [wall-clock fallback]"));
                 }
             }
-            if (drift > -500'000 && drift < 500'000)
+            // #93 stage 3 — automatic resync. Don't wait for the drift to
+            // blow past the ±500 ms lock gate (a half-second lip-sync error
+            // is already obvious): once it's been beyond ±250 ms for a
+            // sustained 2 s, ask the decode thread to drop the stale audio
+            // and re-jump to live. Hysteresis (5 s cooldown) keeps it from
+            // thrashing while a resync settles, and the 2 s dwell ignores
+            // the harmless transient spike right after (re)connect. Timers
+            // use the raw wall clock (nowWallUs is overwritten by the lock
+            // just below). Consumer-thread-only state — no atomics needed.
+            if (drift <= -250'000 || drift >= 250'000)
+            {
+                if (m_driftOutOfGateSinceUs == 0)
+                {
+                    m_driftOutOfGateSinceUs = nowWallUs;
+                }
+                else if (nowWallUs - m_driftOutOfGateSinceUs > 2'000'000 &&
+                         nowWallUs - m_lastResyncUs          > 5'000'000)
+                {
+                    m_resyncRequested.store(true);
+                    m_lastResyncUs          = nowWallUs;
+                    m_driftOutOfGateSinceUs = 0;
+                    LOG_INFO("VideoCaptureRemote: A/V drift " + std::to_string(drift / 1000) +
+                             " ms sustained — requesting resync (drop stale audio + jump to live)");
+                }
+            }
+            else
+            {
+                m_driftOutOfGateSinceUs = 0;
+            }
+            if (locked)
             {
                 nowWallUs = audioNowWall;
             }
@@ -702,6 +731,25 @@ bool VideoCaptureRemote::captureLatestFrame(Frame &frame)
     return true;
 }
 
+void VideoCaptureRemote::resyncToLive()
+{
+    // Drop the PTS anchor so the next decoded frame re-anchors, flush
+    // any stale audio still queued in the sink (after a messy reconnect
+    // the deferred sink can hold seconds of old samples that otherwise
+    // play behind live), clear queued video, and re-arm the drain so we
+    // settle at the live edge. Runs on the decode thread.
+    m_streamAnchored.store(false);
+    m_firstPtsUs.store(0);
+    if (m_audioPlayback) m_audioPlayback->flush();
+    {
+        std::lock_guard<std::mutex> lock(m_frameMutex);
+        m_frameQueue.clear();
+    }
+    m_drainToLive.store(true);
+    m_drainStartWallUs = 0;
+    m_lastDecodeWallUs = 0;
+}
+
 void VideoCaptureRemote::decodeLoop()
 {
     AVPacket *packet = av_packet_alloc();
@@ -780,20 +828,11 @@ void VideoCaptureRemote::decodeLoop()
             // frames that were sitting in the queue from before the
             // disconnect. Otherwise the new stream's PTS=0 frame would
             // be timed against the old anchor and either play in the
-            // past or sit far in the future.
-            m_streamAnchored.store(false);
-            m_firstPtsUs.store(0);
-            if (m_audioPlayback) m_audioPlayback->flush();
-            {
-                std::lock_guard<std::mutex> lock(m_frameMutex);
-                m_frameQueue.clear();
-            }
+            // past or sit far in the future. resyncToLive() also flushes
+            // audio and re-arms the drain so we anchor at the live edge
+            // instead of ~1 s in the past (#93 stage 1).
+            resyncToLive();
             rgbW = 0; rgbH = 0; rgbBuf.clear();
-            // #93 stage 1 — start draining the host's pre-connect backlog so
-            // we anchor at the live edge instead of ~1 s in the past.
-            m_drainToLive.store(true);
-            m_drainStartWallUs = 0;
-            m_lastDecodeWallUs = 0;
             // Reconnect succeeded — drop backoff state so the next
             // hiccup starts from the 2 s slot again.
             m_consecutiveReconnectFailures.store(0);
@@ -801,6 +840,16 @@ void VideoCaptureRemote::decodeLoop()
             LOG_INFO(std::string("VideoCaptureRemote: ") +
                      (m_everReceivedFrame.load() ? "reconnected to " : "connected to ") +
                      m_url);
+        }
+
+        // #93 stage 3 — mid-stream resync requested by the consumer thread
+        // after sustained A/V drift (stale audio backlog or runaway drift).
+        // Drop the divergent state and re-settle at the live edge instead
+        // of staying in wall-clock fallback forever.
+        if (m_resyncRequested.exchange(false))
+        {
+            LOG_INFO("VideoCaptureRemote: A/V resync — dropping stale audio + queued video, re-anchoring to live");
+            resyncToLive();
         }
 
         int rc = av_read_frame(m_formatCtx, packet);

--- a/src/capture/VideoCaptureRemote.cpp
+++ b/src/capture/VideoCaptureRemote.cpp
@@ -868,7 +868,16 @@ void VideoCaptureRemote::decodeLoop()
                     uint8_t *outPlanes[1] = { reinterpret_cast<uint8_t *>(m_audioScratch.data()) };
                     const int produced = swr_convert(m_swrCtx, outPlanes, static_cast<int>(maxOut),
                                                      const_cast<const uint8_t **>(aFrame->data), nbIn);
-                    if (produced > 0 && aFrame->pts != AV_NOPTS_VALUE)
+                    // #93 stage 1/3 — while jumping to live, drop the audio
+                    // backlog too. The video path drains its backlog and
+                    // anchors at the live edge; if we kept submitting the
+                    // buffered audio here, the sink would play from the old
+                    // start and lag video by the whole backlog (seen as a
+                    // multi-second A/V drift on a reconnect with a large host
+                    // buffer → the 'audio clock drift' fallback). Skipping
+                    // submit during the drain keeps audio empty so it starts
+                    // at the live edge alongside video.
+                    if (produced > 0 && aFrame->pts != AV_NOPTS_VALUE && !m_drainToLive.load())
                     {
                         // Convert the frame's PTS (stream-tb units)
                         // to absolute stream microseconds. The drift

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -120,6 +120,13 @@ public:
 
 private:
     void decodeLoop();
+
+    // #93 stage 3 — reset the PTS anchor, flush stale audio, drop queued
+    // video and re-arm the drain-to-live so the next decoded frames
+    // re-anchor at the live edge. Shared by the fresh-stream (reconnect)
+    // path and the mid-stream resync triggered by sustained A/V drift.
+    // Runs on the decode thread only.
+    void resyncToLive();
     bool initDecoder();
     void cleanupDecoder();
     // Bring up the audio sink + resampler from the audio decoder's
@@ -255,6 +262,20 @@ private:
     std::atomic<bool> m_drainToLive{false};
     int64_t           m_drainStartWallUs = 0;
     int64_t           m_lastDecodeWallUs = 0;
+
+    // #93 stage 3 — automatic A/V resync. When the audio clock and the
+    // wall/video clock drift apart by more than a perceptible amount and
+    // stay there (stale audio backlog after a messy reconnect, or runaway
+    // drift over a long session), we don't limp along in wall-clock
+    // fallback forever. The consumer thread (captureLatestFrame) detects
+    // the sustained drift and raises m_resyncRequested; the decode thread
+    // acts on it by flushing the stale audio, dropping queued video, and
+    // re-jumping to the live edge (resyncToLive) so A/V re-lock at ~0.
+    // m_driftOutOfGateSinceUs / m_lastResyncUs are touched only by the
+    // consumer thread (under m_frameMutex) so they need no atomicity.
+    std::atomic<bool> m_resyncRequested{false};
+    int64_t           m_driftOutOfGateSinceUs = 0;
+    int64_t           m_lastResyncUs          = 0;
     // PTS of the first video frame in microseconds. Lets the audio
     // path (which has its own stream timebase) translate its absolute
     // PTS into the same stream-origin-relative coordinate the video

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -262,20 +262,6 @@ private:
     std::atomic<bool> m_drainToLive{false};
     int64_t           m_drainStartWallUs = 0;
     int64_t           m_lastDecodeWallUs = 0;
-
-    // #93 stage 3 — automatic A/V resync. When the audio clock and the
-    // wall/video clock drift apart by more than a perceptible amount and
-    // stay there (stale audio backlog after a messy reconnect, or runaway
-    // drift over a long session), we don't limp along in wall-clock
-    // fallback forever. The consumer thread (captureLatestFrame) detects
-    // the sustained drift and raises m_resyncRequested; the decode thread
-    // acts on it by flushing the stale audio, dropping queued video, and
-    // re-jumping to the live edge (resyncToLive) so A/V re-lock at ~0.
-    // m_driftOutOfGateSinceUs / m_lastResyncUs are touched only by the
-    // consumer thread (under m_frameMutex) so they need no atomicity.
-    std::atomic<bool> m_resyncRequested{false};
-    int64_t           m_driftOutOfGateSinceUs = 0;
-    int64_t           m_lastResyncUs          = 0;
     // PTS of the first video frame in microseconds. Lets the audio
     // path (which has its own stream timebase) translate its absolute
     // PTS into the same stream-origin-relative coordinate the video

--- a/src/capture/VideoCaptureRemote.h
+++ b/src/capture/VideoCaptureRemote.h
@@ -245,6 +245,16 @@ private:
     std::atomic<int64_t> m_lastFrameAtSteadyUs{0};
     int64_t m_streamStartWallUs  = 0;
     int64_t m_firstPtsTicks      = 0;
+
+    // #93 stage 1 — jump-to-live. A host that's already streaming has up to
+    // ~1 s of frames buffered; anchoring on the first (oldest) decoded frame
+    // bakes that whole backlog in as permanent latency, and the stale frames
+    // replay before live. On every (re)connect we drain (drop) that initial
+    // burst and only anchor once decode cadence drops to ~real time (the live
+    // edge). m_drainStartWallUs=0 means "init on first decoded frame".
+    std::atomic<bool> m_drainToLive{false};
+    int64_t           m_drainStartWallUs = 0;
+    int64_t           m_lastDecodeWallUs = 0;
     // PTS of the first video frame in microseconds. Lets the audio
     // path (which has its own stream timebase) translate its absolute
     // PTS into the same stream-origin-relative coordinate the video

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5274,13 +5274,28 @@ void Application::run()
                                         LOG_DEBUG("Streaming target resolution: " + std::to_string(m_ui->getStreamingWidth()) + "x" + std::to_string(m_ui->getStreamingHeight()));
                                         LOG_DEBUG("----------------------------------");
                                     }
-                                    if (useSource)
+                                    // #109 — gate the /stream feed on having a
+                                    // /stream client, exactly as /raw is gated by
+                                    // hasRawClients() below. Without this the host
+                                    // ran a second h264_vaapi 720p60 encode for the
+                                    // shader-processed /stream output even when only
+                                    // a remote /raw client was connected and nobody
+                                    // was watching /stream — two VAAPI encodes
+                                    // competing for the GPU, which starved the /raw
+                                    // encode and left the remote client's video
+                                    // lagging the audio (and overflowed the /stream
+                                    // synchronizer continuously). Idle the /stream
+                                    // encoder when no one is watching it.
+                                    if (m_streamManager->hasClients())
                                     {
-                                        m_streamManager->pushFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
-                                    }
-                                    else
-                                    {
-                                        m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        if (useSource)
+                                        {
+                                            m_streamManager->pushFrame(m_captureSourceFrameData.data(), sourceFrameW, sourceFrameH);
+                                        }
+                                        else
+                                        {
+                                            m_streamManager->pushFrame(frameData.data(), actualCaptureWidth, actualCaptureHeight);
+                                        }
                                     }
 
                                     // Phase 2 of #47: also feed the /raw output (pre-shader, always).

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -1091,6 +1091,13 @@ int64_t MediaEncoder::calculateVideoPTS(int64_t captureTimestampUs)
         m_firstVideoTimestampSet = true;
         m_videoFrameCountForPTS = 0;
     }
+    // #109 — latch the SHARED A/V epoch from whichever stream (audio or
+    // video) is encoded first, so audio and video PTS share one origin.
+    if (!m_firstMediaTimestampSet)
+    {
+        m_firstMediaTimestampUs  = captureTimestampUs;
+        m_firstMediaTimestampSet = true;
+    }
 
     AVCodecContext *codecCtx = static_cast<AVCodecContext *>(m_videoCodecContext);
     if (!codecCtx)
@@ -1107,7 +1114,11 @@ int64_t MediaEncoder::calculateVideoPTS(int64_t captureTimestampUs)
     
     // Calculate PTS based on actual elapsed time since first frame
     // This ensures video speed matches real time, regardless of actual capture FPS
-    int64_t relativeTimeUs = captureTimestampUs - m_firstVideoTimestampUs;
+    int64_t relativeTimeUs = captureTimestampUs - m_firstMediaTimestampUs;
+    // The shared epoch may be latched by an audio chunk captured slightly
+    // after a video frame that's encoded later — clamp so the video PTS
+    // never goes negative (audio does the same below).
+    if (relativeTimeUs < 0) relativeTimeUs = 0;
     double relativeTimeSeconds = static_cast<double>(relativeTimeUs) / 1000000.0;
     calculatedPTS = static_cast<int64_t>(relativeTimeSeconds * timeBase.den / timeBase.num);
     
@@ -1319,6 +1330,13 @@ int64_t MediaEncoder::calculateAudioPTS(int64_t captureTimestampUs, size_t /* sa
         m_totalAudioSamplesProcessed = 0;
         m_audioFrameCount = 0;
     }
+    // #109 — latch the SHARED A/V epoch (see calculateVideoPTS) so audio
+    // arriving before the first video frame still anchors both timelines.
+    if (!m_firstMediaTimestampSet)
+    {
+        m_firstMediaTimestampUs  = captureTimestampUs;
+        m_firstMediaTimestampSet = true;
+    }
 
     AVCodecContext *codecCtx = static_cast<AVCodecContext *>(m_audioCodecContext);
     if (!codecCtx)
@@ -1337,7 +1355,10 @@ int64_t MediaEncoder::calculateAudioPTS(int64_t captureTimestampUs, size_t /* sa
         // (esp. system-audio bursts), so sample-count drifts behind real
         // time and the client ended up playing video with no usable audio
         // (#109). Wall-clock tracks real time regardless of drops.
-        int64_t relativeTimeUs = captureTimestampUs - m_firstAudioTimestampUs;
+        // Subtract the SHARED epoch (not the audio-only first timestamp) so
+        // audio and video PTS share one origin — otherwise the gap between
+        // the first video frame and first audio chunk is a constant skew.
+        int64_t relativeTimeUs = captureTimestampUs - m_firstMediaTimestampUs;
         if (relativeTimeUs < 0) relativeTimeUs = 0;
         calculatedPTS = (relativeTimeUs * timeBase.den) / (timeBase.num * 1000000LL);
     }
@@ -1826,6 +1847,8 @@ void MediaEncoder::cleanup()
     m_firstAudioTimestampSet = false;
     m_firstVideoTimestampUs = 0;
     m_firstAudioTimestampUs = 0;
+    m_firstMediaTimestampSet = false;
+    m_firstMediaTimestampUs = 0;
     m_totalAudioSamplesProcessed = 0;
     m_audioFrameCount = 0;
     m_videoFrameCountForPTS = 0;

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -196,6 +196,16 @@ private:
     int64_t m_firstAudioTimestampUs = 0;
     bool m_firstVideoTimestampSet = false;
     bool m_firstAudioTimestampSet = false;
+    // #109 — SHARED A/V epoch. Video and audio capture timestamps come
+    // from the same clock (HTTPTSStreamer::getTimestampUs), but PTS used
+    // to be made relative to two SEPARATE first-timestamps; the gap
+    // between the first video frame and first audio chunk arriving then
+    // became a permanent A/V skew baked into the muxed stream (the client
+    // saw video consistently behind audio). Latched by whichever media
+    // arrives first and subtracted by BOTH the video PTS and the
+    // streaming audio PTS so they share one origin.
+    int64_t m_firstMediaTimestampUs = 0;
+    bool    m_firstMediaTimestampSet = false;
     
     // Contadores precisos para cálculo de PTS (baseado em samples/frames, não timestamps)
     int64_t m_audioFrameCount = 0;  // Número de frames de áudio processados

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1491,12 +1491,28 @@ int HTTPTSStreamer::writeToRawClients(const uint8_t *buf, int buf_size)
                                  p.tail.begin() + static_cast<std::ptrdiff_t>(p.tailOffset));
                     p.tailOffset = 0;
                 }
+                // Slow /raw receiver (remote hop, congested link). Closing
+                // it here forced the client into a full messy reconnect —
+                // re-probe, deferred audio sink, multi-second A/V desync,
+                // audio dropout (#93). The /raw consumer is an FFmpeg
+                // demuxer that resyncs at the next in-band keyframe/PAT, so
+                // instead of tearing down we DROP the queued backlog and
+                // keep the connection. We clear the whole tail (rather than
+                // a partial trim) so what we resume sending stays 188-byte
+                // TS-packet aligned; the client sees a brief glitch, not a
+                // disconnect. /stream (browser mpegts.js) is left closing
+                // because it cannot tolerate a mid-stream byte drop.
                 if (p.pending() > kMaxClientBacklog)
                 {
-                    LOG_WARN("/raw client fd=" + std::to_string(clientFd) +
-                             " send backlog " + std::to_string(p.pending()) +
-                             " bytes exceeded cap — closing");
-                    drop = true;
+                    p.tail.clear();
+                    p.tailOffset = 0;
+                    uint64_t n = ++p.backlogDrops;
+                    if (n == 1 || (n % 30) == 0)
+                    {
+                        LOG_WARN("/raw client fd=" + std::to_string(clientFd) +
+                                 " send backlog exceeded cap — dropped backlog, keeping connection (total drops: " +
+                                 std::to_string(n) + ")");
+                    }
                 }
             }
 

--- a/src/streaming/HTTPTSStreamer.h
+++ b/src/streaming/HTTPTSStreamer.h
@@ -360,6 +360,11 @@ private:
     {
         std::vector<uint8_t> tail;
         size_t tailOffset = 0;
+        // #93 — how many times this client's send backlog overflowed the
+        // cap. For /raw we drop the backlog and keep the connection (the
+        // FFmpeg demuxer resyncs at the next keyframe) instead of closing
+        // and forcing a messy reconnect; this just throttles the log.
+        uint64_t backlogDrops = 0;
         size_t pending() const { return tail.size() - tailOffset; }
     };
     static constexpr size_t kMaxClientBacklog = 4 * 1024 * 1024; // 4 MB

--- a/src/streaming/StreamManager.cpp
+++ b/src/streaming/StreamManager.cpp
@@ -165,6 +165,16 @@ bool StreamManager::hasRawClients() const
     return false;
 }
 
+bool StreamManager::hasClients() const
+{
+    for (const auto &streamer : m_streamers)
+    {
+        if (!streamer->isActive()) continue;
+        if (streamer->getClientCount() > 0) return true;
+    }
+    return false;
+}
+
 std::vector<std::string> StreamManager::getStreamUrls() const
 {
     std::vector<std::string> urls;

--- a/src/streaming/StreamManager.h
+++ b/src/streaming/StreamManager.h
@@ -68,6 +68,14 @@ public:
     bool hasRawClients() const;
 
     /**
+     * True if at least one streamer has a connected /stream client.
+     * Application uses this to gate pushFrame (the shader-processed
+     * /stream feed) so the host doesn't run a second VAAPI encode when
+     * nobody is watching /stream — symmetric to hasRawClients().
+     */
+    bool hasClients() const;
+
+    /**
      * Get all stream URLs
      */
     std::vector<std::string> getStreamUrls() const;


### PR DESCRIPTION
Closes #93.

Fixes the remote-client A/V desync reported on the `0.8.0-alpha` release. Measured end-to-end with on-screen A/V-offset instrumentation: went from a **-14 s reconnect desync with no audio** to **~0 to -50 ms, audio-locked, in a stable window**.

## What was wrong (measured, not guessed)
The desync had several independent root causes, found by adding an `A/V offset (audio-wall) = … vqueue=N/20` log and reading host+client logs across many reconnect cycles:

1. **Connection cascade** — on a slow `/raw` receiver the host hit the 4 MB send-backlog cap and **hard-closed** the socket, forcing a full messy reconnect (re-probe, deferred audio sink, multi-second desync, audio dropout) in a loop.
2. **No audio on reconnect** — an earlier auto-resync attempt flushed the audio sink every few seconds, so audio never played; reverted.
3. **Constant A/V skew** — `MediaEncoder` latched **two separate epochs** (`m_firstVideoTimestampUs` vs `m_firstAudioTimestampUs`); the gap between the first video frame and first audio chunk became a permanent skew baked into the muxed PTS.
4. **~14 s reconnect desync** — after the video drained to the live edge, a burst of stale audio (loosely-interleaved MPEG-TS over the relay) arrived *after* the drain and played seconds behind the picture.
5. **Wasted second encode** — `pushFrame` (the shader `/stream` feed) had **no client gate** while `pushRawFrame` did, so the host ran a second h264_vaapi 720p60 encode for `/stream` even when only a remote `/raw` client was connected — competing for the GPU and starving the `/raw` encode.

## Fixes (one commit each)
- `feat(client)`: jump to live on remote (re)connect — drop the connect backlog instead of replaying it.
- `fix(client)`: drop audio backlog on jump-to-live.
- `revert(av-sync)`: remove the sustained-drift auto-resync — it starved audio.
- `fix(streaming)`: drop `/raw` backlog instead of closing slow clients — the FFmpeg demuxer resyncs at the next keyframe, no teardown (`/stream`/mpegts.js left closing, it can't tolerate a byte drop).
- `fix(av-sync)`: share one A/V epoch in `MediaEncoder` so audio and video PTS share an origin.
- `fix(av-sync)`: drop stale audio older than the live video anchor (`m_firstPtsUs`, 300 ms tolerance) — kills the ~14 s reconnect desync.
- `fix(streaming)`: idle the `/stream` encoder when nobody is watching it (`StreamManager::hasClients()`), freeing the GPU for `/raw`.
- `diag(av-sync)`: A/V offset + video-queue-depth instrumentation (kept; INFO level).

Builds clean on Linux x86_64 and Windows x86_64 (MinGW).

## Out of scope — follow-ups
A/V *clock* sync is delivered. The residual issues are separate infra/perf problems, filed as follow-ups:
- Connection instability through the relay / host upload bandwidth for 720p60 (tls pull error / 502 / IO error).
- `/raw` encode throughput on the host (can't sustain 60 fps; per-frame `convertRGBToYUV` swscale + VAAPI).
- Small residual progressive drift (~-180 ms over ~20 s) within a stable window.