### PR TITLE
refactor(capture): extract V4L2 format-choice policy into FormatNegotiator (#161)

### DIFF
--- a/src/capture/FormatNegotiator.cpp
+++ b/src/capture/FormatNegotiator.cpp
@@ -1,0 +1,70 @@
+#include "FormatNegotiator.h"
+
+#include "../utils/Logger.h"
+
+namespace rc
+{
+namespace capture
+{
+std::string FormatNegotiator::fourccToString(uint32_t fourcc)
+{
+    char s[5] = {0};
+    s[0] = static_cast<char>((fourcc >> 0) & 0xFF);
+    s[1] = static_cast<char>((fourcc >> 8) & 0xFF);
+    s[2] = static_cast<char>((fourcc >> 16) & 0xFF);
+    s[3] = static_cast<char>((fourcc >> 24) & 0xFF);
+    return std::string(s);
+}
+
+uint32_t FormatNegotiator::chooseDefaultV4L2Format(bool yuyvSupported, bool mjpegSupported,
+                                                   uint32_t deviceCurrentFormat, bool &ok)
+{
+    ok = true;
+
+    if (yuyvSupported)
+    {
+        LOG_INFO("YUYV supported, using YUYV as default format");
+        return FOURCC_YUYV;
+    }
+
+    // Se YUYV não é suportado, pegar o formato atual do dispositivo
+    uint32_t pixelFormat = deviceCurrentFormat;
+    if (pixelFormat == 0)
+    {
+        // Se ainda não temos formato, tentar MJPG como último recurso
+        if (mjpegSupported)
+        {
+            LOG_WARN("YUYV not supported, falling back to MJPG (not fully supported yet)");
+            return FOURCC_MJPG;
+        }
+        LOG_ERROR("Nenhum formato suportado encontrado");
+        ok = false;
+        return 0;
+    }
+    if (pixelFormat == FOURCC_MJPG)
+    {
+        LOG_WARN("Device is using MJPG but YUYV is unavailable. MJPG is not fully supported.");
+    }
+    return pixelFormat;
+}
+
+bool FormatNegotiator::isAcceptedFormat(uint32_t requested, uint32_t actual)
+{
+    if (requested == actual)
+    {
+        return true;
+    }
+
+    LOG_WARN("Formato solicitado '" + fourccToString(requested) +
+             "' mas dispositivo retornou '" + fourccToString(actual) + "'");
+
+    // Se foi solicitado YUYV mas retornou MJPG, tentar forçar novamente
+    if (requested == FOURCC_YUYV && actual == FOURCC_MJPG)
+    {
+        LOG_ERROR("Device did not accept YUYV and returned MJPG. YUYV may not be supported.");
+        return false;
+    }
+    return true;
+}
+} // namespace capture
+} // namespace rc

--- a/src/capture/FormatNegotiator.h
+++ b/src/capture/FormatNegotiator.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// #161 — FormatNegotiator: the pure capture-format decision logic that
+// VideoCaptureV4L2::setFormat used to carry inline. The platform-specific
+// ioctl calls (VIDIOC_ENUM_FMT / VIDIOC_S_FMT) stay in the backend; this
+// helper just makes the choice and reports it, so the policy is in one
+// testable place.
+//
+// Scoped to the V4L2 fallback chain: the DirectShow backend doesn't enumerate
+// or retry candidates (it requests RGB24 and lets DirectShow's intelligent
+// connect insert converters), so there is no shared retry logic to unify —
+// see #161 for the rationale. Kept dependency-free (no <linux/videodev2.h>)
+// so it builds on every platform; the YUYV/MJPG fourcc values it compares
+// against are defined locally and equal V4L2_PIX_FMT_YUYV / V4L2_PIX_FMT_MJPEG.
+namespace rc
+{
+namespace capture
+{
+class FormatNegotiator
+{
+public:
+    // v4l2_fourcc('Y','U','Y','V') / ('M','J','P','G') computed without
+    // <linux/videodev2.h> so this stays cross-platform.
+    static constexpr uint32_t FOURCC_YUYV =
+        uint32_t('Y') | (uint32_t('U') << 8) | (uint32_t('Y') << 16) | (uint32_t('V') << 24);
+    static constexpr uint32_t FOURCC_MJPG =
+        uint32_t('M') | (uint32_t('J') << 8) | (uint32_t('P') << 16) | (uint32_t('G') << 24);
+
+    // Human-readable 4-character fourcc (for logs).
+    static std::string fourccToString(uint32_t fourcc);
+
+    // Choose the default capture format when the caller didn't request one.
+    // Inputs are what the backend learned by enumerating the device:
+    //   yuyvSupported / mjpegSupported — VIDIOC_ENUM_FMT results
+    //   deviceCurrentFormat            — the device's current pixelformat (may be 0)
+    // Returns the chosen fourcc. Sets ok=false (and logs an error) when no usable
+    // format exists. Emits the same INFO/WARN messages as the original inline code.
+    static uint32_t chooseDefaultV4L2Format(bool yuyvSupported, bool mjpegSupported,
+                                            uint32_t deviceCurrentFormat, bool &ok);
+
+    // After the driver applied the format: returns true when `actual` is an
+    // acceptable result for `requested`. When they differ it logs a warning, and
+    // it returns false only for the requested-YUYV / got-MJPG case (logging an
+    // error), matching the original setFormat() verification.
+    static bool isAcceptedFormat(uint32_t requested, uint32_t actual);
+};
+} // namespace capture
+} // namespace rc

--- a/src/capture/VideoCaptureV4L2.cpp
+++ b/src/capture/VideoCaptureV4L2.cpp
@@ -1,4 +1,5 @@
 #include "VideoCaptureV4L2.h"
+#include "FormatNegotiator.h"
 #include "../utils/Logger.h"
 #include "../utils/V4L2DeviceScanner.h"
 #include "../v4l2/V4L2ControlMapper.h"
@@ -182,33 +183,14 @@ bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixel
             }
         }
 
-        if (yuyvSupported)
+        // #161 — format-choice policy lives in FormatNegotiator; the ioctl
+        // enumeration above stays here (the platform seam).
+        bool negotiateOk = true;
+        pixelFormat = rc::capture::FormatNegotiator::chooseDefaultV4L2Format(
+            yuyvSupported, mjpegSupported, fmt.fmt.pix.pixelformat, negotiateOk);
+        if (!negotiateOk)
         {
-            LOG_INFO("YUYV supported, using YUYV as default format");
-            pixelFormat = V4L2_PIX_FMT_YUYV;
-        }
-        else
-        {
-            // Se YUYV não é suportado, pegar o formato atual do dispositivo
-            pixelFormat = fmt.fmt.pix.pixelformat;
-            if (pixelFormat == 0)
-            {
-                // Se ainda não temos formato, tentar MJPG como último recurso
-                if (mjpegSupported)
-                {
-                    LOG_WARN("YUYV not supported, falling back to MJPG (not fully supported yet)");
-                    pixelFormat = V4L2_PIX_FMT_MJPEG;
-                }
-                else
-                {
-                    LOG_ERROR("Nenhum formato suportado encontrado");
-                    return false;
-                }
-            }
-            else if (pixelFormat == V4L2_PIX_FMT_MJPEG)
-            {
-                LOG_WARN("Device is using MJPG but YUYV is unavailable. MJPG is not fully supported.");
-            }
+            return false;
         }
     }
 
@@ -232,41 +214,17 @@ bool VideoCaptureV4L2::setFormat(uint32_t width, uint32_t height, uint32_t pixel
     m_height = fmt.fmt.pix.height;
     m_pixelFormat = fmt.fmt.pix.pixelformat;
 
-    // Verificar se o formato foi aceito corretamente
-    if (m_pixelFormat != pixelFormat)
+    // Verificar se o formato foi aceito corretamente (#161 — policy in FormatNegotiator).
+    if (!rc::capture::FormatNegotiator::isAcceptedFormat(pixelFormat, m_pixelFormat))
     {
-        char requestedStr[5] = {0};
-        requestedStr[0] = (pixelFormat >> 0) & 0xFF;
-        requestedStr[1] = (pixelFormat >> 8) & 0xFF;
-        requestedStr[2] = (pixelFormat >> 16) & 0xFF;
-        requestedStr[3] = (pixelFormat >> 24) & 0xFF;
-
-        char actualStr[5] = {0};
-        actualStr[0] = (m_pixelFormat >> 0) & 0xFF;
-        actualStr[1] = (m_pixelFormat >> 8) & 0xFF;
-        actualStr[2] = (m_pixelFormat >> 16) & 0xFF;
-        actualStr[3] = (m_pixelFormat >> 24) & 0xFF;
-
-        LOG_WARN("Formato solicitado '" + std::string(requestedStr) +
-                 "' mas dispositivo retornou '" + std::string(actualStr) + "'");
-
-        // Se foi solicitado YUYV mas retornou MJPG, tentar forçar novamente
-        if (pixelFormat == V4L2_PIX_FMT_YUYV && m_pixelFormat == V4L2_PIX_FMT_MJPEG)
-        {
-            LOG_ERROR("Device did not accept YUYV and returned MJPG. YUYV may not be supported.");
-            return false;
-        }
+        return false;
     }
 
     // Log do formato de forma mais legível
-    char formatStr[5] = {0};
-    formatStr[0] = (m_pixelFormat >> 0) & 0xFF;
-    formatStr[1] = (m_pixelFormat >> 8) & 0xFF;
-    formatStr[2] = (m_pixelFormat >> 16) & 0xFF;
-    formatStr[3] = (m_pixelFormat >> 24) & 0xFF;
     LOG_INFO("Formato definido: " + std::to_string(m_width) + "x" +
              std::to_string(m_height) + " (format: 0x" +
-             std::to_string(m_pixelFormat) + " = '" + std::string(formatStr) + "')");
+             std::to_string(m_pixelFormat) + " = '" +
+             rc::capture::FormatNegotiator::fourccToString(m_pixelFormat) + "')");
 
     return true;
 }


### PR DESCRIPTION
## What

Pulls the format-decision logic out of `VideoCaptureV4L2::setFormat` into a small, testable **`FormatNegotiator`** helper, keeping the platform-specific ioctls (`VIDIOC_ENUM_FMT` / `VIDIOC_S_FMT`) in the backend as the seam:

- `chooseDefaultV4L2Format(yuyvSupported, mjpegSupported, deviceCurrent, ok)` — the "prefer YUYV → device-current → MJPG" decision, moved verbatim (incl. logs).
- `isAcceptedFormat(requested, actual)` — the post-`S_FMT` verification (warn on mismatch, fail only on requested-YUYV / got-MJPG).
- `fourccToString()` — replaces the repeated `char[5]` fourcc formatting.

## Rescope (vs the original #161)

The issue assumed a shared DS+V4L2 negotiator. Reading the code, the two backends **share almost no concrete negotiation logic**:

- **V4L2** enumerates fourccs and falls back across them (YUYV → device-current → MJPG), with a verify-and-fail rule.
- **VideoCaptureDS** doesn't enumerate or retry — it requests RGB24 and lets DirectShow's intelligent-connect insert converters; its only fallback is "use device default if `SetFormat` fails."

A forced cross-platform abstraction would require **rewriting V4L2's flow** (a behavior change) for no real shared code — risky on capture hardware the smoke-test can't exercise. So the negotiator is V4L2-scoped; the helper is dependency-free (no `<linux/videodev2.h>`) so it still compiles on Windows. (Confirmed with @geldoronie before implementing.)

## Safety

Pure logic move — identical decisions and log messages.

Validated:
- Linux x86_64 + Windows x86_64 (MXE GCC 5.5) builds ✅
- `tools/smoke-test.sh` ✅

> The V4L2 path isn't exercised by the synthetic `--source test`; real-device fallback is unchanged by construction, but worth a quick check on the Macrosilicon YUY2 card.

Closes #161