### PR TITLE
refactor(ui): group UIManager web-portal settings into WebPortalConfig (#160 — 3/N)

### DIFF
--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -2537,10 +2537,10 @@ void UIManager::triggerStreamingStartStop(bool start)
 
 void UIManager::triggerWebPortalEnabledChange(bool enabled)
 {
-    m_webPortalEnabled = enabled;
-    if (!enabled && m_webPortalHTTPSEnabled)
+    m_webPortalConfig.enabled = enabled;
+    if (!enabled && m_webPortalConfig.httpsEnabled)
     {
-        m_webPortalHTTPSEnabled = false;
+        m_webPortalConfig.httpsEnabled = false;
         if (m_onWebPortalHTTPSChanged)
         {
             m_onWebPortalHTTPSChanged(false);
@@ -2555,7 +2555,7 @@ void UIManager::triggerWebPortalEnabledChange(bool enabled)
 
 void UIManager::triggerWebPortalHTTPSChange(bool enabled)
 {
-    m_webPortalHTTPSEnabled = enabled;
+    m_webPortalConfig.httpsEnabled = enabled;
     if (m_onWebPortalHTTPSChanged)
     {
         m_onWebPortalHTTPSChanged(enabled);
@@ -2574,7 +2574,7 @@ void UIManager::triggerWebPortalStartStop(bool start)
 
 void UIManager::triggerWebPortalTitleChange(const std::string &title)
 {
-    m_webPortalTitle = title;
+    m_webPortalConfig.title = title;
     if (m_onWebPortalTitleChanged)
     {
         m_onWebPortalTitleChanged(title);
@@ -2584,7 +2584,7 @@ void UIManager::triggerWebPortalTitleChange(const std::string &title)
 
 void UIManager::triggerWebPortalSubtitleChange(const std::string &subtitle)
 {
-    m_webPortalSubtitle = subtitle;
+    m_webPortalConfig.subtitle = subtitle;
     if (m_onWebPortalSubtitleChanged)
     {
         m_onWebPortalSubtitleChanged(subtitle);
@@ -2594,7 +2594,7 @@ void UIManager::triggerWebPortalSubtitleChange(const std::string &subtitle)
 
 void UIManager::triggerWebPortalSSLCertPathChange(const std::string &path)
 {
-    m_webPortalSSLCertPath = path;
+    m_webPortalConfig.sslCertPath = path;
     if (m_onWebPortalSSLCertPathChanged)
     {
         m_onWebPortalSSLCertPathChanged(path);
@@ -2604,7 +2604,7 @@ void UIManager::triggerWebPortalSSLCertPathChange(const std::string &path)
 
 void UIManager::triggerWebPortalSSLKeyPathChange(const std::string &path)
 {
-    m_webPortalSSLKeyPath = path;
+    m_webPortalConfig.sslKeyPath = path;
     if (m_onWebPortalSSLKeyPathChanged)
     {
         m_onWebPortalSSLKeyPathChanged(path);
@@ -2865,19 +2865,19 @@ void UIManager::loadConfig()
         {
             auto &webPortal = config["webPortal"];
             if (webPortal.contains("enabled"))
-                m_webPortalEnabled = webPortal["enabled"];
+                m_webPortalConfig.enabled = webPortal["enabled"];
             if (webPortal.contains("httpsEnabled"))
-                m_webPortalHTTPSEnabled = webPortal["httpsEnabled"];
+                m_webPortalConfig.httpsEnabled = webPortal["httpsEnabled"];
             if (webPortal.contains("sslCertPath"))
-                m_webPortalSSLCertPath = webPortal["sslCertPath"].get<std::string>();
+                m_webPortalConfig.sslCertPath = webPortal["sslCertPath"].get<std::string>();
             if (webPortal.contains("sslKeyPath"))
-                m_webPortalSSLKeyPath = webPortal["sslKeyPath"].get<std::string>();
+                m_webPortalConfig.sslKeyPath = webPortal["sslKeyPath"].get<std::string>();
             if (webPortal.contains("title"))
-                m_webPortalTitle = webPortal["title"].get<std::string>();
+                m_webPortalConfig.title = webPortal["title"].get<std::string>();
             if (webPortal.contains("subtitle"))
-                m_webPortalSubtitle = webPortal["subtitle"].get<std::string>();
+                m_webPortalConfig.subtitle = webPortal["subtitle"].get<std::string>();
             if (webPortal.contains("imagePath"))
-                m_webPortalImagePath = webPortal["imagePath"].get<std::string>();
+                m_webPortalConfig.imagePath = webPortal["imagePath"].get<std::string>();
             if (webPortal.contains("backgroundImagePath"))
                 m_webPortalBackgroundImagePath = webPortal["backgroundImagePath"].get<std::string>();
 
@@ -2886,37 +2886,37 @@ void UIManager::loadConfig()
             {
                 auto &texts = webPortal["texts"];
                 if (texts.contains("streamInfo"))
-                    m_webPortalTextStreamInfo = texts["streamInfo"].get<std::string>();
+                    m_webPortalConfig.textStreamInfo = texts["streamInfo"].get<std::string>();
                 if (texts.contains("quickActions"))
-                    m_webPortalTextQuickActions = texts["quickActions"].get<std::string>();
+                    m_webPortalConfig.textQuickActions = texts["quickActions"].get<std::string>();
                 if (texts.contains("compatibility"))
-                    m_webPortalTextCompatibility = texts["compatibility"].get<std::string>();
+                    m_webPortalConfig.textCompatibility = texts["compatibility"].get<std::string>();
                 if (texts.contains("status"))
-                    m_webPortalTextStatus = texts["status"].get<std::string>();
+                    m_webPortalConfig.textStatus = texts["status"].get<std::string>();
                 if (texts.contains("codec"))
-                    m_webPortalTextCodec = texts["codec"].get<std::string>();
+                    m_webPortalConfig.textCodec = texts["codec"].get<std::string>();
                 if (texts.contains("resolution"))
-                    m_webPortalTextResolution = texts["resolution"].get<std::string>();
+                    m_webPortalConfig.textResolution = texts["resolution"].get<std::string>();
                 if (texts.contains("streamUrl"))
-                    m_webPortalTextStreamUrl = texts["streamUrl"].get<std::string>();
+                    m_webPortalConfig.textStreamUrl = texts["streamUrl"].get<std::string>();
                 if (texts.contains("copyUrl"))
-                    m_webPortalTextCopyUrl = texts["copyUrl"].get<std::string>();
+                    m_webPortalConfig.textCopyUrl = texts["copyUrl"].get<std::string>();
                 if (texts.contains("openNewTab"))
-                    m_webPortalTextOpenNewTab = texts["openNewTab"].get<std::string>();
+                    m_webPortalConfig.textOpenNewTab = texts["openNewTab"].get<std::string>();
                 if (texts.contains("supported"))
-                    m_webPortalTextSupported = texts["supported"].get<std::string>();
+                    m_webPortalConfig.textSupported = texts["supported"].get<std::string>();
                 if (texts.contains("format"))
-                    m_webPortalTextFormat = texts["format"].get<std::string>();
+                    m_webPortalConfig.textFormat = texts["format"].get<std::string>();
                 if (texts.contains("codecInfo"))
-                    m_webPortalTextCodecInfo = texts["codecInfo"].get<std::string>();
+                    m_webPortalConfig.textCodecInfo = texts["codecInfo"].get<std::string>();
                 if (texts.contains("supportedBrowsers"))
-                    m_webPortalTextSupportedBrowsers = texts["supportedBrowsers"].get<std::string>();
+                    m_webPortalConfig.textSupportedBrowsers = texts["supportedBrowsers"].get<std::string>();
                 if (texts.contains("formatInfo"))
-                    m_webPortalTextFormatInfo = texts["formatInfo"].get<std::string>();
+                    m_webPortalConfig.textFormatInfo = texts["formatInfo"].get<std::string>();
                 if (texts.contains("codecInfoValue"))
-                    m_webPortalTextCodecInfoValue = texts["codecInfoValue"].get<std::string>();
+                    m_webPortalConfig.textCodecInfoValue = texts["codecInfoValue"].get<std::string>();
                 if (texts.contains("connecting"))
-                    m_webPortalTextConnecting = texts["connecting"].get<std::string>();
+                    m_webPortalConfig.textConnecting = texts["connecting"].get<std::string>();
             }
 
             // Carregar cores
@@ -3330,15 +3330,15 @@ void UIManager::saveConfig()
 
         // Salvar configurações do Web Portal
         config["webPortal"] = {
-            {"enabled", m_webPortalEnabled},
-            {"httpsEnabled", m_webPortalHTTPSEnabled},
-            {"sslCertPath", m_webPortalSSLCertPath},
-            {"sslKeyPath", m_webPortalSSLKeyPath},
-            {"title", m_webPortalTitle},
-            {"subtitle", m_webPortalSubtitle},
-            {"imagePath", m_webPortalImagePath},
+            {"enabled", m_webPortalConfig.enabled},
+            {"httpsEnabled", m_webPortalConfig.httpsEnabled},
+            {"sslCertPath", m_webPortalConfig.sslCertPath},
+            {"sslKeyPath", m_webPortalConfig.sslKeyPath},
+            {"title", m_webPortalConfig.title},
+            {"subtitle", m_webPortalConfig.subtitle},
+            {"imagePath", m_webPortalConfig.imagePath},
             {"backgroundImagePath", m_webPortalBackgroundImagePath},
-            {"texts", {{"streamInfo", m_webPortalTextStreamInfo}, {"quickActions", m_webPortalTextQuickActions}, {"compatibility", m_webPortalTextCompatibility}, {"status", m_webPortalTextStatus}, {"codec", m_webPortalTextCodec}, {"resolution", m_webPortalTextResolution}, {"streamUrl", m_webPortalTextStreamUrl}, {"copyUrl", m_webPortalTextCopyUrl}, {"openNewTab", m_webPortalTextOpenNewTab}, {"supported", m_webPortalTextSupported}, {"format", m_webPortalTextFormat}, {"codecInfo", m_webPortalTextCodecInfo}, {"supportedBrowsers", m_webPortalTextSupportedBrowsers}, {"formatInfo", m_webPortalTextFormatInfo}, {"codecInfoValue", m_webPortalTextCodecInfoValue}, {"connecting", m_webPortalTextConnecting}}},
+            {"texts", {{"streamInfo", m_webPortalConfig.textStreamInfo}, {"quickActions", m_webPortalConfig.textQuickActions}, {"compatibility", m_webPortalConfig.textCompatibility}, {"status", m_webPortalConfig.textStatus}, {"codec", m_webPortalConfig.textCodec}, {"resolution", m_webPortalConfig.textResolution}, {"streamUrl", m_webPortalConfig.textStreamUrl}, {"copyUrl", m_webPortalConfig.textCopyUrl}, {"openNewTab", m_webPortalConfig.textOpenNewTab}, {"supported", m_webPortalConfig.textSupported}, {"format", m_webPortalConfig.textFormat}, {"codecInfo", m_webPortalConfig.textCodecInfo}, {"supportedBrowsers", m_webPortalConfig.textSupportedBrowsers}, {"formatInfo", m_webPortalConfig.textFormatInfo}, {"codecInfoValue", m_webPortalConfig.textCodecInfoValue}, {"connecting", m_webPortalConfig.textConnecting}}},
             {"colors", {{"background", {m_webPortalColorBackground[0], m_webPortalColorBackground[1], m_webPortalColorBackground[2], m_webPortalColorBackground[3]}}, {"text", {m_webPortalColorText[0], m_webPortalColorText[1], m_webPortalColorText[2], m_webPortalColorText[3]}}, {"primary", {m_webPortalColorPrimary[0], m_webPortalColorPrimary[1], m_webPortalColorPrimary[2], m_webPortalColorPrimary[3]}}, {"primaryLight", {m_webPortalColorPrimaryLight[0], m_webPortalColorPrimaryLight[1], m_webPortalColorPrimaryLight[2], m_webPortalColorPrimaryLight[3]}}, {"primaryDark", {m_webPortalColorPrimaryDark[0], m_webPortalColorPrimaryDark[1], m_webPortalColorPrimaryDark[2], m_webPortalColorPrimaryDark[3]}}, {"secondary", {m_webPortalColorSecondary[0], m_webPortalColorSecondary[1], m_webPortalColorSecondary[2], m_webPortalColorSecondary[3]}}, {"secondaryHighlight", {m_webPortalColorSecondaryHighlight[0], m_webPortalColorSecondaryHighlight[1], m_webPortalColorSecondaryHighlight[2], m_webPortalColorSecondaryHighlight[3]}}, {"cardHeader", {m_webPortalColorCardHeader[0], m_webPortalColorCardHeader[1], m_webPortalColorCardHeader[2], m_webPortalColorCardHeader[3]}}, {"border", {m_webPortalColorBorder[0], m_webPortalColorBorder[1], m_webPortalColorBorder[2], m_webPortalColorBorder[3]}}, {"success", {m_webPortalColorSuccess[0], m_webPortalColorSuccess[1], m_webPortalColorSuccess[2], m_webPortalColorSuccess[3]}}, {"warning", {m_webPortalColorWarning[0], m_webPortalColorWarning[1], m_webPortalColorWarning[2], m_webPortalColorWarning[3]}}, {"danger", {m_webPortalColorDanger[0], m_webPortalColorDanger[1], m_webPortalColorDanger[2], m_webPortalColorDanger[3]}}, {"info", {m_webPortalColorInfo[0], m_webPortalColorInfo[1], m_webPortalColorInfo[2], m_webPortalColorInfo[3]}}}}};
 
         // Salvar configurações de captura
@@ -3439,13 +3439,13 @@ void UIManager::renderWebPortalPanel()
     ImGui::Spacing();
 
     // Web Portal Enable/Disable (configuração)
-    bool portalEnabled = m_webPortalEnabled;
+    bool portalEnabled = m_webPortalConfig.enabled;
     if (ImGui::Checkbox("Enable Web Portal", &portalEnabled))
     {
-        m_webPortalEnabled = portalEnabled;
-        if (!portalEnabled && m_webPortalHTTPSEnabled)
+        m_webPortalConfig.enabled = portalEnabled;
+        if (!portalEnabled && m_webPortalConfig.httpsEnabled)
         {
-            m_webPortalHTTPSEnabled = false;
+            m_webPortalConfig.httpsEnabled = false;
             if (m_onWebPortalHTTPSChanged)
             {
                 m_onWebPortalHTTPSChanged(false);
@@ -3482,7 +3482,7 @@ void UIManager::renderWebPortalPanel()
             }
         }
         ImGui::Spacing();
-        std::string portalUrl = (m_webPortalHTTPSEnabled ? "https://" : "http://") +
+        std::string portalUrl = (m_webPortalConfig.httpsEnabled ? "https://" : "http://") +
                                 std::string("localhost:") + std::to_string(m_streamingConfig.port);
         ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "✓ Portal Web Ativo");
         ImGui::Text("URL: %s", portalUrl.c_str());
@@ -3506,10 +3506,10 @@ void UIManager::renderWebPortalPanel()
     ImGui::Spacing();
 
     // HTTPS Enable/Disable
-    bool httpsEnabled = m_webPortalHTTPSEnabled;
+    bool httpsEnabled = m_webPortalConfig.httpsEnabled;
     if (ImGui::Checkbox("Enable HTTPS", &httpsEnabled))
     {
-        m_webPortalHTTPSEnabled = httpsEnabled;
+        m_webPortalConfig.httpsEnabled = httpsEnabled;
         if (m_onWebPortalHTTPSChanged)
         {
             m_onWebPortalHTTPSChanged(httpsEnabled);
@@ -3536,31 +3536,31 @@ void UIManager::renderWebPortalPanel()
         if (ImGui::CollapsingHeader("Certificate Settings"))
         {
             char certPathBuffer[512];
-            strncpy(certPathBuffer, m_webPortalSSLCertPath.c_str(), sizeof(certPathBuffer) - 1);
+            strncpy(certPathBuffer, m_webPortalConfig.sslCertPath.c_str(), sizeof(certPathBuffer) - 1);
             certPathBuffer[sizeof(certPathBuffer) - 1] = '\0';
 
             ImGui::Text("Caminho do Certificado:");
             if (ImGui::InputText("##SSLCertPath", certPathBuffer, sizeof(certPathBuffer)))
             {
-                m_webPortalSSLCertPath = std::string(certPathBuffer);
+                m_webPortalConfig.sslCertPath = std::string(certPathBuffer);
                 if (m_onWebPortalSSLCertPathChanged)
                 {
-                    m_onWebPortalSSLCertPathChanged(m_webPortalSSLCertPath);
+                    m_onWebPortalSSLCertPathChanged(m_webPortalConfig.sslCertPath);
                 }
                 saveConfig();
             }
 
             char keyPathBuffer[512];
-            strncpy(keyPathBuffer, m_webPortalSSLKeyPath.c_str(), sizeof(keyPathBuffer) - 1);
+            strncpy(keyPathBuffer, m_webPortalConfig.sslKeyPath.c_str(), sizeof(keyPathBuffer) - 1);
             keyPathBuffer[sizeof(keyPathBuffer) - 1] = '\0';
 
             ImGui::Text("Caminho da Chave Privada:");
             if (ImGui::InputText("##SSLKeyPath", keyPathBuffer, sizeof(keyPathBuffer)))
             {
-                m_webPortalSSLKeyPath = std::string(keyPathBuffer);
+                m_webPortalConfig.sslKeyPath = std::string(keyPathBuffer);
                 if (m_onWebPortalSSLKeyPathChanged)
                 {
-                    m_onWebPortalSSLKeyPathChanged(m_webPortalSSLKeyPath);
+                    m_onWebPortalSSLKeyPathChanged(m_webPortalConfig.sslKeyPath);
                 }
                 saveConfig();
             }
@@ -3578,15 +3578,15 @@ void UIManager::renderWebPortalPanel()
 
     // Título
     char titleBuffer[256];
-    strncpy(titleBuffer, m_webPortalTitle.c_str(), sizeof(titleBuffer) - 1);
+    strncpy(titleBuffer, m_webPortalConfig.title.c_str(), sizeof(titleBuffer) - 1);
     titleBuffer[sizeof(titleBuffer) - 1] = '\0';
     ImGui::Text("Title:");
     if (ImGui::InputText("##WebPortalTitle", titleBuffer, sizeof(titleBuffer)))
     {
-        m_webPortalTitle = std::string(titleBuffer);
+        m_webPortalConfig.title = std::string(titleBuffer);
         if (m_onWebPortalTitleChanged)
         {
-            m_onWebPortalTitleChanged(m_webPortalTitle);
+            m_onWebPortalTitleChanged(m_webPortalConfig.title);
         }
         saveConfig();
     }
@@ -3595,15 +3595,15 @@ void UIManager::renderWebPortalPanel()
 
     // Subtítulo
     char subtitleBuffer[256];
-    strncpy(subtitleBuffer, m_webPortalSubtitle.c_str(), sizeof(subtitleBuffer) - 1);
+    strncpy(subtitleBuffer, m_webPortalConfig.subtitle.c_str(), sizeof(subtitleBuffer) - 1);
     subtitleBuffer[sizeof(subtitleBuffer) - 1] = '\0';
     ImGui::Text("Subtitle:");
     if (ImGui::InputText("##WebPortalSubtitle", subtitleBuffer, sizeof(subtitleBuffer)))
     {
-        m_webPortalSubtitle = std::string(subtitleBuffer);
+        m_webPortalConfig.subtitle = std::string(subtitleBuffer);
         if (m_onWebPortalSubtitleChanged)
         {
-            m_onWebPortalSubtitleChanged(m_webPortalSubtitle);
+            m_onWebPortalSubtitleChanged(m_webPortalConfig.subtitle);
         }
         saveConfig();
     }

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -95,6 +95,34 @@ struct RecordingConfig
     std::string amfQuality       = "quality";
 };
 
+// #160 — UIManager web-portal settings + theme strings grouped (group 3/N).
+struct WebPortalConfig
+{
+    bool        enabled       = true;
+    bool        httpsEnabled  = false;
+    std::string sslCertPath   = "ssl/server.crt";
+    std::string sslKeyPath    = "ssl/server.key";
+    std::string title         = "RetroCapture Stream";
+    std::string subtitle      = "Real-time video streaming";
+    std::string imagePath     = "logo.png";
+    std::string textStreamInfo        = "Stream Information";
+    std::string textQuickActions      = "Quick Actions";
+    std::string textCompatibility     = "Compatibilidade";
+    std::string textStatus            = "Status";
+    std::string textCodec             = "Codec";
+    std::string textResolution        = "Resolution";
+    std::string textStreamUrl         = "URL do Stream";
+    std::string textCopyUrl           = "Copiar URL";
+    std::string textOpenNewTab        = "Abrir em Nova Aba";
+    std::string textSupported         = "Suportado";
+    std::string textFormat            = "Formato";
+    std::string textCodecInfo         = "Codec";
+    std::string textSupportedBrowsers = "Chrome, Firefox, Safari, Edge";
+    std::string textFormatInfo        = "HLS (HTTP Live Streaming)";
+    std::string textCodecInfoValue    = "H.264/AAC";
+    std::string textConnecting        = "Conectando...";
+};
+
 class UIManager
 {
 public:
@@ -926,14 +954,14 @@ public:
     void setOnRecordingAmfQualityChanged (std::function<void(const std::string &)> cb) { m_onRecordingAmfQualityChanged = cb; }
 
     // Web Portal settings
-    void setWebPortalEnabled(bool enabled) { m_webPortalEnabled = enabled; }
-    void setWebPortalHTTPSEnabled(bool enabled) { m_webPortalHTTPSEnabled = enabled; }
-    void setWebPortalSSLCertPath(const std::string &path) { m_webPortalSSLCertPath = path; }
-    void setWebPortalSSLKeyPath(const std::string &path) { m_webPortalSSLKeyPath = path; }
+    void setWebPortalEnabled(bool enabled) { m_webPortalConfig.enabled = enabled; }
+    void setWebPortalHTTPSEnabled(bool enabled) { m_webPortalConfig.httpsEnabled = enabled; }
+    void setWebPortalSSLCertPath(const std::string &path) { m_webPortalConfig.sslCertPath = path; }
+    void setWebPortalSSLKeyPath(const std::string &path) { m_webPortalConfig.sslKeyPath = path; }
     void setFoundSSLCertificatePath(const std::string &path) { m_foundSSLCertPath = path; }
     void setFoundSSLKeyPath(const std::string &path) { m_foundSSLKeyPath = path; }
-    void setWebPortalTitle(const std::string &title) { m_webPortalTitle = title; }
-    void setWebPortalImagePath(const std::string &path) { m_webPortalImagePath = path; }
+    void setWebPortalTitle(const std::string &title) { m_webPortalConfig.title = title; }
+    void setWebPortalImagePath(const std::string &path) { m_webPortalConfig.imagePath = path; }
     void setWebPortalBackgroundImagePath(const std::string &path) { m_webPortalBackgroundImagePath = path; }
     void setWebPortalColorBackground(const float color[4])
     {
@@ -981,34 +1009,38 @@ public:
             memcpy(m_webPortalColorDanger, color, 4 * sizeof(float));
     }
 
-    bool getWebPortalEnabled() const { return m_webPortalEnabled; }
-    bool getWebPortalHTTPSEnabled() const { return m_webPortalHTTPSEnabled; }
-    std::string getWebPortalSSLCertPath() const { return m_webPortalSSLCertPath; }
-    std::string getWebPortalSSLKeyPath() const { return m_webPortalSSLKeyPath; }
+    bool getWebPortalEnabled() const { return m_webPortalConfig.enabled; }
+    bool getWebPortalHTTPSEnabled() const { return m_webPortalConfig.httpsEnabled; }
+    std::string getWebPortalSSLCertPath() const { return m_webPortalConfig.sslCertPath; }
+    std::string getWebPortalSSLKeyPath() const { return m_webPortalConfig.sslKeyPath; }
     std::string getFoundSSLCertificatePath() const { return m_foundSSLCertPath; }
     std::string getFoundSSLKeyPath() const { return m_foundSSLKeyPath; }
-    std::string getWebPortalTitle() const { return m_webPortalTitle; }
-    std::string getWebPortalSubtitle() const { return m_webPortalSubtitle; }
-    std::string getWebPortalImagePath() const { return m_webPortalImagePath; }
+    std::string getWebPortalTitle() const { return m_webPortalConfig.title; }
+    std::string getWebPortalSubtitle() const { return m_webPortalConfig.subtitle; }
+    std::string getWebPortalImagePath() const { return m_webPortalConfig.imagePath; }
+    // #160 — bulk access to the web-portal settings group (per-field accessors
+    // are thin wrappers over the same struct).
+    const WebPortalConfig &getWebPortalConfig() const { return m_webPortalConfig; }
+    void setWebPortalConfig(const WebPortalConfig &cfg) { m_webPortalConfig = cfg; }
     std::string getWebPortalBackgroundImagePath() const { return m_webPortalBackgroundImagePath; }
 
     // Getters para textos editáveis
-    std::string getWebPortalTextStreamInfo() const { return m_webPortalTextStreamInfo; }
-    std::string getWebPortalTextQuickActions() const { return m_webPortalTextQuickActions; }
-    std::string getWebPortalTextCompatibility() const { return m_webPortalTextCompatibility; }
-    std::string getWebPortalTextStatus() const { return m_webPortalTextStatus; }
-    std::string getWebPortalTextCodec() const { return m_webPortalTextCodec; }
-    std::string getWebPortalTextResolution() const { return m_webPortalTextResolution; }
-    std::string getWebPortalTextStreamUrl() const { return m_webPortalTextStreamUrl; }
-    std::string getWebPortalTextCopyUrl() const { return m_webPortalTextCopyUrl; }
-    std::string getWebPortalTextOpenNewTab() const { return m_webPortalTextOpenNewTab; }
-    std::string getWebPortalTextSupported() const { return m_webPortalTextSupported; }
-    std::string getWebPortalTextFormat() const { return m_webPortalTextFormat; }
-    std::string getWebPortalTextCodecInfo() const { return m_webPortalTextCodecInfo; }
-    std::string getWebPortalTextSupportedBrowsers() const { return m_webPortalTextSupportedBrowsers; }
-    std::string getWebPortalTextFormatInfo() const { return m_webPortalTextFormatInfo; }
-    std::string getWebPortalTextCodecInfoValue() const { return m_webPortalTextCodecInfoValue; }
-    std::string getWebPortalTextConnecting() const { return m_webPortalTextConnecting; }
+    std::string getWebPortalTextStreamInfo() const { return m_webPortalConfig.textStreamInfo; }
+    std::string getWebPortalTextQuickActions() const { return m_webPortalConfig.textQuickActions; }
+    std::string getWebPortalTextCompatibility() const { return m_webPortalConfig.textCompatibility; }
+    std::string getWebPortalTextStatus() const { return m_webPortalConfig.textStatus; }
+    std::string getWebPortalTextCodec() const { return m_webPortalConfig.textCodec; }
+    std::string getWebPortalTextResolution() const { return m_webPortalConfig.textResolution; }
+    std::string getWebPortalTextStreamUrl() const { return m_webPortalConfig.textStreamUrl; }
+    std::string getWebPortalTextCopyUrl() const { return m_webPortalConfig.textCopyUrl; }
+    std::string getWebPortalTextOpenNewTab() const { return m_webPortalConfig.textOpenNewTab; }
+    std::string getWebPortalTextSupported() const { return m_webPortalConfig.textSupported; }
+    std::string getWebPortalTextFormat() const { return m_webPortalConfig.textFormat; }
+    std::string getWebPortalTextCodecInfo() const { return m_webPortalConfig.textCodecInfo; }
+    std::string getWebPortalTextSupportedBrowsers() const { return m_webPortalConfig.textSupportedBrowsers; }
+    std::string getWebPortalTextFormatInfo() const { return m_webPortalConfig.textFormatInfo; }
+    std::string getWebPortalTextCodecInfoValue() const { return m_webPortalConfig.textCodecInfoValue; }
+    std::string getWebPortalTextConnecting() const { return m_webPortalConfig.textConnecting; }
 
     // Getters para cores
     const float *getWebPortalColorBackground() const { return m_webPortalColorBackground; }
@@ -1068,22 +1100,22 @@ public:
     float *getWebPortalColorInfoEditable() { return m_webPortalColorInfo; }
 
     // Getters para textos editáveis (retornam referências não-const)
-    std::string &getWebPortalTextStreamInfoEditable() { return m_webPortalTextStreamInfo; }
-    std::string &getWebPortalTextQuickActionsEditable() { return m_webPortalTextQuickActions; }
-    std::string &getWebPortalTextCompatibilityEditable() { return m_webPortalTextCompatibility; }
-    std::string &getWebPortalTextStatusEditable() { return m_webPortalTextStatus; }
-    std::string &getWebPortalTextCodecEditable() { return m_webPortalTextCodec; }
-    std::string &getWebPortalTextResolutionEditable() { return m_webPortalTextResolution; }
-    std::string &getWebPortalTextStreamUrlEditable() { return m_webPortalTextStreamUrl; }
-    std::string &getWebPortalTextCopyUrlEditable() { return m_webPortalTextCopyUrl; }
-    std::string &getWebPortalTextOpenNewTabEditable() { return m_webPortalTextOpenNewTab; }
-    std::string &getWebPortalTextSupportedEditable() { return m_webPortalTextSupported; }
-    std::string &getWebPortalTextFormatEditable() { return m_webPortalTextFormat; }
-    std::string &getWebPortalTextCodecInfoEditable() { return m_webPortalTextCodecInfo; }
-    std::string &getWebPortalTextSupportedBrowsersEditable() { return m_webPortalTextSupportedBrowsers; }
-    std::string &getWebPortalTextFormatInfoEditable() { return m_webPortalTextFormatInfo; }
-    std::string &getWebPortalTextCodecInfoValueEditable() { return m_webPortalTextCodecInfoValue; }
-    std::string &getWebPortalTextConnectingEditable() { return m_webPortalTextConnecting; }
+    std::string &getWebPortalTextStreamInfoEditable() { return m_webPortalConfig.textStreamInfo; }
+    std::string &getWebPortalTextQuickActionsEditable() { return m_webPortalConfig.textQuickActions; }
+    std::string &getWebPortalTextCompatibilityEditable() { return m_webPortalConfig.textCompatibility; }
+    std::string &getWebPortalTextStatusEditable() { return m_webPortalConfig.textStatus; }
+    std::string &getWebPortalTextCodecEditable() { return m_webPortalConfig.textCodec; }
+    std::string &getWebPortalTextResolutionEditable() { return m_webPortalConfig.textResolution; }
+    std::string &getWebPortalTextStreamUrlEditable() { return m_webPortalConfig.textStreamUrl; }
+    std::string &getWebPortalTextCopyUrlEditable() { return m_webPortalConfig.textCopyUrl; }
+    std::string &getWebPortalTextOpenNewTabEditable() { return m_webPortalConfig.textOpenNewTab; }
+    std::string &getWebPortalTextSupportedEditable() { return m_webPortalConfig.textSupported; }
+    std::string &getWebPortalTextFormatEditable() { return m_webPortalConfig.textFormat; }
+    std::string &getWebPortalTextCodecInfoEditable() { return m_webPortalConfig.textCodecInfo; }
+    std::string &getWebPortalTextSupportedBrowsersEditable() { return m_webPortalConfig.textSupportedBrowsers; }
+    std::string &getWebPortalTextFormatInfoEditable() { return m_webPortalConfig.textFormatInfo; }
+    std::string &getWebPortalTextCodecInfoValueEditable() { return m_webPortalConfig.textCodecInfoValue; }
+    std::string &getWebPortalTextConnectingEditable() { return m_webPortalConfig.textConnecting; }
 
 private:
     bool m_initialized = false;
@@ -1458,34 +1490,13 @@ private:
     std::function<void(const std::string &)> m_onRecordingAmfQualityChanged;
 
     // Web Portal settings
-    bool m_webPortalEnabled = true; // Habilitado por padrão
-    bool m_webPortalHTTPSEnabled = false;
-    std::string m_webPortalSSLCertPath = "ssl/server.crt";
-    std::string m_webPortalSSLKeyPath = "ssl/server.key";
+    // #160 — web-portal settings grouped (see WebPortalConfig above).
+    WebPortalConfig m_webPortalConfig;
     std::string m_foundSSLCertPath;                                       // Caminho real do certificado encontrado (após busca)
     std::string m_foundSSLKeyPath;                                        // Caminho real da chave encontrada (após busca)
-    std::string m_webPortalTitle = "RetroCapture Stream";                 // Título da página web
-    std::string m_webPortalSubtitle = "Real-time video streaming"; // Subtítulo
-    std::string m_webPortalImagePath = "logo.png";                        // Caminho da imagem para o título (padrão: logo.png)
     std::string m_webPortalBackgroundImagePath;                           // Caminho da imagem de fundo (opcional)
 
     // Textos editáveis dos cards
-    std::string m_webPortalTextStreamInfo = "Stream Information";
-    std::string m_webPortalTextQuickActions = "Quick Actions";
-    std::string m_webPortalTextCompatibility = "Compatibilidade";
-    std::string m_webPortalTextStatus = "Status";
-    std::string m_webPortalTextCodec = "Codec";
-    std::string m_webPortalTextResolution = "Resolution";
-    std::string m_webPortalTextStreamUrl = "URL do Stream";
-    std::string m_webPortalTextCopyUrl = "Copiar URL";
-    std::string m_webPortalTextOpenNewTab = "Abrir em Nova Aba";
-    std::string m_webPortalTextSupported = "Suportado";
-    std::string m_webPortalTextFormat = "Formato";
-    std::string m_webPortalTextCodecInfo = "Codec";
-    std::string m_webPortalTextSupportedBrowsers = "Chrome, Firefox, Safari, Edge";
-    std::string m_webPortalTextFormatInfo = "HLS (HTTP Live Streaming)";
-    std::string m_webPortalTextCodecInfoValue = "H.264/AAC";
-    std::string m_webPortalTextConnecting = "Conectando...";
 
     // Cores do portal baseadas no styleguide RetroCapture (RGBA, valores 0.0-1.0)
     // Primary - Retro Teal #0A7A83


### PR DESCRIPTION
## What

**Third group of the #160 config-struct epic.** Consolidates UIManager's 23 web-portal members into **`WebPortalConfig`** (`m_webPortalConfig`): `enabled, httpsEnabled, sslCertPath, sslKeyPath, title, subtitle, imagePath`, and the 16 customizable theme/label strings (`textStreamInfo` … `textConnecting`).

## Scope (same pattern as #177/#178)

- Storage consolidation only — per-field getters/setters stay as thin wrappers; added bulk `getWebPortalConfig()`/`setWebPortalConfig()`.
- `m_webPortalActive` (status) and `m_webPortalBackgroundImagePath` left as standalone members.
- Names are private to UIManager (Application/HTTPTSStreamer keep their own same-named copies) → change confined to `UIManager.{h,cpp}`.

## Not in this PR
Remaining groups (Preferences, Directory, Chat, RemoteStatus) + accessor collapse follow later. **#160 stays open.**

## Validation
- Linux x86_64 + Windows x86_64 builds ✅
- `tools/smoke-test.sh` ✅

Part of #160.