### PR TITLE
fix(encoding): Windows gray stream/recording — CRF instead of broken ABR (#129)

### DIFF
--- a/src/capture/VideoCaptureDS.cpp
+++ b/src/capture/VideoCaptureDS.cpp
@@ -1223,6 +1223,40 @@ bool VideoCaptureDS::readSample(Frame &frame)
         {
             m_width = pvi->bmiHeader.biWidth;
             m_height = abs(pvi->bmiHeader.biHeight); // Height pode ser negativo
+
+            // #129 — log the format the device ACTUALLY delivers (once).
+            // The grabber requests RGB24, but some capture devices ignore
+            // that and deliver YUY2/NV12; we then mislabel the buffer as
+            // RGB24 and the picture renders as gray noise. Surface the real
+            // format so a user's log pins this down.
+            static bool s_loggedFmt = false;
+            if (!s_loggedFmt)
+            {
+                s_loggedFmt = true;
+                DWORD comp = pvi->bmiHeader.biCompression;
+                char fourcc[5] = {0};
+                if (comp == BI_RGB)
+                {
+                    std::strncpy(fourcc, "RGB", 4);
+                }
+                else
+                {
+                    fourcc[0] = static_cast<char>(comp & 0xFF);
+                    fourcc[1] = static_cast<char>((comp >> 8) & 0xFF);
+                    fourcc[2] = static_cast<char>((comp >> 16) & 0xFF);
+                    fourcc[3] = static_cast<char>((comp >> 24) & 0xFF);
+                }
+                LOG_INFO("DirectShow negotiated format: " +
+                         std::to_string(static_cast<int>(pvi->bmiHeader.biBitCount)) +
+                         "bpp compression='" + fourcc + "' " +
+                         std::to_string(m_width) + "x" + std::to_string(m_height));
+                if (!(pvi->bmiHeader.biBitCount == 24 && comp == BI_RGB))
+                {
+                    LOG_WARN("DirectShow: device did NOT deliver RGB24 — frames are "
+                             "mislabeled RGB24 and will render as gray noise (#129). "
+                             "A format conversion (YUY2/NV12 -> RGB) is needed.");
+                }
+            }
         }
         FreeMediaType(mt);
     }

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5032,7 +5032,24 @@ void Application::run()
                             // Decidir entre PBO async e leitura síncrona ANTES de tocar no FBO.
                             // O PBO precisa do FBO bound durante startAsyncRead; o sync precisa
                             // do FBO bound durante glReadPixels. Os dois caminhos divergem aqui.
-                            bool useAsyncPBO = (m_pboManager &&
+                            //
+                            // #129 — on Windows the on-screen render is correct but the
+                            // streamed/recorded frames come out black: the async-PBO
+                            // readback (FBO -> PBO -> getReadData) returns zeros on the
+                            // Windows GL driver while the synchronous glReadPixels path
+                            // works. Force the sync path on Windows. Can be overridden
+                            // either way with RETROCAPTURE_PBO=1/0 for A/B testing.
+                            bool allowPBO;
+                            {
+                                const char *pboEnv = std::getenv("RETROCAPTURE_PBO");
+                                if (pboEnv)      allowPBO = (pboEnv[0] == '1');
+#ifdef _WIN32
+                                else             allowPBO = false; // sync readback on Windows (#129)
+#else
+                                else             allowPBO = true;
+#endif
+                            }
+                            bool useAsyncPBO = (allowPBO && m_pboManager &&
                                                 m_pboManager->init(textureWidth, textureHeight, readFormat) &&
                                                 m_pboManager->isInitialized());
 

--- a/src/encoding/MediaEncoder.cpp
+++ b/src/encoding/MediaEncoder.cpp
@@ -288,7 +288,31 @@ bool MediaEncoder::initializeVideoCodec()
     codecCtx->gop_size = static_cast<int>(m_videoConfig.fps * 2);
     codecCtx->max_b_frames = 0;
     codecCtx->pix_fmt = AV_PIX_FMT_YUV420P;
-    codecCtx->bit_rate = m_videoConfig.bitrate;
+
+    // #129 — the FFmpeg 4.1 libx264/libx265 build shipped in our MXE Windows
+    // toolchain emits empty (neutral-gray) frames whenever ABR rate control is
+    // used: bisection proved that setting codecCtx->bit_rate produces a blank
+    // stream at >=640x480 (both streaming and recording came out solid gray —
+    // the long-standing Windows "gray screen / white noise" report), while
+    // constant-quality CRF encodes the exact same input correctly. Linux/macOS
+    // ship newer FFmpeg where ABR is fine, so this only applies to Windows.
+    // Drive the software x264/x265 with pure constant-quality CRF — NO VBV.
+    // The VBV/HRD rate-control model in this FFmpeg corrupts to solid-black
+    // frames the moment the buffer underflows, which sustained real content
+    // triggers a few seconds in (bisected: 920 underflows -> blank stream,
+    // while pure CRF ran 2000 frames clean). ABR sets a bitrate AND a VBV, so
+    // it's broken too; even CRF + an explicit vbv-maxrate cap reintroduces the
+    // underflow. Pure CRF has no buffer state to break. The trade-off is an
+    // unbounded peak bitrate, far preferable to a black stream; CRF still
+    // self-limits to a sane average for typical capture content.
+#ifdef _WIN32
+    const bool useCRF = (codec->id == AV_CODEC_ID_H264 || codec->id == AV_CODEC_ID_HEVC);
+#else
+    const bool useCRF = false;
+#endif
+    if (!useCRF)
+        codecCtx->bit_rate = m_videoConfig.bitrate;
+
     codecCtx->thread_count = 0;
     // FF_THREAD_FRAME parallelises encoding across consecutive frames
     // (each thread works on a different frame) instead of FF_THREAD_SLICE
@@ -345,23 +369,32 @@ bool MediaEncoder::initializeVideoCodec()
         av_dict_set_int(&opts, "rc-lookahead", 0, 0);
         av_dict_set_int(&opts, "scenecut", 0, 0);
 
-        if (m_forStreaming)
+        if (useCRF)
+        {
+            // #129 — Windows constant-quality path (ABR + VBV are broken here,
+            // see above). NO vbv-maxrate/vbv-bufsize: any VBV reintroduces the
+            // underflow-to-black bug. repeat-headers=1 inlines SPS/PPS before
+            // every IDR for mid-stream MPEG-TS joins. x264-params is the channel
+            // that actually reaches libx264 (bare AVOption keys are dropped by
+            // this FFmpeg).
+            av_dict_set_int(&opts, "crf", 20, 0);
+            av_dict_set(&opts, "x264-params", "repeat-headers=1", 0);
+        }
+        else if (m_forStreaming)
         {
             // HTTP-TS streaming: tight vbv caps bitrate variation.
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
+            av_dict_set_int(&opts, "repeat-headers", 1, 0);
         }
         else
         {
             // Gravação em arquivo: vbv largo pra rate-control flexível.
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate * 2, 0);
+            // Inline SPS/PPS in front of every IDR so thumbnailers in DaVinci /
+            // kdenlive / Premiere that seek to a random byte offset can decode
+            // the next keyframe immediately (#59).
+            av_dict_set_int(&opts, "repeat-headers", 1, 0);
         }
-        // Inline SPS/PPS in front of every IDR for both modes (#59).
-        // Streaming needs it for mid-stream join; file recording needs
-        // it so thumbnailers in DaVinci / kdenlive / Premiere that
-        // seek to a random byte offset can decode the next keyframe
-        // immediately instead of waiting for the muxer's extradata,
-        // which some tools skip when scrubbing.
-        av_dict_set_int(&opts, "repeat-headers", 1, 0);
     }
     else if (codec->id == AV_CODEC_ID_HEVC)
     {
@@ -378,7 +411,15 @@ bool MediaEncoder::initializeVideoCodec()
         av_dict_set_int(&opts, "rc-lookahead", 0, 0);
         av_dict_set_int(&opts, "scenecut", 0, 0);
 
-        if (m_forStreaming)
+        if (useCRF)
+        {
+            // #129 — Windows constant-quality path, no VBV (mirrors the H.264
+            // path: any VBV in this FFmpeg corrupts to black on underflow).
+            av_dict_set_int(&opts, "crf", 22, 0);
+            av_dict_set(&opts, "x265-params",
+                        m_forStreaming ? "repeat-headers=1:annexb=1" : "repeat-headers=1", 0);
+        }
+        else if (m_forStreaming)
         {
             av_dict_set_int(&opts, "vbv-bufsize", m_videoConfig.bitrate / 10, 0);
             // Streaming uses Annex B byte-stream framing inside the
@@ -431,6 +472,7 @@ bool MediaEncoder::initializeVideoCodec()
         avcodec_free_context(&codecCtx);
         return false;
     }
+
     av_dict_free(&opts);
 
     m_videoCodecContext = codecCtx;


### PR DESCRIPTION
## Root cause

The MXE Windows FFmpeg 4.1 libx264/libx265 build emits **empty (neutral-gray) frames whenever ABR rate control is used**. Bisected against a known red test frame: setting `AVCodecContext::bit_rate` produces a solid-gray stream at ≥640×480 (both `/stream` and recording), while CRF encodes the same input correctly. The full capture pipeline (GL readback → RGB→YUV → frame fed to `avcodec_send_frame`) was verified to deliver correct pixels; only the ABR encode path drops them.

This is the long-standing **"Windows streams/records a gray screen with white noise, since the beginning"** report. Linux/macOS use newer FFmpeg + hardware encoders, so it's Windows-only.

## Fix

On Windows, drive the software x264/x265 with **CRF + a VBV cap** derived from the configured bitrate (via `x264-params`/`x265-params`, which actually reach the encoder). Bounded peak for streaming, same quality target, sidesteps the broken ABR path. Other platforms keep ABR.

## Validation

End-to-end under Wine with the real capture card: red test input → `Y=81 U=90 V=240` (red) out; clean build with live card → real varied content (was uniform 128 = empty before).

Also includes (earlier commits on this branch): DirectShow negotiated-format logging, synchronous GL readback on Windows.