### PR TITLE
chore(release): 0.8.1-alpha — Windows-hardening release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.1-alpha] - 2026-06-12
+
+Fourteenth alpha release. A focused **Windows-hardening** pass: every Windows
+bug reported against 0.8.0-alpha is fixed, so capture, streaming, recording,
+audio and the virtual camera all work on a fresh Windows install. No new
+features — stability and platform-correctness only.
+
+### Fixed
+
+- **Windows stream/recording rendered a solid gray screen** (#129). The
+  FFmpeg 4.1 libx264/libx265 build in the MXE toolchain corrupts the stream to
+  empty frames under both ABR (`bit_rate`) and VBV rate control — VBV
+  underflow a few seconds in turned the picture to gray. The Windows software
+  encoder now uses pure constant-quality CRF (no ABR/VBV), which the bisection
+  proved encodes correctly. Other platforms keep ABR.
+- **Windows captured the wrong audio as white noise** (#137). The audio
+  configuration window was never shown on Windows (so the capture card's audio
+  endpoint couldn't be selected), and the WASAPI 32-bit-float mix format was
+  read as int16 — white noise even with the right device. The window is now
+  available, the float format is decoded correctly, and a **local audio
+  monitor** (with a "Resync monitor" button) lets the operator hear the capture
+  live, mirroring Linux/macOS.
+- **Monochrome, horizontally-tiled capture on some devices** (#135). Cards
+  delivering NV12/UYVY/RGB32 (instead of the requested RGB24) were mislabeled
+  and rendered as grayscale repeated ~3× across the top of the window. The
+  DirectShow grabber now converts NV12, UYVY and RGB32 to RGB alongside the
+  existing YUY2 path.
+- **Virtual camera never appeared in OBS/Zoom/Teams** (#133). The DirectShow
+  filter registered only under the legacy filter category, never under
+  `CLSID_VideoInputDeviceCategory`, so capture apps didn't list it. It is now
+  registered (and unregistered) under the video-input category.
+- **TLS errors listing the public stream directory on Windows** (#130) — load
+  the Windows OS trust store (ROOT + CA) into OpenSSL.
+- **Installer created non-working shortcuts** (#131) — fixed the Start Menu
+  entry and added a Desktop shortcut.
+- **ImGui window positions weren't kept across runs** (#132) — persist the
+  layout on shutdown.
+
+### Changed
+
+- The "no device" capture placeholder is now a calm dark gray instead of a
+  jarring bright green (#134).
+
+---
+
 ## [0.8.0-alpha] - 2026-06-10
 
 Thirteenth alpha release. A platform-reach release: the first working

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(RetroCapture VERSION 0.8.0 LANGUAGES CXX)
+project(RetroCapture VERSION 0.8.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > capture cards. Includes HTTP MPEG-TS streaming, local recording, a virtual
 > camera output, and a full web portal for remote control.
 
-![Version](https://img.shields.io/badge/version-0.8.0--alpha-orange)
+![Version](https://img.shields.io/badge/version-0.8.1--alpha-orange)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20macOS%20%7C%20Raspberry%20Pi-lightgrey)
 ![Status](https://img.shields.io/badge/status-alpha-yellow)
@@ -16,7 +16,7 @@
      Target ~1600x900. Save as docs/screenshots/hero.png -->
 ![Hero](docs/screenshots/hero.png)
 
-**[⬇ Download 0.8.0-alpha](https://github.com/geldoronie/RetroCapture/releases/latest)** ·
+**[⬇ Download 0.8.1-alpha](https://github.com/geldoronie/RetroCapture/releases/latest)** ·
 [Documentation](#documentation) ·
 [Issues](https://github.com/geldoronie/RetroCapture/issues) ·
 [Changelog](CHANGELOG.md)
@@ -58,6 +58,25 @@ RetroCapture turns a generic capture card into a "retro-aware" capture rig:
   contrast, saturation, hue, gain, exposure, gamma, white balance, …).
 - 🥧 **Cross-platform**: Linux x86_64, Windows x86_64, Raspberry Pi 4/5
   (ARM64), Raspberry Pi 2/3/Zero (ARM32v7).
+
+### What's new in 0.8.1-alpha
+
+A Windows-hardening release — every Windows bug reported against 0.8.0-alpha is
+fixed, so capture, streaming, recording, audio and the virtual camera all work
+on a fresh Windows install (no new features):
+
+- **Streaming/recording no longer a gray screen (#129)** — the Windows software
+  encoder now uses CRF instead of the broken ABR/VBV rate control.
+- **Capture-card audio works (#137)** — the audio settings window is now
+  available on Windows, the WASAPI float mix format is decoded correctly (was
+  white noise), and a local audio monitor (+ resync) lets you hear the capture
+  live.
+- **No more monochrome/tiled capture (#135)** — NV12/UYVY/RGB32 devices are now
+  converted to RGB.
+- **Virtual camera shows up in OBS/Zoom (#133)** — the DirectShow filter is
+  registered under the video-input category.
+- Plus: Windows TLS trust store (#130), working installer shortcuts (#131),
+  persistent window layout (#132), and a calmer no-device placeholder (#134).
 
 ### What's new in 0.8.0-alpha
 
@@ -144,15 +163,15 @@ shader:
 
 ## Download
 
-Pre-built binaries for **0.8.0-alpha** are attached to the
+Pre-built binaries for **0.8.1-alpha** are attached to the
 [latest GitHub release](https://github.com/geldoronie/RetroCapture/releases/latest):
 
 | Platform | Artifact |
 | --- | --- |
-| Linux x86_64 | `RetroCapture-0.8.0-alpha-linux-x86_64.AppImage` |
-| Linux ARM64 (Raspberry Pi 4 / 5) | `RetroCapture-0.8.0-alpha-linux-arm64v8.tar.gz` |
-| Linux ARM32v7 (Raspberry Pi 2 / 3 / Zero 2) | `RetroCapture-0.8.0-alpha-linux-arm32v7.tar.gz` |
-| Windows x86_64 | `RetroCapture-0.8.0-alpha-windows-x86_64-Setup.exe` |
+| Linux x86_64 | `RetroCapture-0.8.1-alpha-linux-x86_64.AppImage` |
+| Linux ARM64 (Raspberry Pi 4 / 5) | `RetroCapture-0.8.1-alpha-linux-arm64v8.tar.gz` |
+| Linux ARM32v7 (Raspberry Pi 2 / 3 / Zero 2) | `RetroCapture-0.8.1-alpha-linux-arm32v7.tar.gz` |
+| Windows x86_64 | `RetroCapture-0.8.1-alpha-windows-x86_64-Setup.exe` |
 
 A `SHA256SUMS` file is published alongside the binaries.
 
@@ -206,21 +225,21 @@ For the full per-version history see [`CHANGELOG.md`](CHANGELOG.md).
 
 ```bash
 # Download from Releases, then:
-chmod +x RetroCapture-0.8.0-alpha-linux-x86_64.AppImage
-./RetroCapture-0.8.0-alpha-linux-x86_64.AppImage --source v4l2 --v4l2-device /dev/video0
+chmod +x RetroCapture-0.8.1-alpha-linux-x86_64.AppImage
+./RetroCapture-0.8.1-alpha-linux-x86_64.AppImage --source v4l2 --v4l2-device /dev/video0
 ```
 
 ### Windows
 
-Run the installer (`RetroCapture-0.8.0-alpha-windows-x86_64-Setup.exe`),
+Run the installer (`RetroCapture-0.8.1-alpha-windows-x86_64-Setup.exe`),
 then launch RetroCapture from the Start menu. DirectShow is the default
 capture source on Windows.
 
 ### Raspberry Pi
 
 ```bash
-tar -xzf RetroCapture-0.8.0-alpha-linux-arm64v8.tar.gz
-cd RetroCapture-0.8.0-alpha-linux-arm64v8
+tar -xzf RetroCapture-0.8.1-alpha-linux-arm64v8.tar.gz
+cd RetroCapture-0.8.1-alpha-linux-arm64v8
 ./retrocapture --source v4l2 --v4l2-device /dev/video0
 ```
 


### PR DESCRIPTION
Version bump (0.8.0 → 0.8.1), CHANGELOG 0.8.1-alpha section, and README version refs. Closes out the 0.8.1-alpha milestone (8 Windows fixes: #129 #137 #135 #133 #130 #131 #132 #134). No code changes — release metadata only.