### PR TITLE
fix(shader): restore inner-loop continue in renderMultipassPass (#184)

### DIFF
--- a/src/shader/ShaderEngine.cpp
+++ b/src/shader/ShaderEngine.cpp
@@ -1253,7 +1253,7 @@ void ShaderEngine::renderMultipassPass(size_t i, GLuint &currentTexture, uint32_
             const std::string &alias = m_passes[prevPass].passInfo.alias;
             if (alias.empty())
             {
-                return;
+                continue;
             }
 
             GLint aliasTexLoc = getUniformLocation(pass.program, alias);
@@ -1311,7 +1311,7 @@ void ShaderEngine::renderMultipassPass(size_t i, GLuint &currentTexture, uint32_
 
         if (!hasFeedbackUniform)
         {
-            return;
+            continue;
         }
 
         ShaderPassData &fbTarget = m_passes[fbPass];


### PR DESCRIPTION
Fixes #184.

## Problem
Applying any shader preset had no visual effect — the live render showed the raw source. Regression from #154.

## Cause
When #154 extracted `applyShader`'s per-pass loop body into `renderMultipassPass()`, the outer-loop `continue` was correctly mapped to `return`. But two `continue` statements in **inner** loops (alias binding, PassFeedback binding) were also turned into `return`. The first pass of almost every shader has no alias and no PassFeedback uniform, so the method returned before drawing the pass and before `currentTexture = pass.texture`. `applyShader` returned the input texture unchanged.

## Fix
Both inner-loop guards restored to `continue` (matches master). 2 lines.

## Verification
Built via Docker (linux x86_64) and confirmed on hardware: shader presets render again on the live window. Runtime diagnostic showed the output texture now differs from the input (was `in=2 out=2`).

## Follow-up
Smoke-test does not apply a shader, so it never exercised `renderMultipassPass` — separate issue to add multipass-preset coverage.