### PR TITLE
fix(capture/streaming): standardize raw orientation + remote client flip (#187), gate /meta on streaming toggle (#188)

### DIFF
--- a/docs/REMOTE_STREAM_PROTOCOL.md
+++ b/docs/REMOTE_STREAM_PROTOCOL.md
@@ -166,6 +166,15 @@ Properties:
   actively consuming.
 - A single MPEG-TS muxer state per output — a brand-new `/raw` client
   starts receiving packets from the next keyframe boundary.
+- **Frame orientation (since 0.8.2-alpha):** `/raw` carries the capture
+  in the host's canonical **bottom-up** orientation — the same as the
+  post-shader `/stream` and the recording encoder. Earlier builds tapped
+  the raw source one vertical flip off from that, so a 0.8.2-alpha client
+  and an older host (or vice-versa) will render the remote picture
+  upside-down. This was an intentional standardization break: there is no
+  longer a per-tap orientation special-case, and the client compensates
+  the remote feed's inversion uniformly (with or without a client-side
+  shader). Mixing 0.8.2-alpha with pre-0.8.2-alpha peers is unsupported.
 
 ```console
 $ ffplay http://host:8080/raw     # raw source feed, no shader

--- a/src/core/FrameCapturePipeline.cpp
+++ b/src/core/FrameCapturePipeline.cpp
@@ -516,18 +516,19 @@ bool FrameCapturePipeline::renderAndDistributeFrame()
     // Camera image and shader output both need Y inversion in
     // the general case — that's why flipY defaults to true.
     //
-    // Exception: remote source consumed without a client-side
-    // shader. The /raw wire data goes through one fewer Y
-    // inversion than a locally-captured frame (no FrameProcessor
-    // upload→shader→sample chain on the client), so the
-    // renderer's implicit flip overshoots and the image lands
-    // upside-down. When the user disables the client-side
-    // shader pipeline on a Remote source, drop the flip so the
-    // picture stays right-side-up (#67).
-    const bool remoteWithoutShader =
-        (m_app.m_ui && m_app.m_ui->getSourceType() == UIManager::SourceType::Remote &&
-         !isShaderTexture);
-    bool shouldFlipY = !remoteWithoutShader;
+    // Exception: a Remote source. The /raw wire feed arrives
+    // already inverted relative to a locally-captured frame, so
+    // the renderer's implicit flip overshoots and the image lands
+    // upside-down. This holds in BOTH the shader and non-shader
+    // cases — the host now reads /raw bottom-up (#187), matching
+    // its shaded-output orientation, so the client must drop the
+    // flip for any Remote source regardless of the client-side
+    // shader pipeline (#67, #187). Previously the flip was dropped
+    // only when no client-side shader ran, which left a Remote +
+    // client-shader frame upside-down once /raw was made consistent.
+    const bool remoteSource =
+        (m_app.m_ui && m_app.m_ui->getSourceType() == UIManager::SourceType::Remote);
+    bool shouldFlipY = !remoteSource;
 
     // Calculate viewport where capture will be rendered (may be smaller than window if maintainAspect is active)
     uint32_t windowWidth = m_app.m_window->getWidth();
@@ -1165,11 +1166,16 @@ bool FrameCapturePipeline::renderAndDistributeFrame()
                                     glReadPixels(0, 0, static_cast<GLsizei>(sourceFrameW),
                                                  static_cast<GLsizei>(sourceFrameH),
                                                  GL_RGB, GL_UNSIGNED_BYTE, m_app.m_captureSourcePadded.data());
-                                    // glReadPixels returns rows bottom-up; flip + strip row padding.
+                                    // #187 — keep glReadPixels' native bottom-up order (do NOT flip),
+                                    // only strip the row padding. The shaded path (frameData) is read via
+                                    // PBO with flipY=false (also bottom-up) and records/streams correctly;
+                                    // this raw-source buffer feeds the same encoders (recording, /stream,
+                                    // /raw), so it must match that orientation. The old vertical flip here
+                                    // produced upside-down recording whenever apply-shader was OFF.
                                     m_app.m_captureSourceFrameData.resize(rowUnpadded * sourceFrameH);
                                     for (uint32_t row = 0; row < sourceFrameH; ++row)
                                     {
-                                        const uint32_t srcRow = sourceFrameH - 1 - row;
+                                        const uint32_t srcRow = row;
                                         const uint8_t *s = m_app.m_captureSourcePadded.data() + srcRow * rowPadded;
                                         uint8_t *d = m_app.m_captureSourceFrameData.data() + row * rowUnpadded;
                                         memcpy(d, s, rowUnpadded);

--- a/src/streaming/APIController.cpp
+++ b/src/streaming/APIController.cpp
@@ -1339,6 +1339,12 @@ std::string APIController::buildMetaSnapshotJSON()
 
     ShaderEngine *shaderEngine = m_application->getShaderEngine();
     bool shaderActive = shaderEngine && shaderEngine->isShaderActive();
+    // #188 — the remote client consumes the *streaming* feed, so the shader it
+    // applies locally must follow BOTH the master Shader-tab toggle AND the
+    // Streaming-tab apply-shader toggle. Reporting only getShaderPipelineEnabled()
+    // here left the client shaded even after the user disabled shader for streaming.
+    bool clientPipelineEnabled = m_uiManager->getShaderPipelineEnabled() &&
+                                 m_uiManager->getStreamingApplyShader();
     std::string presetName = m_uiManager->getCurrentShader();
     std::string presetPath = shaderEngine ? shaderEngine->getPresetPath() : "";
     std::string presetHash = presetPath.empty() ? "" : computePresetHash(presetPath);
@@ -1349,7 +1355,7 @@ std::string APIController::buildMetaSnapshotJSON()
          << "\"serverVersion\": " << jsonString(RETROCAPTURE_VERSION) << ", "
          << "\"shader\": {"
          <<   "\"active\": "          << jsonBool(shaderActive)                          << ", "
-         <<   "\"pipelineEnabled\": " << jsonBool(m_uiManager->getShaderPipelineEnabled()) << ", "
+         <<   "\"pipelineEnabled\": " << jsonBool(clientPipelineEnabled)                  << ", "
          <<   "\"preset\": "          << jsonString(presetName)                          << ", "
          <<   "\"presetHash\": "      << jsonString(presetHash)                          << ", "
          <<   "\"parameters\": [";


### PR DESCRIPTION
Fixes #187, fixes #188. Pre-existing bugs surfaced during the 0.8.2-alpha regression pass (both verified identical to master — not refactor regressions).

## #187 — raw-source orientation / remote client flip
- The raw readback (`m_captureSourceFrameData`, used when apply-shader is OFF) was top-down while the shaded path (`frameData`, PBO `flipY=false`) is bottom-up → recording the raw source came out upside-down.
- Standardize the raw readback to bottom-up so **recording, /stream, /raw** all share the host's canonical orientation.
- Because /raw's wire orientation changes, the remote-client window flip is generalized: the old 'remote without client shader' flip exception now applies to **any** Remote source (with or without a client-side shader).
- **Protocol break (intentional):** documented in REMOTE_STREAM_PROTOCOL.md — pre-0.8.2-alpha peers render upside-down; mixing versions unsupported. Accepted as a necessary standardization step.

## #188 — remote client ignored the streaming apply-shader toggle
- `buildMetaSnapshotJSON` reported `pipelineEnabled` from the master Shader-tab toggle only; the client mirrors it, so disabling shader for streaming didn't reach the client.
- Now reports `getShaderPipelineEnabled() && getStreamingApplyShader()`.

## Verification (hardware, Linux x86_64)
Full orientation matrix confirmed upright: host window/stream/recording with+without shader; remote client with+without shader. Streaming toggle now drives both /stream and the client; Recording toggle affects only the file; Shader toggle disables everywhere.