### PR TITLE
docs(readme): update for 0.8.2-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > capture cards. Includes HTTP MPEG-TS streaming, local recording, a virtual
 > camera output, and a full web portal for remote control.
 
-![Version](https://img.shields.io/badge/version-0.8.1--alpha-orange)
+![Version](https://img.shields.io/badge/version-0.8.2--alpha-orange)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20macOS%20%7C%20Raspberry%20Pi-lightgrey)
 ![Status](https://img.shields.io/badge/status-alpha-yellow)
@@ -16,7 +16,7 @@
      Target ~1600x900. Save as docs/screenshots/hero.png -->
 ![Hero](docs/screenshots/hero.png)
 
-**[⬇ Download 0.8.1-alpha](https://github.com/geldoronie/RetroCapture/releases/latest)** ·
+**[⬇ Download 0.8.2-alpha](https://github.com/geldoronie/RetroCapture/releases/latest)** ·
 [Documentation](#documentation) ·
 [Issues](https://github.com/geldoronie/RetroCapture/issues) ·
 [Changelog](CHANGELOG.md)
@@ -27,7 +27,8 @@
 
 RetroCapture turns a generic capture card into a "retro-aware" capture rig:
 
-- 🎮 **Real-time capture** from V4L2 (Linux) or DirectShow (Windows) devices.
+- 🎮 **Real-time capture** from V4L2 (Linux), DirectShow (Windows) or
+  AVFoundation (macOS) devices.
 - 🌈 **RetroArch GLSL shaders applied live** — single-pass and multi-pass
   presets, including `PassFeedback` and the `OriginalHistory` alias chain.
 - 📡 **HTTP MPEG-TS streaming** with H.264 / H.265 (VP8 / VP9 experimental)
@@ -58,6 +59,25 @@ RetroCapture turns a generic capture card into a "retro-aware" capture rig:
   contrast, saturation, hue, gain, exposure, gamma, white balance, …).
 - 🥧 **Cross-platform**: Linux x86_64, Windows x86_64, Raspberry Pi 4/5
   (ARM64), Raspberry Pi 2/3/Zero (ARM32v7).
+
+### What's new in 0.8.2-alpha
+
+A maintenance release: a large **internal refactor** that decomposes the
+"god-object" classes (app core, shader engine, UI manager, streaming/API) into
+focused units for long-term maintainability — no new features — plus a few
+correctness fixes and one breaking change for remote users.
+
+- **Recording orientation fixed (#187)** — recording with the Recording tab's
+  "apply shader" toggle *off* came out upside-down; recording, `/stream` and
+  `/raw` now share the host's canonical orientation.
+- **Remote client follows the Streaming "apply shader" toggle (#188)** —
+  disabling the shader for streaming now reaches the remote client too.
+- **`--stream-port` is honored (#163)** — it was being overwritten back to 8080.
+- **⚠️ Breaking (remote source / streaming):** the `/raw` feed orientation was
+  standardized — a 0.8.2 client paired with a pre-0.8.2 host (or vice-versa)
+  renders the remote picture upside-down. **Update both ends to 0.8.2.** (#187)
+- **Tooling:** the smoke-test now applies a shader preset and asserts it
+  actually rendered, so a "shader does nothing" regression can't ship green.
 
 ### What's new in 0.8.1-alpha
 
@@ -163,16 +183,16 @@ shader:
 
 ## Download
 
-Pre-built binaries for **0.8.1-alpha** are attached to the
+Pre-built binaries for **0.8.2-alpha** are attached to the
 [latest GitHub release](https://github.com/geldoronie/RetroCapture/releases/latest):
 
 | Platform | Artifact |
 | --- | --- |
-| Linux x86_64 | `RetroCapture-0.8.1-alpha-linux-x86_64.AppImage` |
-| Linux ARM64 (Raspberry Pi 4 / 5) | `RetroCapture-0.8.1-alpha-linux-arm64v8.tar.gz` |
-| Linux ARM32v7 (Raspberry Pi 2 / 3 / Zero 2) | `RetroCapture-0.8.1-alpha-linux-arm32v7.tar.gz` |
-| Windows x86_64 | `RetroCapture-0.8.1-alpha-windows-x86_64-Setup.exe` |
-| macOS x86_64 | `RetroCapture-0.8.1-alpha-macos-x86_64.tar.gz` |
+| Linux x86_64 | `RetroCapture-0.8.2-alpha-linux-x86_64.AppImage` |
+| Linux ARM64 (Raspberry Pi 4 / 5) | `RetroCapture-0.8.2-alpha-linux-arm64v8.tar.gz` |
+| Linux ARM32v7 (Raspberry Pi 2 / 3 / Zero 2) | `RetroCapture-0.8.2-alpha-linux-arm32v7.tar.gz` |
+| Windows x86_64 | `RetroCapture-0.8.2-alpha-windows-x86_64-Setup.exe` |
+| macOS x86_64 | `RetroCapture-0.8.2-alpha-macos-x86_64.tar.gz` |
 
 A `SHA256SUMS` file is published alongside the binaries.
 
@@ -226,21 +246,21 @@ For the full per-version history see [`CHANGELOG.md`](CHANGELOG.md).
 
 ```bash
 # Download from Releases, then:
-chmod +x RetroCapture-0.8.1-alpha-linux-x86_64.AppImage
-./RetroCapture-0.8.1-alpha-linux-x86_64.AppImage --source v4l2 --v4l2-device /dev/video0
+chmod +x RetroCapture-0.8.2-alpha-linux-x86_64.AppImage
+./RetroCapture-0.8.2-alpha-linux-x86_64.AppImage --source v4l2 --v4l2-device /dev/video0
 ```
 
 ### Windows
 
-Run the installer (`RetroCapture-0.8.1-alpha-windows-x86_64-Setup.exe`),
+Run the installer (`RetroCapture-0.8.2-alpha-windows-x86_64-Setup.exe`),
 then launch RetroCapture from the Start menu. DirectShow is the default
 capture source on Windows.
 
 ### Raspberry Pi
 
 ```bash
-tar -xzf RetroCapture-0.8.1-alpha-linux-arm64v8.tar.gz
-cd RetroCapture-0.8.1-alpha-linux-arm64v8
+tar -xzf RetroCapture-0.8.2-alpha-linux-arm64v8.tar.gz
+cd RetroCapture-0.8.2-alpha-linux-arm64v8
 ./retrocapture --source v4l2 --v4l2-device /dev/video0
 ```
 


### PR DESCRIPTION
Post-release README sync (the release commit carried the old 0.8.1 README).

- Version badge, download link, download table and quick-start filenames → 0.8.2-alpha.
- New `What's new in 0.8.2-alpha` section: internal refactor + fixes (#187 recording orientation, #188 remote shader-sync, #163 --stream-port) and the breaking `/raw` orientation change.
- Note macOS AVFoundation capture in the feature list.
- Historical `What's new in 0.8.1/0.8.0` sections kept.