### PR TITLE
test(smoke): scripted capture/stream/encode smoke-test + synthetic source (#149)

### DIFF
--- a/src/capture/VideoCaptureTestPattern.cpp
+++ b/src/capture/VideoCaptureTestPattern.cpp
@@ -1,0 +1,115 @@
+#include "VideoCaptureTestPattern.h"
+#include "../utils/Logger.h"
+
+#include <cstring>
+
+VideoCaptureTestPattern::VideoCaptureTestPattern() = default;
+VideoCaptureTestPattern::~VideoCaptureTestPattern() { close(); }
+
+bool VideoCaptureTestPattern::open(const std::string & /*device*/)
+{
+    m_open = true;
+    if (m_buffer.empty())
+        m_buffer.resize(static_cast<size_t>(m_width) * m_height * 3, 0);
+    LOG_INFO("VideoCaptureTestPattern opened: " + std::to_string(m_width) + "x" +
+             std::to_string(m_height) + " @ " + std::to_string(m_fps) + "fps (RGB24)");
+    return true;
+}
+
+void VideoCaptureTestPattern::close()
+{
+    m_capturing = false;
+    m_open = false;
+}
+
+bool VideoCaptureTestPattern::setFormat(uint32_t width, uint32_t height, uint32_t /*pixelFormat*/)
+{
+    if (width > 0) m_width = width;
+    if (height > 0) m_height = height;
+    m_buffer.assign(static_cast<size_t>(m_width) * m_height * 3, 0);
+    return true;
+}
+
+bool VideoCaptureTestPattern::setFramerate(uint32_t fps)
+{
+    if (fps > 0) m_fps = fps;
+    return true;
+}
+
+bool VideoCaptureTestPattern::startCapture()
+{
+    if (!m_open) open("");
+    m_capturing = true;
+    return true;
+}
+
+void VideoCaptureTestPattern::stopCapture()
+{
+    m_capturing = false;
+}
+
+std::vector<DeviceInfo> VideoCaptureTestPattern::listDevices()
+{
+    return {DeviceInfo{"test", "Test Pattern", "synthetic", true}};
+}
+
+void VideoCaptureTestPattern::renderPattern()
+{
+    const size_t needed = static_cast<size_t>(m_width) * m_height * 3;
+    if (m_buffer.size() < needed)
+        m_buffer.resize(needed);
+
+    // 8 SMPTE-style vertical colour bars (R,G,B per bar). Having all three
+    // channels vary across the frame is what lets the smoke-test assert the
+    // colour path didn't collapse to grayscale or swap channels.
+    static const uint8_t bars[8][3] = {
+        {255, 255, 255}, // white
+        {255, 255, 0},   // yellow
+        {0, 255, 255},   // cyan
+        {0, 255, 0},     // green
+        {255, 0, 255},   // magenta
+        {255, 0, 0},     // red
+        {0, 0, 255},     // blue
+        {16, 16, 16},    // near-black
+    };
+
+    const uint64_t f = m_frameCounter.fetch_add(1, std::memory_order_relaxed);
+    const uint32_t barW = (m_width > 0) ? (m_width / 8) : 1;
+    // A moving block sweeps left→right one column per frame, giving temporal
+    // variance so a frozen/duplicated frame is detectable downstream.
+    const uint32_t markerX = static_cast<uint32_t>(f % (m_width ? m_width : 1));
+    const uint32_t markerH = m_height / 8;
+
+    for (uint32_t y = 0; y < m_height; ++y)
+    {
+        uint8_t *row = m_buffer.data() + static_cast<size_t>(y) * m_width * 3;
+        for (uint32_t x = 0; x < m_width; ++x)
+        {
+            uint32_t bar = barW ? (x / barW) : 0;
+            if (bar > 7) bar = 7;
+            uint8_t r = bars[bar][0], g = bars[bar][1], b = bars[bar][2];
+            // Moving marker: a black vertical strip in a band near the top.
+            if (y < markerH && (x >= markerX && x < markerX + 8))
+            {
+                r = g = b = 0;
+            }
+            uint8_t *px = row + static_cast<size_t>(x) * 3;
+            px[0] = r;
+            px[1] = g;
+            px[2] = b;
+        }
+    }
+}
+
+bool VideoCaptureTestPattern::captureFrame(Frame &frame)
+{
+    if (!m_open)
+        return false;
+    renderPattern();
+    frame.data = m_buffer.data();
+    frame.size = static_cast<size_t>(m_width) * m_height * 3;
+    frame.width = m_width;
+    frame.height = m_height;
+    frame.format = 0; // RGB24 → FrameProcessor uploads GL_RGB directly
+    return true;
+}

--- a/src/capture/VideoCaptureTestPattern.h
+++ b/src/capture/VideoCaptureTestPattern.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "IVideoCapture.h"
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+/**
+ * Synthetic capture source for the refactor smoke-test (#149).
+ *
+ * Generates a deterministic RGB24 test pattern with no hardware: vertical
+ * SMPTE-style colour bars (so a regression that loses chroma or swaps
+ * channels is detectable) plus a block that marches across the frame each
+ * call (so a frozen/duplicated frame is detectable). Selected with
+ * `--source test`. It is NOT in the platform factory and never touches a
+ * real capture backend, so it can't regress the production capture path —
+ * it only adds an isolated, content-known input the smoke-test can assert on.
+ */
+class VideoCaptureTestPattern : public IVideoCapture
+{
+public:
+    VideoCaptureTestPattern();
+    ~VideoCaptureTestPattern() override;
+
+    bool open(const std::string &device) override;
+    void close() override;
+    bool isOpen() const override { return m_open; }
+    bool setFormat(uint32_t width, uint32_t height, uint32_t pixelFormat = 0) override;
+    bool setFramerate(uint32_t fps) override;
+    bool captureFrame(Frame &frame) override;
+    bool captureLatestFrame(Frame &frame) override { return captureFrame(frame); }
+
+    bool setControl(const std::string &, int32_t) override { return false; }
+    bool getControl(const std::string &, int32_t &) override { return false; }
+    bool getControlMin(const std::string &, int32_t &) override { return false; }
+    bool getControlMax(const std::string &, int32_t &) override { return false; }
+    bool getControlDefault(const std::string &, int32_t &) override { return false; }
+    std::vector<DeviceInfo> listDevices() override;
+    void setDummyMode(bool enabled) override { m_dummy = enabled; }
+    bool isDummyMode() const override { return m_dummy; }
+
+    bool startCapture() override;
+    void stopCapture() override;
+    uint32_t getWidth() const override { return m_width; }
+    uint32_t getHeight() const override { return m_height; }
+    uint32_t getPixelFormat() const override { return 0; } // RGB24
+
+private:
+    void renderPattern();
+
+    uint32_t m_width = 1280;
+    uint32_t m_height = 720;
+    uint32_t m_fps = 60;
+    bool m_open = false;
+    bool m_capturing = false;
+    bool m_dummy = false;
+    std::atomic<uint64_t> m_frameCounter{0};
+    std::vector<uint8_t> m_buffer; // RGB24, width*height*3
+};

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -5,6 +5,7 @@
 #include "../capture/VideoCaptureFactory.h"
 #include "../capture/VideoCaptureRemote.h"
 #include "../capture/VideoCaptureScreen.h"
+#include "../capture/VideoCaptureTestPattern.h"
 #include "../streaming/RemoteMetaSync.h"
 #include "../encoding/MediaEncoder.h"
 #ifdef PLATFORM_LINUX
@@ -463,6 +464,13 @@ bool Application::initCapture()
         screen->setRegion(m_ui->getScreenRegionX(), m_ui->getScreenRegionY(),
                           m_ui->getScreenRegionW(), m_ui->getScreenRegionH());
         m_capture = std::move(screen);
+    }
+    else if (m_ui && m_ui->getSourceType() == UIManager::SourceType::Test)
+    {
+        // #149 — synthetic test-pattern source for the smoke-test. Isolated
+        // from the platform factory so it can't regress real capture.
+        LOG_INFO("Source is test — creating VideoCaptureTestPattern");
+        m_capture = std::make_unique<VideoCaptureTestPattern>();
     }
     else
     {
@@ -2288,16 +2296,19 @@ bool Application::initUI()
                                          using ST = UIManager::SourceType;
                                          const bool wantScreen = (sourceType == ST::Screen);
                                          const bool wantRemote = (sourceType == ST::Remote);
-                                         const bool wantFactory = !wantScreen && !wantRemote; // V4L2/DS/AVF/None
+                                         const bool wantTest   = (sourceType == ST::Test); // #149 smoke-test source
+                                         const bool wantFactory = !wantScreen && !wantRemote && !wantTest; // V4L2/DS/AVF/None
 
                                          const bool haveScreen  = dynamic_cast<VideoCaptureScreen *>(m_capture.get()) != nullptr;
                                          const bool haveRemote  = dynamic_cast<VideoCaptureRemote *>(m_capture.get()) != nullptr;
-                                         const bool haveFactory = m_capture && !haveScreen && !haveRemote;
+                                         const bool haveTest    = dynamic_cast<VideoCaptureTestPattern *>(m_capture.get()) != nullptr;
+                                         const bool haveFactory = m_capture && !haveScreen && !haveRemote && !haveTest;
 
                                          const bool wrongType =
                                              !m_capture ||
                                              (wantScreen && !haveScreen) ||
                                              (wantRemote && !haveRemote) ||
+                                             (wantTest && !haveTest) ||
                                              (wantFactory && !haveFactory);
 
                                          if (wrongType)
@@ -2318,6 +2329,7 @@ bool Application::initUI()
 
                                              if (wantScreen)      m_capture = std::make_unique<VideoCaptureScreen>();
                                              else if (wantRemote) m_capture = std::make_unique<VideoCaptureRemote>();
+                                             else if (wantTest)   m_capture = std::make_unique<VideoCaptureTestPattern>();
                                              else                 m_capture = VideoCaptureFactory::create();
 
                                              // Factory backend with no device yet → idle dummy
@@ -2336,6 +2348,23 @@ bool Application::initUI()
                                              // for V4L2/DS it re-enumerates the control set.
                                              if (m_ui) m_ui->setCaptureControls(m_capture.get());
                                          }
+                                     }
+
+                                     // #149 — Test: open the synthetic source and start it
+                                     // immediately (no device to pick).
+                                     if (sourceType == UIManager::SourceType::Test)
+                                     {
+                                         LOG_INFO("Test source selected — starting synthetic pattern");
+                                         if (m_capture)
+                                         {
+                                             m_capture->open("test");
+                                             m_capture->setFormat(m_captureWidth, m_captureHeight, 0);
+                                             m_capture->startCapture();
+                                             if (m_ui)
+                                                 m_ui->setCaptureInfo(m_capture->getWidth(), m_capture->getHeight(),
+                                                                      m_captureFps, "Test Pattern");
+                                         }
+                                         return; // Test fully handled
                                      }
 
                                      // #107 — Screen: auto-open the default target so the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,24 +236,26 @@ int main(int argc, char *argv[])
             sourceType = argv[++i];
             // Converter para minúsculas para comparação case-insensitive
             std::transform(sourceType.begin(), sourceType.end(), sourceType.begin(), ::tolower);
+            // 'test' is the synthetic test-pattern source (#149), valid on
+            // every platform — it has no hardware backend.
 #ifdef __linux__
-            if (sourceType != "none" && sourceType != "v4l2" && sourceType != "remote")
+            if (sourceType != "none" && sourceType != "v4l2" && sourceType != "remote" && sourceType != "test")
 #elif defined(_WIN32)
-            if (sourceType != "none" && sourceType != "ds" && sourceType != "remote")
+            if (sourceType != "none" && sourceType != "ds" && sourceType != "remote" && sourceType != "test")
 #elif defined(__APPLE__)
-            if (sourceType != "none" && sourceType != "avfoundation" && sourceType != "remote")
+            if (sourceType != "none" && sourceType != "avfoundation" && sourceType != "remote" && sourceType != "test")
 #else
-            if (sourceType != "none" && sourceType != "remote")
+            if (sourceType != "none" && sourceType != "remote" && sourceType != "test")
 #endif
             {
 #ifdef __linux__
-                LOG_ERROR("Invalid source type. Use 'none', 'v4l2' or 'remote'");
+                LOG_ERROR("Invalid source type. Use 'none', 'v4l2', 'remote' or 'test'");
 #elif defined(_WIN32)
-                LOG_ERROR("Invalid source type. Use 'none', 'ds' or 'remote'");
+                LOG_ERROR("Invalid source type. Use 'none', 'ds', 'remote' or 'test'");
 #elif defined(__APPLE__)
-                LOG_ERROR("Invalid source type. Use 'none', 'avfoundation' or 'remote'");
+                LOG_ERROR("Invalid source type. Use 'none', 'avfoundation', 'remote' or 'test'");
 #else
-                LOG_ERROR("Invalid source type. Use 'none' or 'remote'");
+                LOG_ERROR("Invalid source type. Use 'none', 'remote' or 'test'");
 #endif
                 return 1;
             }
@@ -994,6 +996,8 @@ int main(int argc, char *argv[])
 #endif
     if (sourceType == "remote")
         sourceTypeEnum = UIManager::SourceType::Remote;
+    if (sourceType == "test")
+        sourceTypeEnum = UIManager::SourceType::Test;
     app.getUIManager()->setSourceType(sourceTypeEnum);
     LOG_INFO("Source type: " + sourceType);
     

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -166,7 +166,8 @@ public:
         DS = 2,           // DirectShow (Windows)
         Remote = 3,       // Remote /raw MPEG-TS from another RetroCapture (Phase 3 of #47)
         AVFoundation = 4, // AVFoundation (macOS)
-        Screen = 5        // Desktop / window / region screen capture (#107)
+        Screen = 5,       // Desktop / window / region screen capture (#107)
+        Test = 6          // Synthetic test-pattern source for the smoke-test (#149)
     };
 
     // Source type setter (para uso pelas classes de abas)

--- a/tools/README.md
+++ b/tools/README.md
@@ -169,6 +169,30 @@ Estes scripts são usados dentro dos containers Docker durante o build:
 
 **Nota:** Estes scripts são chamados automaticamente pelos scripts Docker principais. Não é necessário executá-los manualmente.
 
+## 🧪 Testes
+
+### `smoke-test.sh`
+
+Smoke-test ponta-a-ponta do pipeline de captura/stream/encode (#149). Sobe um
+RetroCapture já compilado com a fonte sintética de teste (`--source test`, sem
+hardware), habilita streaming, puxa `/stream`, decodifica um frame e valida que
+o vídeo continua correto: presença de brilho, variância espacial, cor (barras
+SMPTE saturadas), barras distintas e variância temporal (marcador móvel). É a
+rede de segurança para refatorações — uma refatoração que preserva comportamento
+deve mantê-lo verde.
+
+```bash
+# usa build-linux-x86_64/bin/retrocapture por padrão
+./tools/smoke-test.sh
+
+# ou aponte um binário específico
+./tools/smoke-test.sh /caminho/para/retrocapture
+```
+
+Requisitos: `ffmpeg`, `ffprobe`, `curl`, `python3` e um display (usa `$DISPLAY`,
+ou cai pra `xvfb-run` em CI). Usa a porta 8080 — recusa rodar se já houver uma
+instância servindo nela (use `SMOKE_PORT` para mudar). Exit 0 = passou.
+
 ## 📝 Notas
 
 - Todos os scripts de build suportam argumentos em qualquer ordem

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Capture/stream/encode smoke-test (#149) — the refactor safety net.
+#
+# Boots a built RetroCapture with the synthetic test-pattern source
+# (`--source test`, no hardware), enables streaming, pulls /stream, decodes a
+# frame and asserts the pipeline still delivers correct video:
+#   - the stream exists and has sane dimensions
+#   - the frame is NOT gray/black (real brightness + spatial variance)
+#   - chroma is present (the colour bars survived — catches a channel/colour
+#     regression, e.g. the kind behind #135)
+#   - two frames differ (the moving marker → catches a frozen/duplicated feed)
+#
+# Behaviour-preserving refactors must keep this green. Exit 0 = pass.
+#
+# Usage:  tools/smoke-test.sh [path-to-retrocapture-binary]
+# Default binary: build-linux-x86_64/bin/retrocapture
+#
+# Needs: ffmpeg, ffprobe, curl, python3. A display — uses $DISPLAY if set,
+# otherwise falls back to xvfb-run (install xvfb in CI).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN="${1:-$REPO_ROOT/build-linux-x86_64/bin/retrocapture}"
+# The streaming server binds 8080 regardless of --stream-port (the flag only
+# echoes; the bind is fixed — tracked separately). Use 8080 and refuse to run
+# if it's already taken, rather than fighting a live instance.
+PORT="${SMOKE_PORT:-8080}"
+W=1280; H=720
+WORK="$(mktemp -d /tmp/rc-smoke.XXXXXX)"
+APP_PID=""
+
+cleanup() {
+    [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null
+    [ -n "$APP_PID" ] && wait "$APP_PID" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "❌ SMOKE FAIL: $*"; exit 1; }
+note() { echo "   $*"; }
+
+# --- prerequisites ----------------------------------------------------------
+for tool in ffmpeg ffprobe curl python3; do
+    command -v "$tool" >/dev/null 2>&1 || fail "missing required tool: $tool"
+done
+[ -x "$BIN" ] || fail "binary not found/executable: $BIN"
+
+# Wrap in xvfb when there's no display (CI). GLFW needs a GL context.
+LAUNCH_PREFIX=""
+if [ -z "${DISPLAY:-}" ]; then
+    if command -v xvfb-run >/dev/null 2>&1; then
+        LAUNCH_PREFIX="xvfb-run -a"
+        note "no DISPLAY — using xvfb-run"
+    else
+        fail "no DISPLAY and xvfb-run not installed (need a GL context)"
+    fi
+fi
+
+echo "▶ smoke-test: $BIN  (test pattern, port $PORT)"
+
+# Is the HTTP server answering? /stream is an infinite feed, so we can't use
+# curl's exit code (it always times out mid-download); probe the root path and
+# look at the HTTP status instead — anything but 000 means the port is up.
+port_up() {
+    local code
+    code=$(curl -s -m 2 -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/" 2>/dev/null)
+    [ -n "$code" ] && [ "$code" != "000" ]
+}
+
+# Refuse to run if something already answers on the port — otherwise we'd
+# test that instance, not the binary under test.
+if port_up; then
+    fail "port $PORT is already serving — stop the running RetroCapture first (or set SMOKE_PORT)"
+fi
+
+# --- launch -----------------------------------------------------------------
+# Isolated XDG dirs so the user's saved shader/config can't perturb the output.
+XDG_CONFIG_HOME="$WORK/cfg" XDG_DATA_HOME="$WORK/data" \
+    $LAUNCH_PREFIX "$BIN" --source test --stream-enable --hide-ui \
+    --width "$W" --height "$H" \
+    > "$WORK/app.log" 2>&1 &
+APP_PID=$!
+
+# Wait until the stream port answers (max ~20s), instead of a fixed sleep.
+ready=0
+for _ in $(seq 1 40); do
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+        cat "$WORK/app.log"; fail "app exited during startup"
+    fi
+    if port_up; then ready=1; break; fi
+    sleep 0.5
+done
+[ "$ready" = 1 ] || { tail -20 "$WORK/app.log"; fail "stream port $PORT never came up"; }
+
+# The stream port comes up during init() (while the default backend is still
+# attached); the test-pattern source is swapped in just after, via setSourceType.
+# Wait for that swap to land in the app log before capturing, so we don't grab
+# the brief opening frames from whatever the platform factory opened first.
+# The app logs to its own file under the data dir (not stdout) — find it.
+APP_LOG=$(find "$WORK/data" -name retrocapture.log 2>/dev/null | head -1)
+if [ -n "$APP_LOG" ]; then
+    swapped=0
+    for _ in $(seq 1 20); do
+        grep -q "VideoCaptureTestPattern opened" "$APP_LOG" && { swapped=1; break; }
+        sleep 0.5
+    done
+    [ "$swapped" = 1 ] || fail "test-pattern source was not used (check $APP_LOG)"
+else
+    note "app log not found — relying on content assertions to confirm the source"
+fi
+# Small settle so the synthetic frames are flowing through the encoder.
+sleep 1
+
+# --- capture a few seconds of /stream --------------------------------------
+timeout 6 curl -s -o "$WORK/stream.ts" "http://127.0.0.1:$PORT/stream"
+[ -s "$WORK/stream.ts" ] || fail "no stream data captured"
+note "captured $(wc -c < "$WORK/stream.ts") bytes of MPEG-TS"
+
+# --- probe dimensions -------------------------------------------------------
+res=$(ffprobe -v error -select_streams v -show_entries stream=width,height \
+      -of csv=p=0 "$WORK/stream.ts" 2>/dev/null | head -1)
+[ -n "$res" ] || fail "no decodable video stream"
+note "stream resolution: $res"
+
+# --- decode two frames (1s apart) for spatial + temporal checks -------------
+ffmpeg -v error -ss 2 -i "$WORK/stream.ts" -frames:v 1 -f rawvideo -pix_fmt rgb24 "$WORK/a.rgb" 2>/dev/null
+ffmpeg -v error -ss 4 -i "$WORK/stream.ts" -frames:v 1 -f rawvideo -pix_fmt rgb24 "$WORK/b.rgb" 2>/dev/null
+[ -s "$WORK/a.rgb" ] || fail "could not decode a video frame"
+
+# --- assertions (python) ----------------------------------------------------
+python3 - "$WORK/a.rgb" "$WORK/b.rgb" "$res" <<'PY' || exit 1
+import sys, numpy as np
+a_path, b_path, res = sys.argv[1], sys.argv[2], sys.argv[3]
+w, h = (int(x) for x in res.split(','))
+a = np.fromfile(a_path, dtype=np.uint8)
+if a.size < w*h*3:
+    print("❌ SMOKE FAIL: decoded frame too small"); sys.exit(1)
+a = a[:w*h*3].reshape(h, w, 3).astype(float)
+
+bright_max = a.max()
+spatial_std = a.std()
+# Local saturation: mean of (max channel - min channel) per pixel. Saturated
+# colour bars give a high value; a grayscale/monochrome regression gives ~0.
+# (A global channel-mean comparison would be ~0 here because SMPTE bars are
+# channel-balanced — each of R/G/B is on in 4 of the 8 bars.)
+chroma = (a.max(axis=2) - a.min(axis=2)).mean()
+# per-bar colour distinctness: sample 8 bar centres, count distinct hues.
+bw = w // 8
+bars = [tuple(int(v) for v in a[h//2, i*bw + bw//2]) for i in range(8)]
+distinct = len(set(bars))
+
+ok = True
+def check(cond, msg):
+    global ok
+    print(("   [ok] " if cond else "   [X]  ") + msg)
+    ok = ok and cond
+
+check(bright_max >= 180, f"brightness present (max={bright_max:.0f}, need >=180)")
+check(spatial_std >= 20, f"spatial variance / not flat (std={spatial_std:.1f}, need >=20)")
+check(chroma >= 30, f"colour present / saturated bars (saturation={chroma:.0f}, need >=30)")
+check(distinct >= 5, f"distinct colour bars ({distinct}/8, need >=5)")
+
+# temporal: the moving marker should make two frames differ.
+try:
+    b = np.fromfile(b_path, dtype=np.uint8)[:w*h*3].reshape(h, w, 3).astype(float)
+    diff = np.abs(a - b).mean()
+    check(diff >= 0.05, f"frames change over time (mean diff={diff:.3f})")
+except Exception:
+    print("   - temporal check skipped (second frame unavailable)")
+
+sys.exit(0 if ok else 1)
+PY
+
+echo "✅ SMOKE PASS"


### PR DESCRIPTION
Closes #149. **Phase 0** of the 0.8.2-alpha refactor — the safety net that lets every later refactor PR self-verify the pipeline end to end.

## What

- **`VideoCaptureTestPattern` (`--source test`)** — a synthetic, hardware-free capture source: deterministic SMPTE colour bars + a marker that marches across the frame each call (temporal variance). Implemented as an **isolated `IVideoCapture` class, NOT in the platform factory**, so it can't regress the real capture path — it only adds a content-known input to assert on. Wired through `main.cpp`, the `SourceType::Test` enum, `initCapture`, and the UI source-type rebuild callback.
- **`tools/smoke-test.sh`** — boots a built binary with the test source + streaming under an **isolated XDG config** (so a saved shader can't perturb output), waits for the synthetic source to take over, pulls `/stream`, decodes frames and asserts: brightness, spatial variance, colour saturation, distinct colour bars, and temporal change. Probes readiness via HTTP status (not the infinite `/stream` body), confirms the synthetic source via the app log, and refuses to run if the port is already serving.
- Docs in `tools/README.md`.

## Validation

Deterministic **3/3 PASS** on Linux x86_64; Windows cross-build compiles clean. Sample output:

```
   [ok] brightness present (max=255, need >=180)
   [ok] spatial variance / not flat (std=124.5, need >=20)
   [ok] colour present / saturated bars (saturation=190, need >=30)
   [ok] distinct colour bars (8/8, need >=5)
   [ok] frames change over time (mean diff=0.340)
✅ SMOKE PASS
```

## Note

While building this I confirmed `--stream-port` doesn't actually rebind the streaming server (it always binds 8080 — the flag only echoes). Out of scope here; worth a separate issue. The smoke-test uses 8080 and refuses to run if it's taken.
