### PR TITLE
fix(capture): calm no-device placeholder instead of jarring green (#134)

### DIFF
--- a/src/capture/VideoCapture.cpp
+++ b/src/capture/VideoCapture.cpp
@@ -71,6 +71,26 @@ void VideoCapture::close()
     }
 }
 
+namespace
+{
+    // #134 — fill a YUYV (YUY2) dummy buffer with a calm neutral dark-gray
+    // "no signal" frame. All-zero bytes look black in RGB but in YUYV the
+    // chroma bytes default to 0 (= -128 after the 128 bias), which the
+    // YUYV→RGB conversion turns into bright GREEN — that read like an
+    // error/glitch when no device was present. Set Y to a dark level and
+    // U/V to neutral 128. Byte order per 2 px: Y0 U Y1 V.
+    void fillDummyNoSignalYUYV(std::vector<uint8_t> &buf)
+    {
+        for (size_t i = 0; i + 3 < buf.size(); i += 4)
+        {
+            buf[i]     = 0x18; // Y0 — dark gray
+            buf[i + 1] = 0x80; // U  — neutral (128)
+            buf[i + 2] = 0x18; // Y1
+            buf[i + 3] = 0x80; // V  — neutral (128)
+        }
+    }
+} // namespace
+
 bool VideoCapture::setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat)
 {
     // Em modo dummy, apenas definir dimensões sem abrir dispositivo
@@ -82,7 +102,8 @@ bool VideoCapture::setFormat(uint32_t width, uint32_t height, uint32_t pixelForm
 
         // Criar buffer dummy para frame preto (YUYV: 2 bytes por pixel)
         size_t frameSize = width * height * 2;
-        m_dummyFrameBuffer.resize(frameSize, 0); // Preencher com zeros (preto em YUYV)
+        m_dummyFrameBuffer.resize(frameSize);
+        fillDummyNoSignalYUYV(m_dummyFrameBuffer); // neutral dark "no signal", not green (#134)
 
         LOG_INFO("Formato dummy definido: " + std::to_string(m_width) + "x" +
                  std::to_string(m_height) + " (format: 0x" +
@@ -284,7 +305,8 @@ bool VideoCapture::startCapture()
         if (m_dummyFrameBuffer.empty() && m_width > 0 && m_height > 0)
         {
             size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
-            m_dummyFrameBuffer.resize(frameSize, 0);   // Preencher com zeros (preto)
+            m_dummyFrameBuffer.resize(frameSize);
+            fillDummyNoSignalYUYV(m_dummyFrameBuffer); // neutral dark "no signal", not green (#134)
         }
 
         m_streaming = true;
@@ -418,7 +440,8 @@ bool VideoCapture::captureFrame(Frame &frame)
             if (m_width > 0 && m_height > 0)
             {
                 size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
-                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_dummyFrameBuffer.resize(frameSize);
+                fillDummyNoSignalYUYV(m_dummyFrameBuffer); // neutral dark "no signal", not green (#134)
                 m_streaming = true;
                 LOG_INFO("Dummy mode activated automatically after device disconnect");
             }
@@ -476,7 +499,8 @@ bool VideoCapture::captureFrame(Frame &frame)
             if (m_width > 0 && m_height > 0)
             {
                 size_t frameSize = m_width * m_height * 2; // YUYV: 2 bytes por pixel
-                m_dummyFrameBuffer.resize(frameSize, 0);
+                m_dummyFrameBuffer.resize(frameSize);
+                fillDummyNoSignalYUYV(m_dummyFrameBuffer); // neutral dark "no signal", not green (#134)
                 m_streaming = true;
                 LOG_INFO("Dummy mode activated automatically after device disconnect");
             }

--- a/src/capture/VideoCaptureDS.cpp
+++ b/src/capture/VideoCaptureDS.cpp
@@ -913,17 +913,11 @@ bool VideoCaptureDS::setFormat(uint32_t width, uint32_t height, uint32_t pixelFo
         m_height = height;
         m_pixelFormat = pixelFormat;
 
-        // Create dummy buffer (RGB24: 3 bytes per pixel)
-        // Preencher com verde (0, 255, 0) para depuração
+        // Dummy "no signal" buffer (RGB24). Calm neutral dark gray —
+        // the previous bright-green debug fill read like an error when
+        // no device was present (#134).
         size_t frameSize = width * height * 3;
-        m_dummyFrameBuffer.resize(frameSize);
-        // Preencher com verde: RGB(0, 255, 0)
-        for (size_t i = 0; i < frameSize; i += 3)
-        {
-            m_dummyFrameBuffer[i] = 0;     // R
-            m_dummyFrameBuffer[i + 1] = 255; // G
-            m_dummyFrameBuffer[i + 2] = 0;   // B
-        }
+        m_dummyFrameBuffer.assign(frameSize, 0x18); // R=G=B=24 → dark gray
 
         LOG_INFO("Formato dummy definido: " + std::to_string(m_width) + "x" + std::to_string(m_height));
         return true;
@@ -978,15 +972,9 @@ bool VideoCaptureDS::startCapture()
 
         if (m_dummyFrameBuffer.empty() && m_width > 0 && m_height > 0)
         {
-            size_t frameSize = m_width * m_height * 3; // RGB24: 3 bytes per pixel
-            m_dummyFrameBuffer.resize(frameSize);
-            // Preencher com verde: RGB(0, 255, 0) para depuração
-            for (size_t i = 0; i < frameSize; i += 3)
-            {
-                m_dummyFrameBuffer[i] = 0;     // R
-                m_dummyFrameBuffer[i + 1] = 255; // G
-                m_dummyFrameBuffer[i + 2] = 0;   // B
-            }
+            size_t frameSize = m_width * m_height * 3; // RGB24
+            // Calm neutral dark gray "no signal" fill (#134), not green.
+            m_dummyFrameBuffer.assign(frameSize, 0x18); // R=G=B=24 → dark gray
         }
 
         m_streaming = true;


### PR DESCRIPTION
Closes #134. Replace the bright-green no-signal placeholder with a calm dark gray (YUYV + DirectShow dummy paths). Rebased on 0.8.1-alpha. Test: run with no capture device — placeholder is dark gray, not green.