### PR TITLE
fix(stream): don't run the /stream encode for /raw-only clients (#123)

### DIFF
--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -15,6 +15,7 @@ extern "C"
 #include "../utils/FFmpegCompat.h"
 #include <cstring>
 #include <mutex>
+#include <chrono>
 
 const char *MediaEncoder::hardwareEncoderName(HardwareEncoder h)
 {
@@ -1490,11 +1491,18 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
         return false;
     }
 
+    // #123 — time each encode stage so the streaming telemetry can show
+    // whether the CPU swscale convert, the HW upload, or the codec itself
+    // is the bottleneck when the synchronizer overflows at 60 fps.
+    using stage_clock = std::chrono::steady_clock;
+    auto stageT0 = stage_clock::now();
+
     if (!convertRGBToYUV(rgbData, width, height, videoFrame))
     {
         LOG_ERROR("MediaEncoder: convertRGBToYUV failed");
         return false;
     }
+    auto stageAfterConvert = stage_clock::now();
 
     int64_t calculatedPTS = calculateVideoPTS(captureTimestampUs);
     videoFrame->pts = calculatedPTS;
@@ -1524,6 +1532,7 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
     // AMF / D3D11) need the software-side NV12 frame uploaded to a
     // hardware surface before the codec can consume it. NVENC and the
     // software path skip this and feed the sw frame directly.
+    auto stageBeforeUpload = stage_clock::now();
     AVFrame *frameToSend = videoFrame;
     if (m_hwVideoFrame &&
         m_activeHardwareEncoder != HardwareEncoder::Software &&
@@ -1543,6 +1552,7 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
         FFmpegCompat::setKeyFrame(hwFrame, forceKeyframe);
         frameToSend = hwFrame;
     }
+    auto stageAfterUpload = stage_clock::now();
 
     int ret = avcodec_send_frame(codecCtx, frameToSend);
     if (ret < 0)
@@ -1562,7 +1572,20 @@ bool MediaEncoder::encodeVideo(const uint8_t *rgbData, uint32_t width, uint32_t 
     // path is inactive.
     (void)frameToSend;
 
-    return receiveVideoPackets(packets, captureTimestampUs);
+    bool recvOk = receiveVideoPackets(packets, captureTimestampUs);
+    auto stageEnd = stage_clock::now();
+
+    // #123 — accumulate per-stage microseconds for the telemetry.
+    using us = std::chrono::microseconds;
+    m_convertUs.fetch_add(std::chrono::duration_cast<us>(stageAfterConvert - stageT0).count(),
+                          std::memory_order_relaxed);
+    m_uploadUs.fetch_add(std::chrono::duration_cast<us>(stageAfterUpload - stageBeforeUpload).count(),
+                         std::memory_order_relaxed);
+    m_encodeUs.fetch_add(std::chrono::duration_cast<us>(stageEnd - stageAfterUpload).count(),
+                         std::memory_order_relaxed);
+    m_stageFrames.fetch_add(1, std::memory_order_relaxed);
+
+    return recvOk;
 }
 
 bool MediaEncoder::receiveVideoPackets(std::vector<EncodedPacket> &packets, int64_t captureTimestampUs)
@@ -1853,6 +1876,10 @@ void MediaEncoder::cleanup()
     m_audioFrameCount = 0;
     m_videoFrameCountForPTS = 0;
     m_desyncFrameCount.store(0, std::memory_order_relaxed);
+    m_convertUs.store(0, std::memory_order_relaxed);
+    m_uploadUs.store(0, std::memory_order_relaxed);
+    m_encodeUs.store(0, std::memory_order_relaxed);
+    m_stageFrames.store(0, std::memory_order_relaxed);
 
     {
         std::lock_guard<std::mutex> lock(m_ptsMutex);

--- a/src/encoding/MediaEncoder.h
+++ b/src/encoding/MediaEncoder.h
@@ -131,6 +131,24 @@ public:
     // Não-zero indica instabilidade no timestamp source.
     uint64_t getDesyncFrameCount() const { return m_desyncFrameCount.load(std::memory_order_relaxed); }
 
+    // #123 — per-stage video encode timing, in microseconds, accumulated
+    // since the last fetch. encodeVideo() splits its cost into:
+    //   convertUs — convertRGBToYUV (CPU swscale: RGB→NV12 + any resize)
+    //   uploadUs  — av_hwframe_transfer_data (sw NV12 → GPU surface; 0 for SW/NVENC)
+    //   encodeUs  — avcodec_send_frame + receiveVideoPackets (codec)
+    // frames is how many encodeVideo calls contributed. fetch resets the
+    // accumulators so a caller can print a clean rolling average.
+    struct VideoStageTimings { uint64_t convertUs = 0, uploadUs = 0, encodeUs = 0, frames = 0; };
+    VideoStageTimings fetchVideoStageTimings()
+    {
+        VideoStageTimings t;
+        t.convertUs = m_convertUs.exchange(0, std::memory_order_relaxed);
+        t.uploadUs  = m_uploadUs.exchange(0, std::memory_order_relaxed);
+        t.encodeUs  = m_encodeUs.exchange(0, std::memory_order_relaxed);
+        t.frames    = m_stageFrames.exchange(0, std::memory_order_relaxed);
+        return t;
+    }
+
 private:
     // Inicialização de codecs
     bool initializeVideoCodec();
@@ -245,4 +263,13 @@ private:
     // timestamp source — o stream ainda fica monotônico, mas isso vira jitter
     // de duração de frame no arquivo final.
     std::atomic<uint64_t> m_desyncFrameCount{0};
+
+    // #123 — per-stage encode timing accumulators (microseconds). See
+    // fetchVideoStageTimings(). Populated by encodeVideo, read+reset by
+    // the streaming telemetry. Per-instance, so /stream and /raw report
+    // independently.
+    std::atomic<uint64_t> m_convertUs{0};
+    std::atomic<uint64_t> m_uploadUs{0};
+    std::atomic<uint64_t> m_encodeUs{0};
+    std::atomic<uint64_t> m_stageFrames{0};
 };

--- a/src/encoding/MediaSynchronizer.cpp
+++ b/src/encoding/MediaSynchronizer.cpp
@@ -61,7 +61,7 @@ bool MediaSynchronizer::addVideoFrame(const uint8_t *data, uint32_t width, uint3
             uint64_t dropped = m_videoDropCount.fetch_add(1, std::memory_order_relaxed) + 1;
             if (dropped == 1 || (dropped % 30) == 0)
             {
-                LOG_WARN("MediaSynchronizer: video buffer overflow, dropped frame (total: " +
+                LOG_WARN("MediaSynchronizer[" + m_name + "]: video buffer overflow, dropped frame (total: " +
                          std::to_string(dropped) + ")");
             }
         }
@@ -113,7 +113,7 @@ bool MediaSynchronizer::addAudioChunk(const int16_t *samples, size_t sampleCount
             uint64_t dropped = m_audioDropCount.fetch_add(1, std::memory_order_relaxed) + 1;
             if (dropped == 1 || (dropped % 30) == 0)
             {
-                LOG_WARN("MediaSynchronizer: audio buffer overflow, dropped chunk (total: " +
+                LOG_WARN("MediaSynchronizer[" + m_name + "]: audio buffer overflow, dropped chunk (total: " +
                          std::to_string(dropped) + ")");
             }
         }

--- a/src/encoding/MediaSynchronizer.h
+++ b/src/encoding/MediaSynchronizer.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <string>
 
 /**
  * MediaSynchronizer - Classe responsável por sincronização de áudio e vídeo
@@ -64,6 +65,10 @@ public:
 
     MediaSynchronizer();
     ~MediaSynchronizer();
+
+    // Rótulo da instância ("stream" / "raw") — aparece nos logs de overflow
+    // para desambiguar qual pipeline está descartando frames (#123).
+    void setName(const std::string &name) { m_name = name; }
 
     // Configurar parâmetros de sincronização
     void setSyncTolerance(int64_t toleranceUs) { m_syncToleranceUs = toleranceUs; }
@@ -160,4 +165,7 @@ private:
     // chamados de threads distintas dos getters.
     std::atomic<uint64_t> m_videoDropCount{0};
     std::atomic<uint64_t> m_audioDropCount{0};
+
+    // Rótulo da instância para logs (#123). Vazio por padrão.
+    std::string m_name;
 };

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -1537,6 +1537,7 @@ int HTTPTSStreamer::writeToRawClients(const uint8_t *buf, int buf_size)
 bool HTTPTSStreamer::initializeEncoding()
 {
     // Configurar MediaSynchronizer com valores configuráveis
+    m_streamSynchronizer.setName("stream");
     m_streamSynchronizer.setMaxBufferTime(m_maxBufferTimeSeconds * 1000000LL);
     m_streamSynchronizer.setMaxVideoBufferSize(m_maxVideoBufferSize);
     m_streamSynchronizer.setMaxAudioBufferSize(m_maxAudioBufferSize);
@@ -1621,6 +1622,7 @@ bool HTTPTSStreamer::initializeRawPipeline()
     // meaningful latency — the encoder still pulls in near-real-time.
     const size_t rawMaxVideo = std::max<size_t>(m_maxVideoBufferSize, 60);
     const size_t rawMaxAudio = std::max<size_t>(m_maxAudioBufferSize, 120);
+    m_rawStreamSynchronizer.setName("raw");
     m_rawStreamSynchronizer.setMaxBufferTime(m_maxBufferTimeSeconds * 1000000LL);
     m_rawStreamSynchronizer.setMaxVideoBufferSize(rawMaxVideo);
     m_rawStreamSynchronizer.setMaxAudioBufferSize(rawMaxAudio);

--- a/src/streaming/HTTPTSStreamer.cpp
+++ b/src/streaming/HTTPTSStreamer.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #endif
 #include <cstring>
+#include <cstdio>
 #include <cerrno>
 #include <cstdlib>
 #include <time.h>
@@ -3560,10 +3561,32 @@ void HTTPTSStreamer::rawEncodingThread()
         auto nowTs = std::chrono::steady_clock::now();
         if (std::chrono::duration_cast<std::chrono::seconds>(nowTs - statStart).count() >= 1)
         {
-            LOG_DEBUG("/raw encoder: video=" + std::to_string(statVideoEncoded) +
-                      "/s audio=" + std::to_string(statAudioEncoded) +
-                      "/s iters=" + std::to_string(statIterations) +
-                      " maxVidQueue=" + std::to_string(statMaxQueueDepth));
+            // #123 — per-stage averages (ms/frame) so we can see whether the
+            // CPU swscale convert, the HW surface upload, or the codec is the
+            // 60 fps bottleneck. avg = accumulated µs / frames encoded.
+            auto st = m_rawMediaEncoder.fetchVideoStageTimings();
+            std::string line = "/raw encoder: video=" + std::to_string(statVideoEncoded) +
+                               "/s audio=" + std::to_string(statAudioEncoded) +
+                               "/s iters=" + std::to_string(statIterations) +
+                               " maxVidQueue=" + std::to_string(statMaxQueueDepth);
+            if (st.frames > 0)
+            {
+                double convMs = (st.convertUs / 1000.0) / st.frames;
+                double upMs   = (st.uploadUs  / 1000.0) / st.frames;
+                double encMs  = (st.encodeUs  / 1000.0) / st.frames;
+                char buf[160];
+                std::snprintf(buf, sizeof(buf),
+                              " stages(ms/f): convert=%.2f upload=%.2f encode=%.2f total=%.2f",
+                              convMs, upMs, encMs, convMs + upMs + encMs);
+                line += buf;
+                // Active /raw client: surface at INFO so the bottleneck is
+                // visible without enabling debug logging (#123 measurement).
+                LOG_INFO(line);
+            }
+            else
+            {
+                LOG_DEBUG(line);
+            }
             statVideoEncoded = statAudioEncoded = statIterations = 0;
             statMaxQueueDepth = 0;
             statStart = nowTs;

--- a/src/streaming/HTTPTSStreamer.h
+++ b/src/streaming/HTTPTSStreamer.h
@@ -65,6 +65,17 @@ public:
     uint32_t getRawClientCount() const { return m_rawClientCount.load(); }
     bool hasRawClients() const { return m_rawClientCount.load() > 0; }
 
+    // /stream-only subscriber count. getClientCount() above deliberately
+    // combines /stream + /raw for the audience display (#68); this counts
+    // ONLY the MPEG-TS /stream viewers. Used to gate the shader-processed
+    // /stream encode: a /raw client must NOT make the host run a second
+    // VAAPI encode for a /stream feed nobody is watching (#123 — the
+    // combined count let a /raw client defeat the #121 gate, so the host
+    // ran two concurrent 720p60 encodes and the /stream synchronizer
+    // overflowed continuously).
+    uint32_t getStreamClientCount() const { return m_clientCount.load(); }
+    bool hasStreamClients() const { return m_clientCount.load() > 0; }
+
     // Additional configuration methods
     void setVideoBitrate(uint32_t bitrate) { m_videoBitrate = bitrate; }
     void setAudioBitrate(uint32_t bitrate) { m_audioBitrate = bitrate; }

--- a/src/streaming/StreamManager.cpp
+++ b/src/streaming/StreamManager.cpp
@@ -167,10 +167,20 @@ bool StreamManager::hasRawClients() const
 
 bool StreamManager::hasClients() const
 {
+    // /stream-only gate. Mirrors hasRawClients(): we must NOT count /raw
+    // subscribers here, otherwise a remote /raw client makes this return
+    // true and the host runs the shader-processed /stream VAAPI encode for
+    // a feed nobody is watching — a second concurrent 720p60 encode that
+    // overflowed the /stream synchronizer and stole GPU from the /raw
+    // encode (#123). getClientCount() is combined for the audience display
+    // (#68); the encode gate needs the /stream-only count.
     for (const auto &streamer : m_streamers)
     {
         if (!streamer->isActive()) continue;
-        if (streamer->getClientCount() > 0) return true;
+        if (auto *ts = dynamic_cast<const HTTPTSStreamer *>(streamer.get()))
+        {
+            if (ts->hasStreamClients()) return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
## Symptom

With a remote `/raw` client connected, the host logged `MediaSynchronizer: video buffer overflow, dropped frame` growing continuously (~10/s). The issue assumed the `/raw` h264_vaapi encode couldn't sustain 60 fps.

## Measurement (it wasn't /raw)

Added per-stage encode timing + per-instance synchronizer labels. The data disproved the premise:

```
/raw encoder: video=60/s audio=43/s maxVidQueue=1 stages(ms/f): convert=2.3 upload=0.4 encode=2.1 total=4.9
MediaSynchronizer[stream]: video buffer overflow, dropped frame (total: ...)
```

The `/raw` encoder ran a solid **60 fps** at ~4.9 ms/frame (headroom for ~200 fps), queue depth 1 — never the bottleneck. The overflow was tagged `[stream]`, and it happened with **no `/stream` viewer connected at all**.

## Root cause

The #121 gate that idles the shader-processed `/stream` encode when nobody's watching used `StreamManager::hasClients()` → `IStreamer::getClientCount()`. But `getClientCount()` deliberately returns `m_clientCount + m_rawClientCount` — the **combined** audience count for the #68 UI display. So a single remote `/raw` client made `hasClients()` true, and the host ran a **second concurrent h264_vaapi 720p60 encode** for a `/stream` feed nobody was watching. That second encode overflowed the `/stream` synchronizer and stole GPU from the `/raw` encode — the same contention that hurt the remote client's A/V in #93.

## Fix

- Add `HTTPTSStreamer::hasStreamClients()` (counts `m_clientCount` only — `/stream` viewers).
- `StreamManager::hasClients()` — used **solely** to gate the `/stream` encode — now checks the `/stream`-only count, mirroring `hasRawClients()`. `getClientCount()` stays combined for the audience display (#68).

A `/raw`-only session now runs a single VAAPI encode; the `/stream` synchronizer stays empty.

## Test

- Linux x86_64 + Windows x86_64 Docker builds pass clean.
- Host with a `/raw`-only remote client, post-fix: **zero** `MediaSynchronizer[stream]` overflow drops; `/raw encoder` steady at `video=60/s maxVidQueue=1`.

The per-stage timing and synchronizer-name instrumentation are kept — cheap, INFO-gated on an active client, and useful for the related #122/#124 follow-ups.

Closes #123