### PR TITLE
refactor(core): split Application::initUI() callback wiring by domain (#153)

### DIFF
--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -933,39 +933,8 @@ bool Application::reconfigureCapture(uint32_t width, uint32_t height, uint32_t f
     return true;
 }
 
-bool Application::initUI()
+void Application::wireVisualCallbacks()
 {
-    // IMPORTANT: Ensure OpenGL context is active before initializing ImGui
-    // ImGui needs a valid OpenGL context to initialize correctly
-    if (m_window)
-    {
-        m_window->makeCurrent();
-    }
-    else
-    {
-        LOG_ERROR("Window not available to initialize UI");
-        return false;
-    }
-
-    m_ui = std::make_unique<UIManager>();
-
-    // Get window pointer from WindowManager (GLFW or SDL2)
-    void *window = m_window->getWindow();
-    if (!window)
-    {
-        LOG_ERROR("Failed to get window pointer for ImGui");
-        m_ui.reset();
-        return false;
-    }
-
-    if (!m_ui->init(window))
-    {
-        LOG_ERROR("Failed to initialize UIManager");
-        m_ui.reset();
-        return false;
-    }
-
-    // Configure callbacks
     m_ui->setOnVisibilityChanged([this](bool /* visible */)
                                   {
         updateCursorVisibility();
@@ -1455,6 +1424,10 @@ bool Application::initUI()
         m_window->setFullscreen(m_fullscreen, m_monitorIndex);
     }
 
+}
+
+void Application::wireStreamingCallbacks()
+{
     m_ui->setOnStreamingStartStop([this](bool start)
                                   {
         // CRITICAL: This callback runs in main thread (ImGui render thread)
@@ -1842,6 +1815,10 @@ bool Application::initUI()
                 m_streamingAVIOBufferSize);
         } });
 
+}
+
+void Application::wireRecordingCallbacks()
+{
     // Recording callbacks
     m_ui->setOnRecordingStartStop([this](bool start)
                                   {
@@ -2037,6 +2014,10 @@ bool Application::initUI()
             m_recordingManager->setRecordingSettings(settings);
         } });
 
+}
+
+void Application::wireWebPortalCallbacks()
+{
     // Web Portal callbacks
     m_ui->setOnWebPortalEnabledChanged([this](bool enabled)
                                        {
@@ -2258,6 +2239,10 @@ bool Application::initUI()
         
         LOG_INFO("[CALLBACK] Thread criada, retornando (thread principal continua)"); });
 
+}
+
+void Application::wireSourceAndMiscCallbacks()
+{
     // Callback for source type change
     m_ui->setOnSourceTypeChanged([this](UIManager::SourceType sourceType)
                                  {
@@ -3130,6 +3115,47 @@ bool Application::initUI()
         } });
     }
 
+}
+
+
+bool Application::initUI()
+{
+    // IMPORTANT: Ensure OpenGL context is active before initializing ImGui
+    // ImGui needs a valid OpenGL context to initialize correctly
+    if (m_window)
+    {
+        m_window->makeCurrent();
+    }
+    else
+    {
+        LOG_ERROR("Window not available to initialize UI");
+        return false;
+    }
+
+    m_ui = std::make_unique<UIManager>();
+
+    // Get window pointer from WindowManager (GLFW or SDL2)
+    void *window = m_window->getWindow();
+    if (!window)
+    {
+        LOG_ERROR("Failed to get window pointer for ImGui");
+        m_ui.reset();
+        return false;
+    }
+
+    if (!m_ui->init(window))
+    {
+        LOG_ERROR("Failed to initialize UIManager");
+        m_ui.reset();
+        return false;
+    }
+
+    // Configure callbacks
+    wireVisualCallbacks();
+    wireStreamingCallbacks();
+    wireRecordingCallbacks();
+    wireWebPortalCallbacks();
+    wireSourceAndMiscCallbacks();
     return true;
 }
 

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -484,6 +484,12 @@ private:
     bool initWindow();
     bool initRenderer();
     bool initUI();
+    // #153 — initUI() callback wiring split into contiguous groups (behavior-preserving).
+    void wireVisualCallbacks();
+    void wireStreamingCallbacks();
+    void wireRecordingCallbacks();
+    void wireWebPortalCallbacks();
+    void wireSourceAndMiscCallbacks();
     bool initStreaming();
     bool initWebPortal();
     void stopWebPortal();


### PR DESCRIPTION
## What

`Application::initUI()` had grown to ~2179 lines, almost entirely contiguous `UIManager` callback registrations. This extracts that wiring into five behavior-preserving in-class methods, grouped by domain:

- `wireVisualCallbacks()`
- `wireStreamingCallbacks()` — keeps its local `restartIfStreaming` helper (self-contained within the block)
- `wireRecordingCallbacks()`
- `wireWebPortalCallbacks()`
- `wireSourceAndMiscCallbacks()`

`initUI()` now contains only the ImGui context / `UIManager` setup and the five `wire*()` calls.

## Why

Part of the 0.8.2-alpha refactor milestone (god-object decomposition). Smaller, domain-focused methods are far easier to navigate than one 2k-line function.

## Safety

Pure code move — each group is a brace-balanced contiguous block lifted verbatim; callbacks register in the same order as before. No logic change.

Validated:
- Linux x86_64 Docker build ✅
- Windows x86_64 (MXE GCC 5.5) Docker build ✅
- `tools/smoke-test.sh` ✅ (capture→shader→encode→mux→stream→decode)

Closes #153