### PR TITLE
refactor(ui): group UIManager chat settings into ChatConfig (#160 — 6/N)

### DIFF
--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -309,7 +309,7 @@ bool UIManager::init(void *window)
     // self-hides while the client is Idle, so a null/unconfigured
     // pointer renders as nothing.
     m_chatOverlay = std::make_unique<OSDChat>(this, m_chatClient);
-    m_chatOverlay->setVisible(m_chatOverlayVisible);
+    m_chatOverlay->setVisible(m_chatConfig.overlayVisible);
     // Shortcuts orientation widget — UI layer, top-right corner,
     // F12-gated unlike the OSD.
     m_shortcutsHelpWindow = std::make_unique<UIShortcutsHelp>(this);
@@ -344,7 +344,7 @@ void UIManager::setChatClient(ChatClient *chat)
         // pointer. Cheaper to swap than to expose another setter that
         // most callers wouldn't touch.
         m_chatOverlay = std::make_unique<OSDChat>(this, m_chatClient);
-        m_chatOverlay->setVisible(m_chatOverlayVisible);
+        m_chatOverlay->setVisible(m_chatConfig.overlayVisible);
     }
 }
 
@@ -2758,8 +2758,8 @@ void UIManager::loadConfig()
             if (streaming.contains("chat"))
             {
                 auto &chat = streaming["chat"];
-                if (chat.contains("baseUrl"))  m_chatBaseUrl  = chat["baseUrl"].get<std::string>();
-                if (chat.contains("nickname")) m_chatNickname = chat["nickname"].get<std::string>();
+                if (chat.contains("baseUrl"))  m_chatConfig.baseUrl  = chat["baseUrl"].get<std::string>();
+                if (chat.contains("nickname")) m_chatConfig.nickname = chat["nickname"].get<std::string>();
                 if (chat.contains("streamChatEnabled"))
                     m_streamChatEnabled = chat["streamChatEnabled"].get<bool>();
                 if (chat.contains("streamRoomTitle"))
@@ -2789,9 +2789,9 @@ void UIManager::loadConfig()
             // (m_directoryState.hostNickname). The chat Profile now owns
             // it; copy across when the chat nickname is empty so
             // legacy configs don't suddenly look "unnamed".
-            if (m_chatNickname.empty() && !m_directoryState.hostNickname.empty())
+            if (m_chatConfig.nickname.empty() && !m_directoryState.hostNickname.empty())
             {
-                m_chatNickname = m_directoryState.hostNickname;
+                m_chatConfig.nickname = m_directoryState.hostNickname;
             }
         }
 
@@ -2819,7 +2819,7 @@ void UIManager::loadConfig()
             // Chat overlay visibility (#84). Default true — same
             // discoverability story as the quick-actions widget.
             if (prefs.contains("chatOverlayVisible"))
-                m_chatOverlayVisible = prefs["chatOverlayVisible"].get<bool>();
+                m_chatConfig.overlayVisible = prefs["chatOverlayVisible"].get<bool>();
         }
 
         // Carregar configurações de captura
@@ -3282,8 +3282,8 @@ void UIManager::saveConfig()
             }},
             // Chat service URL + persistent nickname (#84).
             {"chat", {
-                {"baseUrl",            m_chatBaseUrl},
-                {"nickname",           m_chatNickname},
+                {"baseUrl",            m_chatConfig.baseUrl},
+                {"nickname",           m_chatConfig.nickname},
                 {"streamChatEnabled",  m_streamChatEnabled},
                 {"streamRoomTitle",    m_streamRoomTitle},
                 {"streamRoomSlug",     m_streamRoomSlug},
@@ -3315,7 +3315,7 @@ void UIManager::saveConfig()
                                    : m_shortcutsHelpVisible},
             {"chatOverlayVisible",
              m_chatOverlay ? m_chatOverlay->isVisible()
-                           : m_chatOverlayVisible},
+                           : m_chatConfig.overlayVisible},
         };
 
         // Salvar configurações de imagem

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -162,6 +162,14 @@ struct RemoteState
     bool        audioMuted            = false;
 };
 
+// #160 — UIManager chat settings grouped (group 6/N, final grouping group).
+struct ChatConfig
+{
+    bool        overlayVisible = true;
+    std::string baseUrl        = "https://chat.retrocapture.com";
+    std::string nickname       = "";
+};
+
 class UIManager
 {
 public:
@@ -405,16 +413,20 @@ public:
     // Configurations → Streaming → Advanced, mirroring the directory
     // URL field. Application reads this every frame and reconfigures
     // the ChatClient when it changes (cheap no-op when unchanged).
-    const std::string &getChatBaseUrl() const        { return m_chatBaseUrl; }
-    void setChatBaseUrl(const std::string &v)        { m_chatBaseUrl = v; }
+    const std::string &getChatBaseUrl() const        { return m_chatConfig.baseUrl; }
+    void setChatBaseUrl(const std::string &v)        { m_chatConfig.baseUrl = v; }
     // #84 — Persistent chat nickname. Shared between host and viewer
     // modes (you're "geldo" regardless of which side you're on); the
     // OSD chat panel writes here when the user clicks Apply. Empty
     // means "use a fallback": Application falls back to the directory
     // host nickname when publishing, or sends an empty hello (server
     // generates anon-<rand>) when viewing.
-    const std::string &getChatNickname() const       { return m_chatNickname; }
-    void setChatNickname(const std::string &v)       { m_chatNickname = v; }
+    const std::string &getChatNickname() const       { return m_chatConfig.nickname; }
+    void setChatNickname(const std::string &v)       { m_chatConfig.nickname = v; }
+    // #160 — bulk access to the chat settings group (per-field accessors are
+    // thin wrappers over the same struct).
+    const ChatConfig &getChatConfig() const { return m_chatConfig; }
+    void setChatConfig(const ChatConfig &cfg) { m_chatConfig = cfg; }
     // #84 — Cross-window request to open the Chat Profile dialog.
     // Set by UIConfigurationStreaming when the user clicks
     // "Configure Profile"; consumed by OSDChat on the next frame.
@@ -519,14 +531,14 @@ public:
     const std::string &getDirectoryStreamName() const { return m_directoryState.streamName; }
     void setDirectoryStreamName(const std::string &v) { m_directoryState.streamName = v; }
     // #84 — As of the profile unification, the directory's "host
-    // nickname" is derived from the chat Profile (m_chatNickname).
+    // nickname" is derived from the chat Profile (m_chatConfig.nickname).
     // The setter is still here for ConfigJSON round-trips of legacy
     // configs that have a separate hostNickname field; on first
-    // load we mirror it into m_chatNickname when the latter is
+    // load we mirror it into m_chatConfig.nickname when the latter is
     // empty, then the chat profile owns the value going forward.
     const std::string &getDirectoryHostNickname() const
     {
-        return m_chatNickname.empty() ? m_directoryState.hostNickname : m_chatNickname;
+        return m_chatConfig.nickname.empty() ? m_directoryState.hostNickname : m_chatConfig.nickname;
     }
     void setDirectoryHostNickname(const std::string &v) { m_directoryState.hostNickname = v; }
     const std::string &getDirectoryPassword() const  { return m_directoryState.password; }
@@ -1207,7 +1219,8 @@ private:
     // reveal it again on the next movement. Default on; toggled in
     // Preferences and persisted.
     bool m_quickActionsAutoHide = true;
-    bool m_chatOverlayVisible  = true;
+    // #160 — chat settings grouped (see ChatConfig above).
+    ChatConfig m_chatConfig;
     // Same persistence pattern for the shortcuts-help orientation
     // widget (#68 follow-up). Default true so new users see the
     // keyboard hints on first launch.
@@ -1387,10 +1400,8 @@ private:
     // launch; the Streaming → Advanced field overrides at runtime.
     // Accepts https://, http://, wss://, ws:// — ChatClient
     // normalizes the scheme when building REST vs WS endpoints.
-    std::string m_chatBaseUrl             = "https://chat.retrocapture.com";
     // #84 — Persistent chat display name. Default empty; OSD chat
     // panel's Apply button writes here + saveConfig.
-    std::string m_chatNickname            = "";
     // #84 — One-shot flag: UIConfigurationStreaming raises it when
     // the user clicks "Configure Profile" from the streaming
     // settings; OSDChat consumes it on the next frame and opens


### PR DESCRIPTION
Sixth (final grouping) group of the #160 epic. Consolidates UIManager's 3 chat members into **ChatConfig** (`m_chatConfig`): `overlayVisible, baseUrl, nickname`.

Storage consolidation only — per-field accessors stay as thin wrappers; added bulk `getChatConfig()`/`setChatConfig()`. Confined to `UIManager.{h,cpp}`.

This **completes the member-grouping phase**: streaming, recording, web-portal, directory, remote, chat each now live in one struct. (Preferences is a single field — `m_language` — left as a plain member.) Remaining #160 work: the accessor collapse (migrate call sites to `getXConfig().field`, drop per-field wrappers) — larger churn, follows separately. **#160 stays open.**

Validated: Linux + Windows builds ✅, smoke-test ✅.

Part of #160.