### PR TITLE
fix(meta): decode chunked Transfer-Encoding in the SSE reader (#120)

### DIFF
--- a/src/streaming/RemoteMetaSync.cpp
+++ b/src/streaming/RemoteMetaSync.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 
 namespace
@@ -356,29 +357,92 @@ bool RemoteMetaSync::runSSE()
         int code = std::atoi(headerSection.c_str() + sp + 1);
         if (code < 200 || code >= 300) return false;
     }
+    // Lower-case header copy for the Content-Type / Transfer-Encoding checks.
+    std::string headerLower = headerSection;
+    std::transform(headerLower.begin(), headerLower.end(), headerLower.begin(),
+                   [](unsigned char c) { return static_cast<char>(::tolower(c)); });
+
     // Content-Type check — must be text/event-stream for SSE.
+    if (headerLower.find("text/event-stream") == std::string::npos)
     {
-        std::string lower = headerSection;
-        std::transform(lower.begin(), lower.end(), lower.begin(),
-                       [](unsigned char c) { return static_cast<char>(::tolower(c)); });
-        if (lower.find("text/event-stream") == std::string::npos)
+        // Server responded with the old one-shot JSON snapshot — parse it
+        // and dispatch, then return false so the caller falls back to
+        // short-polling (since this server doesn't support SSE).
+        std::string body = buf.substr(headerEnd + 4);
+        Snapshot snap;
+        if (parseSnapshotJSON(body, snap))
         {
-            // Server responded with the old one-shot JSON snapshot — parse it
-            // and dispatch, then return false so the caller falls back to
-            // short-polling (since this server doesn't support SSE).
-            std::string body = buf.substr(headerEnd + 4);
-            Snapshot snap;
-            if (parseSnapshotJSON(body, snap))
-            {
-                dispatchIfChanged(snap);
-            }
-            return false;
+            dispatchIfChanged(snap);
         }
+        return false;
     }
 
-    LOG_INFO("RemoteMetaSync: SSE stream established with " + m_baseUrl);
+    // #120 — through a proxy (Cloudflare / stream.retrocapture.com) the SSE
+    // response is sent with Transfer-Encoding: chunked. The hand-rolled
+    // reader below splits events on "\n\n" over the raw bytes; without
+    // de-chunking, the chunk-size framing ("<hexsize>\r\n … \r\n") gets
+    // embedded into whichever event straddles a chunk boundary and the
+    // JSON parse fails ("ill-formed UTF-8 byte" / "missing closing quote").
+    // Direct host connections are unchunked so it only bit behind a proxy.
+    const bool chunked = (headerLower.find("transfer-encoding:") != std::string::npos &&
+                          headerLower.find("chunked") != std::string::npos);
 
-    std::string body = buf.substr(headerEnd + 4);
+    LOG_INFO(std::string("RemoteMetaSync: SSE stream established with ") + m_baseUrl +
+             (chunked ? " (chunked)" : ""));
+
+    // Incremental HTTP chunked-transfer decoder. Chunks can straddle recv()
+    // boundaries, so state (which phase, bytes left in the current chunk)
+    // persists across calls. Consumes complete framing from rawBuf and
+    // appends only the de-chunked payload to out; leaves any incomplete
+    // tail in rawBuf for the next pass.
+    std::string rawBuf;          // undecoded chunked bytes
+    size_t chunkRemaining = 0;   // data bytes left in the current chunk
+    int    chunkPhase     = 0;   // 0 = size line, 1 = data, 2 = trailing CRLF
+    bool   chunkError     = false;
+    auto dechunk = [&](std::string &out)
+    {
+        while (!rawBuf.empty())
+        {
+            if (chunkPhase == 0) // reading "<hexsize>[;ext]\r\n"
+            {
+                size_t crlf = rawBuf.find("\r\n");
+                if (crlf == std::string::npos)
+                {
+                    if (rawBuf.size() > 16 * 1024) chunkError = true; // garbage / desync
+                    break;
+                }
+                std::string sizeLine = rawBuf.substr(0, crlf);
+                size_t semi = sizeLine.find(';'); // strip chunk extensions
+                if (semi != std::string::npos) sizeLine.erase(semi);
+                chunkRemaining = static_cast<size_t>(strtoul(sizeLine.c_str(), nullptr, 16));
+                rawBuf.erase(0, crlf + 2);
+                if (chunkRemaining == 0) break; // last chunk (0\r\n\r\n) — stream end
+                chunkPhase = 1;
+            }
+            else if (chunkPhase == 1) // chunk data
+            {
+                size_t take = std::min(chunkRemaining, rawBuf.size());
+                out.append(rawBuf, 0, take);
+                rawBuf.erase(0, take);
+                chunkRemaining -= take;
+                if (chunkRemaining == 0) chunkPhase = 2;
+                else break; // need more bytes for this chunk
+            }
+            else // chunkPhase == 2: CRLF terminating the chunk data
+            {
+                if (rawBuf.size() < 2) break; // wait for both bytes
+                rawBuf.erase(0, 2);
+                chunkPhase = 0;
+            }
+        }
+    };
+
+    std::string body;
+    {
+        std::string afterHeaders = buf.substr(headerEnd + 4);
+        if (chunked) { rawBuf = std::move(afterHeaders); dechunk(body); }
+        else         { body    = std::move(afterHeaders); }
+    }
     buf.clear();
 
     auto processEvents = [&](std::string &stream)
@@ -428,7 +492,22 @@ bool RemoteMetaSync::runSSE()
     {
         int n = conn.recvSome(chunk, sizeof(chunk));
         if (n <= 0) break;
-        body.append(chunk, static_cast<size_t>(n));
+        if (chunked)
+        {
+            rawBuf.append(chunk, static_cast<size_t>(n));
+            dechunk(body);
+            // Malformed chunk framing — bail so the caller reconnects fresh
+            // rather than spinning on a desynced byte stream.
+            if (chunkError)
+            {
+                LOG_WARN("RemoteMetaSync: malformed chunked framing on SSE — reconnecting");
+                return true;
+            }
+        }
+        else
+        {
+            body.append(chunk, static_cast<size_t>(n));
+        }
         if (body.size() > 256 * 1024)
         {
             // Sanity cap. Drop anything before the last complete event boundary.


### PR DESCRIPTION
## Problem

When a remote client consumes `/meta` through a proxy (e.g. Cloudflare on `stream.retrocapture.com`), the proxy re-frames the SSE response with `Transfer-Encoding: chunked`. The SSE reader in `RemoteMetaSync::runSSE` fed the raw socket bytes straight into the `\n\n` event splitter without stripping chunk framing, so the hex size lines and inter-chunk CRLFs corrupted the JSON payload. Every client logged a steady stream of:

```
RemoteMetaSync: JSON parse failed — ... ill-formed UTF-8 byte / missing closing quote
```

and `/meta`-driven sync (shader / parameters / source) silently failed behind the proxy. Direct (non-proxied) connections were unaffected because the host doesn't chunk.

## Fix

Detect `Transfer-Encoding: chunked` from the response headers and run an **incremental** chunked decoder before the event splitter. State persists across `recv` boundaries (a chunk can straddle reads): size line → data → trailing CRLF. Only the de-chunked payload reaches the JSON parser. Malformed framing (or an oversized size line) bails to a clean reconnect rather than wedging. The direct, non-chunked path is untouched.

The SSE-established log now appends `(chunked)` when the decoder is active, for quick diagnosis.

## Test

- Build: Linux x86_64 and Windows x86_64 Docker builds pass clean.
- Connect a remote client through `stream.retrocapture.com`: log shows `SSE stream established ... (chunked)`, the `JSON parse failed` spam is gone, and shader/param/source changes on the host reflect on the client.

Closes #120